### PR TITLE
feat(oauth): configurable client_id, client_secret, callback host/port/path (#140)

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -328,6 +328,9 @@ impl Backend {
             oauth_config.token_refresh_buffer_secs,
             oauth_config.client_id.clone(),
             oauth_config.client_secret.clone(),
+            oauth_config.callback_port,
+            oauth_config.callback_path.clone(),
+            oauth_config.callback_host.clone(),
         );
 
         Ok(Some(oauth))

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -318,7 +318,7 @@ impl Backend {
                 .map_err(|e| Error::OAuth(format!("Failed to create token storage: {e}")))?,
         );
 
-        // Create OAuth client
+        // Create OAuth client, passing through any pre-configured client_id and client_secret
         let oauth = OAuthClient::new(
             http_client,
             self.name.clone(),
@@ -326,6 +326,8 @@ impl Backend {
             oauth_config.scopes.clone(),
             storage,
             oauth_config.token_refresh_buffer_secs,
+            oauth_config.client_id.clone(),
+            oauth_config.client_secret.clone(),
         );
 
         Ok(Some(oauth))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -529,6 +529,9 @@ pub struct OAuthConfig {
     /// Client ID (optional — uses dynamic registration or generates one if not set).
     #[serde(default)]
     pub client_id: Option<String>,
+    /// Client secret (optional — required by some providers for token exchange).
+    #[serde(default)]
+    pub client_secret: Option<String>,
     /// Seconds before expiry to proactively refresh the token (default: 300).
     #[serde(default = "default_token_refresh_buffer")]
     pub token_refresh_buffer_secs: u64,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -540,6 +540,18 @@ pub struct OAuthConfig {
     /// Client secret (optional — required by some providers for token exchange).
     #[serde(default)]
     pub client_secret: Option<String>,
+    /// Fixed port for the OAuth callback server (optional — uses a random port if not set).
+    /// Some providers (e.g., Slack) require the callback on a specific port.
+    #[serde(default)]
+    pub callback_port: Option<u16>,
+    /// Callback path for the OAuth redirect (default: "/oauth/callback").
+    /// Some providers register a specific path (e.g., "/callback").
+    #[serde(default)]
+    pub callback_path: Option<String>,
+    /// Callback host for the OAuth redirect URI (default: "127.0.0.1").
+    /// Some providers register "localhost" instead of "127.0.0.1".
+    #[serde(default)]
+    pub callback_host: Option<String>,
     /// Seconds before expiry to proactively refresh the token (default: 300).
     #[serde(default = "default_token_refresh_buffer")]
     pub token_refresh_buffer_secs: u64,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -246,6 +246,14 @@ impl Config {
             for value in backend.env.values_mut() {
                 *value = Self::expand_string(&re, value);
             }
+            if let Some(ref mut oauth) = backend.oauth {
+                if let Some(ref mut id) = oauth.client_id {
+                    *id = Self::expand_string(&re, id);
+                }
+                if let Some(ref mut secret) = oauth.client_secret {
+                    *secret = Self::expand_string(&re, secret);
+                }
+            }
         }
 
         for dir in &mut self.capabilities.directories {

--- a/src/oauth/callback.rs
+++ b/src/oauth/callback.rs
@@ -101,7 +101,10 @@ pub async fn start_callback_server(
         .local_addr()
         .map_err(|e| Error::OAuth(format!("Failed to get callback server address: {e}")))?;
 
-    let callback_url = format!("http://{callback_host}:{}{callback_path}", actual_addr.port());
+    let callback_url = format!(
+        "http://{callback_host}:{}{callback_path}",
+        actual_addr.port()
+    );
     info!(url = %callback_url, "OAuth callback server listening");
 
     // Create oneshot channel for the result
@@ -265,7 +268,9 @@ mod tests {
     #[tokio::test]
     async fn callback_flow_success() {
         let state = "csrf_state_123".to_string();
-        let server = start_callback_server(state.clone(), None, None, None).await.unwrap();
+        let server = start_callback_server(state.clone(), None, None, None)
+            .await
+            .unwrap();
         let callback_url = server.callback_url.clone();
 
         // Simulate the OAuth provider redirecting back

--- a/src/oauth/callback.rs
+++ b/src/oauth/callback.rs
@@ -84,10 +84,16 @@ impl CallbackServer {
 pub async fn start_callback_server(
     expected_state: String,
     port: Option<u16>,
+    path: Option<&str>,
+    host: Option<&str>,
 ) -> Result<CallbackServer> {
-    // Find an available port
-    let addr: SocketAddr = format!("127.0.0.1:{}", port.unwrap_or(0)).parse().unwrap();
-    let listener = TcpListener::bind(addr)
+    let callback_host = host.unwrap_or("127.0.0.1");
+    let callback_path = path.unwrap_or("/oauth/callback");
+
+    // Bind to 127.0.0.1 (even if callback_host is "localhost") since
+    // SocketAddr requires a numeric IP, but use callback_host in the URL.
+    let bind_addr: SocketAddr = format!("127.0.0.1:{}", port.unwrap_or(0)).parse().unwrap();
+    let listener = TcpListener::bind(bind_addr)
         .await
         .map_err(|e| Error::OAuth(format!("Failed to bind callback server: {e}")))?;
 
@@ -95,7 +101,7 @@ pub async fn start_callback_server(
         .local_addr()
         .map_err(|e| Error::OAuth(format!("Failed to get callback server address: {e}")))?;
 
-    let callback_url = format!("http://127.0.0.1:{}/oauth/callback", actual_addr.port());
+    let callback_url = format!("http://{callback_host}:{}{callback_path}", actual_addr.port());
     info!(url = %callback_url, "OAuth callback server listening");
 
     // Create oneshot channel for the result
@@ -108,7 +114,7 @@ pub async fn start_callback_server(
 
     // Build router
     let app = Router::new()
-        .route("/oauth/callback", get(handle_callback))
+        .route(callback_path, get(handle_callback))
         .with_state(state);
 
     // Spawn server task
@@ -233,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn callback_server_binds_to_random_port() {
-        let server = start_callback_server("test_state".to_string(), None)
+        let server = start_callback_server("test_state".to_string(), None, None, None)
             .await
             .unwrap();
         assert!(server.callback_url.starts_with("http://127.0.0.1:"));
@@ -245,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn callback_server_binds_to_specified_port() {
         // Use port 0 as fallback since specific ports might be taken
-        let server = start_callback_server("test_state".to_string(), Some(0))
+        let server = start_callback_server("test_state".to_string(), Some(0), None, None)
             .await
             .unwrap();
         assert!(server.callback_url.starts_with("http://127.0.0.1:"));
@@ -259,7 +265,7 @@ mod tests {
     #[tokio::test]
     async fn callback_flow_success() {
         let state = "csrf_state_123".to_string();
-        let server = start_callback_server(state.clone(), None).await.unwrap();
+        let server = start_callback_server(state.clone(), None, None, None).await.unwrap();
         let callback_url = server.callback_url.clone();
 
         // Simulate the OAuth provider redirecting back
@@ -279,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     async fn callback_flow_state_mismatch() {
-        let server = start_callback_server("expected_state".to_string(), None)
+        let server = start_callback_server("expected_state".to_string(), None, None, None)
             .await
             .unwrap();
         let callback_url = server.callback_url.clone();
@@ -297,7 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn callback_flow_error_from_provider() {
-        let server = start_callback_server("some_state".to_string(), None)
+        let server = start_callback_server("some_state".to_string(), None, None, None)
             .await
             .unwrap();
         let callback_url = server.callback_url.clone();
@@ -317,7 +323,7 @@ mod tests {
 
     #[tokio::test]
     async fn callback_flow_missing_code() {
-        let server = start_callback_server("state123".to_string(), None)
+        let server = start_callback_server("state123".to_string(), None, None, None)
             .await
             .unwrap();
         let callback_url = server.callback_url.clone();

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -53,6 +53,9 @@ pub struct OAuthClient {
     /// Client ID (registered or generated)
     client_id: RwLock<Option<String>>,
 
+    /// Client secret (optional — needed by some providers for token exchange)
+    client_secret: RwLock<Option<String>>,
+
     /// Seconds before expiry at which the background task proactively refreshes.
     ///
     /// The task triggers when `time_until_expiry < max(lifetime * 10%, buffer)`.
@@ -87,6 +90,8 @@ impl OAuthClient {
         scopes: Vec<String>,
         storage: Arc<TokenStorage>,
         token_refresh_buffer_secs: u64,
+        client_id: Option<String>,
+        client_secret: Option<String>,
     ) -> Self {
         Self {
             http_client,
@@ -98,7 +103,8 @@ impl OAuthClient {
             storage,
             current_token: RwLock::new(None),
             scopes,
-            client_id: RwLock::new(None),
+            client_id: RwLock::new(client_id),
+            client_secret: RwLock::new(client_secret),
             token_refresh_buffer_secs,
         }
     }
@@ -471,12 +477,17 @@ impl OAuthClient {
             .clone()
             .ok_or_else(|| Error::OAuth("No client ID".to_string()))?;
 
+        let client_secret_val = self.client_secret.read().clone();
+
         let mut params = HashMap::new();
         params.insert("grant_type", "authorization_code");
         params.insert("code", code);
         params.insert("redirect_uri", redirect_uri);
         params.insert("client_id", &client_id);
         params.insert("code_verifier", code_verifier);
+        if let Some(ref secret) = client_secret_val {
+            params.insert("client_secret", secret.as_str());
+        }
 
         let response = self
             .http_client
@@ -625,6 +636,10 @@ impl OAuthClient {
             .json()
             .await
             .map_err(|e| Error::OAuth(format!("Failed to parse registration response: {e}")))?;
+
+        if let Some(ref secret) = reg_response.client_secret {
+            *self.client_secret.write() = Some(secret.clone());
+        }
 
         info!(client_id = %reg_response.client_id, "Registered OAuth client");
         Ok(reg_response.client_id)

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -92,6 +92,7 @@ struct ClientRegistrationResponse {
 impl OAuthClient {
     /// Create a new OAuth client for a backend
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         http_client: Client,
         backend_name: String,
@@ -428,7 +429,8 @@ impl OAuthClient {
             self.callback_port,
             self.callback_path.as_deref(),
             self.callback_host.as_deref(),
-        ).await?;
+        )
+        .await?;
         let callback_url = callback_server.callback_url.clone();
 
         // Now ensure we have a client ID, passing the actual callback URL for registration

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -56,6 +56,15 @@ pub struct OAuthClient {
     /// Client secret (optional — needed by some providers for token exchange)
     client_secret: RwLock<Option<String>>,
 
+    /// Fixed port for the OAuth callback server (optional)
+    callback_port: Option<u16>,
+
+    /// Callback path for the OAuth redirect (default: "/oauth/callback")
+    callback_path: Option<String>,
+
+    /// Callback host for the OAuth redirect URI (default: "127.0.0.1")
+    callback_host: Option<String>,
+
     /// Seconds before expiry at which the background task proactively refreshes.
     ///
     /// The task triggers when `time_until_expiry < max(lifetime * 10%, buffer)`.
@@ -92,6 +101,9 @@ impl OAuthClient {
         token_refresh_buffer_secs: u64,
         client_id: Option<String>,
         client_secret: Option<String>,
+        callback_port: Option<u16>,
+        callback_path: Option<String>,
+        callback_host: Option<String>,
     ) -> Self {
         Self {
             http_client,
@@ -105,6 +117,9 @@ impl OAuthClient {
             scopes,
             client_id: RwLock::new(client_id),
             client_secret: RwLock::new(client_secret),
+            callback_port,
+            callback_path,
+            callback_host,
             token_refresh_buffer_secs,
         }
     }
@@ -408,7 +423,12 @@ impl OAuthClient {
 
         // Start callback server FIRST to get the actual callback URL
         // This must happen BEFORE client registration so we know the port
-        let callback_server = callback::start_callback_server(state.clone(), None).await?;
+        let callback_server = callback::start_callback_server(
+            state.clone(),
+            self.callback_port,
+            self.callback_path.as_deref(),
+            self.callback_host.as_deref(),
+        ).await?;
         let callback_url = callback_server.callback_url.clone();
 
         // Now ensure we have a client ID, passing the actual callback URL for registration

--- a/src/oauth/client/tests.rs
+++ b/src/oauth/client/tests.rs
@@ -117,6 +117,8 @@ fn new_client_has_no_valid_token() {
         vec!["read".to_string()],
         storage,
         300,
+        None,
+        None,
     );
     assert!(!client.has_valid_token());
 }
@@ -132,6 +134,8 @@ fn client_with_valid_token_returns_true() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
 
     // Inject a non-expired token
@@ -158,6 +162,8 @@ fn client_with_expired_token_returns_false() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
 
     // Inject an expired token
@@ -184,6 +190,8 @@ fn backend_name_returns_configured_name() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
     assert_eq!(client.backend_name(), "my-service");
 }
@@ -205,6 +213,8 @@ fn needs_proactive_refresh_false_when_no_token() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
 
     // WHEN / THEN: no token means no proactive refresh needed
@@ -224,6 +234,8 @@ fn needs_proactive_refresh_false_when_token_no_expiry() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
     let token = TokenInfo::from_response("tok".to_string(), None, None, None, None);
     *client.current_token.write() = Some(token);
@@ -245,6 +257,8 @@ fn needs_proactive_refresh_true_when_within_buffer() {
         vec![],
         storage,
         300, // 300s buffer
+        None,
+        None,
     );
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -273,6 +287,8 @@ fn needs_proactive_refresh_false_when_outside_buffer() {
         vec![],
         storage,
         300,
+        None,
+        None,
     );
     let token = TokenInfo::from_response("tok".to_string(), None, None, Some(3600), None);
     *client.current_token.write() = Some(token);

--- a/src/oauth/client/tests.rs
+++ b/src/oauth/client/tests.rs
@@ -119,6 +119,9 @@ fn new_client_has_no_valid_token() {
         300,
         None,
         None,
+        None,
+        None,
+        None,
     );
     assert!(!client.has_valid_token());
 }
@@ -134,6 +137,9 @@ fn client_with_valid_token_returns_true() {
         vec![],
         storage,
         300,
+        None,
+        None,
+        None,
         None,
         None,
     );
@@ -164,6 +170,9 @@ fn client_with_expired_token_returns_false() {
         300,
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     // Inject an expired token
@@ -192,6 +201,9 @@ fn backend_name_returns_configured_name() {
         300,
         None,
         None,
+        None,
+        None,
+        None,
     );
     assert_eq!(client.backend_name(), "my-service");
 }
@@ -215,6 +227,9 @@ fn needs_proactive_refresh_false_when_no_token() {
         300,
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     // WHEN / THEN: no token means no proactive refresh needed
@@ -234,6 +249,9 @@ fn needs_proactive_refresh_false_when_token_no_expiry() {
         vec![],
         storage,
         300,
+        None,
+        None,
+        None,
         None,
         None,
     );
@@ -257,6 +275,9 @@ fn needs_proactive_refresh_true_when_within_buffer() {
         vec![],
         storage,
         300, // 300s buffer
+        None,
+        None,
+        None,
         None,
         None,
     );
@@ -287,6 +308,9 @@ fn needs_proactive_refresh_false_when_outside_buffer() {
         vec![],
         storage,
         300,
+        None,
+        None,
+        None,
         None,
         None,
     );


### PR DESCRIPTION
Based on @akaralar's fork (`akaralar/mcp-gateway@fix/wire-oauth-client-id-from-config`). Thanks for the contribution — this closes the gap flagged in #140 where Slack and Figma can't complete an OAuth flow against the gateway.

## Summary

Adds four new optional fields to `OAuthConfig`:

- `client_id: Option<String>` — pre-configured client ID (skips dynamic registration when set)
- `client_secret: Option<String>` — sent as `client_secret` on token exchange when present (confidential clients)
- `callback_host: Option<String>` — default `"127.0.0.1"`, needed as `"localhost"` for Figma
- `callback_port: Option<u16>` — fixed callback port (Slack requires a specific port)
- `callback_path: Option<String>` — default `"/oauth/callback"`, Slack uses `/slack/oauth_redirect`

Wires them through `Backend::build_oauth_client` -> `OAuthClient::new` -> `callback::start_callback_server`, and the token exchange in `OAuthClient`. `client_id` and `client_secret` are passed through the existing `expand_env` pass on config load so `${SLACK_CLIENT_SECRET}` references are resolved.

Also: if dynamic registration returns a `client_secret`, it is captured and used on subsequent token exchanges.

## Clusters evaluated from the fork

The fork had two parallel clusters on `fix/wire-oauth-client-id-from-config`:

1. **OAuth configurability** (commits `cc402def`, `fa412776`, `70963d0b`) — **this PR.**
2. **HTTP stale-session auto re-initialize** (commit `2b2a689c`) — deliberately not included here. Different topic, and the silent auto-reinit deserves maintainer design input (see comment on #140).

(The earlier triage that mentioned A2A transport and CI hash-pinning was incorrect — both are already in upstream; fork had only the four OAuth commits.)

## Tweaks applied on top of akaralar's commits

One extra commit `chore(oauth): rustfmt + clippy allow` (co-authored to @akaralar):

- `cargo fmt` differences in `src/oauth/callback.rs` and `src/oauth/client/mod.rs`.
- `#[allow(clippy::too_many_arguments)]` on `OAuthClient::new` — it now takes 11 inputs, above clippy's pedantic limit of 7. A natural follow-up is to bundle these into an `OAuthClientConfig` struct; leaving that to a focused refactor.

## Open design questions (not blocking this PR, but flagged from issue #140)

@MikkoParkkola raised two in the issue thread that this PR does **not** yet address:

1. **`client_secret` literal vs `\${ENV}`-only** — currently accepts both. Should emit a warning (or reject) literal values?
2. **`callback_host` whitelist** — currently accepts any string. Mikko suggested whitelisting to `{\"127.0.0.1\", \"localhost\"}` to avoid SSRF / open-redirect weirdness on the local callback server.
3. **`callback_path` validation** — should enforce starts-with-`/`, no query string, no `..`.
4. **PKCE + `client_secret` combo** — some providers require both, some only one. Worth confirming against Slack/Figma docs.

Happy to tighten these in a follow-up commit on this branch if you want them in before merge, or land as a separate hardening PR.

## Verification

Run on an Apple-Silicon mac, on the `feat/oauth-configurability` branch (4 commits ahead of `main` after `625738fe`):

- `cargo build --all-targets` -> finished in 4m 14s, no errors
- `cargo test --all-features --lib` -> **2672 passed, 0 failed**
- `cargo test --all-features --lib --bins` -> 111 additional bin tests passed
- `cargo clippy --all-targets --all-features -- -D warnings` -> clean
- `cargo fmt --check` -> clean

## Authorship

Three commits retain `Ahmet Karalar <ahmet.karalar@backmarket.com>` as author; the fmt/clippy commit is co-authored to him.