### PR TITLE
fix: close gateway security review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-audit
+        env:
+          RUSTFLAGS: ""
+        run: cargo install cargo-audit --locked
+      - run: cargo audit
+
   kani:
     name: Kani
     # ubuntu-20.04 was retired by GitHub in April 2025. Jobs targeting it
@@ -85,7 +98,7 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, test, fmt, public-claims]
+    needs: [check, test, fmt, audit, public-claims]
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ history.txt
 
 # Claude Code
 .claude/
+.agents/
 
 # Build artifacts
 .mypy_cache/
@@ -37,6 +38,7 @@ history.txt
 
 # Internal planning docs and drafts
 docs/plans/
+docs/submissions/
 linkedin-post-draft.md
 .gitnexus
 AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **mcp-gateway** (9871 symbols, 23969 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **mcp-gateway** (11322 symbols, 27517 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
+ "shlex",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -2598,9 +2599,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ dashmap = "6.1"
 parking_lot = "0.12"
 bytes = "1.11.1"
 pin-project-lite = "0.2"
+shlex = "1.3"
 
 # OAuth / Crypto
 sha2 = "0.11"

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Embedded web UI at `/ui` -- live status, searchable tools, server health, config
 
 | Feature | Description | Docs |
 |---------|-------------|------|
-| **Authentication** | Bearer tokens, API keys, per-client rate limits | [examples/auth.yaml](examples/) |
+| **Authentication** | Bearer tokens, API keys, explicit admin keys, per-client rate limits | [examples/per-client-tool-scopes.yaml](examples/per-client-tool-scopes.yaml) |
 | **Per-Client Tool Scopes** | Allowlist/denylist tools per API key with glob patterns | [examples/per-client-tool-scopes.yaml](examples/per-client-tool-scopes.yaml) |
 | **Security Firewall** | Credential redaction, prompt injection detection, shell/SQL/path traversal scanning | [CHANGELOG](CHANGELOG.md#260---2026-03-13) |
 | **Cost Governance** | Per-tool, per-key, daily budgets with alert thresholds (log/notify/block) | [CHANGELOG](CHANGELOG.md#260---2026-03-13) |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -279,6 +279,8 @@ auth:
   public_paths: ["/health"]
 ```
 
+`env:VAR_NAME` references for auth, agent auth, and key-server admin secrets must be present at startup; missing secret variables fail configuration validation.
+
 For multi-client setups with per-client tool scoping, see the [README auth section](../README.md#authentication).
 
 ## Backup and Recovery

--- a/examples/gateway-full.yaml
+++ b/examples/gateway-full.yaml
@@ -28,11 +28,13 @@ auth:
   # bearer_token: "auto"
 
   # API keys for multi-client access with per-client restrictions.
+  # `env:VAR_NAME` secret references must exist at startup.
   # api_keys:
   #   - key: "env:CLIENT_A_KEY"
   #     name: "Client A"
   #     rate_limit: 100           # Requests per minute (0 = unlimited)
   #     backends: ["tavily"]      # Restrict to specific backends (empty = all)
+  #     admin: false              # Set true only for UI/config management keys
   #   - key: "my-literal-key"
   #     name: "Client B"
   #     backends: []              # All backends

--- a/examples/per-client-tool-scopes.yaml
+++ b/examples/per-client-tool-scopes.yaml
@@ -33,6 +33,7 @@ auth:
     - key: "env:ADMIN_API_KEY"
       name: "Admin"
       rate_limit: 0
+      admin: true             # Required for Web UI mutations and management meta-tools
       # No restrictions = full access (falls back to global policy)
 
     # Restricted bot: No filesystem or execution tools

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,7 +10,7 @@ use dashmap::DashMap;
 use parking_lot::RwLock;
 use reqwest::Client;
 use serde_json::Value;
-use tokio::sync::{Semaphore, watch};
+use tokio::sync::{Mutex, Semaphore, watch};
 use tracing::{debug, info, warn};
 
 use crate::config::{BackendConfig, TransportConfig};
@@ -18,7 +18,7 @@ use crate::failsafe::{Failsafe, with_retry};
 use crate::oauth::{OAuthClient, OAuthClientConfig, TokenStorage};
 use crate::protocol::{
     JsonRpcResponse, Prompt, PromptsListResult, Resource, ResourceTemplate, ResourcesListResult,
-    ResourcesTemplatesListResult, Tool, ToolsListResult,
+    ResourcesTemplatesListResult, Tool, ToolAnnotations, ToolsListResult,
 };
 use crate::transport::{HttpTransport, StdioTransport, Transport};
 use crate::{Error, Result};
@@ -161,6 +161,9 @@ pub struct Backend {
     config: BackendConfig,
     /// Transport
     transport: RwLock<Option<Arc<dyn Transport>>>,
+    /// Serializes backend startup so concurrent warm-start/client requests do
+    /// not spawn duplicate stdio processes for the same backend.
+    start_lock: Mutex<()>,
     /// Failsafe mechanisms
     failsafe: Failsafe,
     /// Cached tools
@@ -194,6 +197,7 @@ impl Backend {
             name: name.to_string(),
             config,
             transport: RwLock::new(None),
+            start_lock: Mutex::new(()),
             failsafe: Failsafe::new(name, failsafe_config),
             tools_cache: CachedMetadata::new(),
             resources_cache: CachedMetadata::new(),
@@ -229,6 +233,15 @@ impl Backend {
             }
         }
 
+        let _start_guard = self.start_lock.lock().await;
+
+        {
+            let transport = self.transport.read();
+            if transport.as_ref().is_some_and(|t| t.is_connected()) {
+                return Ok(());
+            }
+        }
+
         // Start transport
         self.start().await
     }
@@ -251,6 +264,7 @@ impl Backend {
                     command,
                     self.config.env.clone(),
                     cwd.clone(),
+                    self.config.timeout,
                     protocol_version.clone(),
                 );
                 transport.start().await?;
@@ -436,6 +450,9 @@ impl Backend {
                 self.ensure_started().await?;
 
                 let response = self.request_internal(method, None).await?;
+                if let Some(error) = response.error {
+                    return Err(Error::json_rpc(error.code, error.message));
+                }
                 let items = if let Some(result) = response.result {
                     parse(result)?
                 } else {
@@ -454,7 +471,9 @@ impl Backend {
     /// Returns an error if the backend cannot start or the tools request fails.
     pub async fn get_tools_shared(&self) -> Result<Arc<Vec<Tool>>> {
         self.get_cached_list_shared(&self.tools_cache, "tools/list", "tools", |result| {
-            Ok(serde_json::from_value::<ToolsListResult>(result)?.tools)
+            let mut tools = serde_json::from_value::<ToolsListResult>(result)?.tools;
+            normalize_tool_annotations(&self.name, &mut tools);
+            Ok(tools)
         })
         .await
     }
@@ -890,6 +909,114 @@ impl Default for BackendRegistry {
     }
 }
 
+pub(crate) fn normalize_tool_annotations(server: &str, tools: &mut [Tool]) {
+    for tool in tools {
+        let inferred_read_only = infer_read_only_tool(&tool.name);
+        let annotations = tool
+            .annotations
+            .get_or_insert_with(ToolAnnotations::default);
+        let read_only = annotations.read_only_hint.unwrap_or(inferred_read_only);
+        let destructive = annotations
+            .destructive_hint
+            .unwrap_or_else(|| infer_destructive_tool(&tool.name, read_only));
+
+        annotations.read_only_hint = Some(read_only);
+        annotations.destructive_hint = Some(destructive);
+        annotations.idempotent_hint = Some(
+            annotations
+                .idempotent_hint
+                .unwrap_or_else(|| infer_idempotent_tool(&tool.name, read_only, destructive)),
+        );
+        annotations.open_world_hint = Some(
+            annotations
+                .open_world_hint
+                .unwrap_or_else(|| infer_open_world_tool(server, &tool.name)),
+        );
+    }
+}
+
+fn infer_read_only_tool(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    let read_prefixes = [
+        "analyze",
+        "auth_lookup",
+        "benchmark",
+        "calculate",
+        "check",
+        "classify",
+        "count",
+        "describe",
+        "detect",
+        "estimate",
+        "fetch",
+        "find",
+        "fingerprint",
+        "get",
+        "health",
+        "info",
+        "list",
+        "lookup",
+        "preview",
+        "query",
+        "read",
+        "recall",
+        "search",
+        "status",
+        "suggest",
+        "validate",
+        "verify",
+    ];
+    read_prefixes
+        .iter()
+        .any(|prefix| name == *prefix || name.starts_with(&format!("{prefix}_")))
+}
+
+fn infer_destructive_tool(name: &str, read_only: bool) -> bool {
+    if read_only {
+        return false;
+    }
+
+    let name = name.to_ascii_lowercase();
+    let destructive_words = [
+        "archive", "bash", "clear", "delete", "forget", "kill", "login", "post", "remove", "run",
+        "send", "submit", "type", "write",
+    ];
+    destructive_words.iter().any(|word| name.contains(word))
+}
+
+fn infer_idempotent_tool(name: &str, read_only: bool, destructive: bool) -> bool {
+    if read_only {
+        return true;
+    }
+    if destructive {
+        return false;
+    }
+
+    let name = name.to_ascii_lowercase();
+    name.starts_with("set_")
+        || name.starts_with("clear_")
+        || name.starts_with("focus_")
+        || name.starts_with("connect")
+}
+
+fn infer_open_world_tool(server: &str, name: &str) -> bool {
+    let server = server.to_ascii_lowercase();
+    let name = name.to_ascii_lowercase();
+
+    if matches!(
+        server.as_str(),
+        "hebb" | "metacognition" | "pithy" | "cached-grep" | "haiku-file-reader"
+    ) {
+        return false;
+    }
+
+    if name.contains("validate") || name.contains("fingerprint") || name.contains("auth_lookup") {
+        return false;
+    }
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -952,6 +1079,46 @@ mod tests {
             output_schema: None,
             annotations: None,
         }
+    }
+
+    #[test]
+    fn normalize_tool_annotations_fills_missing_hints() {
+        let mut tools = vec![sample_tool("search_messages"), sample_tool("send_message")];
+
+        normalize_tool_annotations("beeper", &mut tools);
+
+        let search = tools[0].annotations.as_ref().unwrap();
+        assert_eq!(search.read_only_hint, Some(true));
+        assert_eq!(search.destructive_hint, Some(false));
+        assert_eq!(search.idempotent_hint, Some(true));
+        assert_eq!(search.open_world_hint, Some(true));
+
+        let send = tools[1].annotations.as_ref().unwrap();
+        assert_eq!(send.read_only_hint, Some(false));
+        assert_eq!(send.destructive_hint, Some(true));
+        assert_eq!(send.idempotent_hint, Some(false));
+        assert_eq!(send.open_world_hint, Some(true));
+    }
+
+    #[test]
+    fn normalize_tool_annotations_preserves_existing_true_hints_and_adds_false_hints() {
+        let mut tool = sample_tool("recall");
+        tool.annotations = Some(ToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: None,
+            idempotent_hint: None,
+            open_world_hint: None,
+            title: None,
+        });
+        let mut tools = vec![tool];
+
+        normalize_tool_annotations("hebb", &mut tools);
+
+        let annotations = tools[0].annotations.as_ref().unwrap();
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 
     #[test]
@@ -1062,5 +1229,25 @@ mod tests {
             backend.get_cached_tool("echo").map(|tool| tool.name),
             Some("echo".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn get_tools_does_not_cache_json_rpc_error_response() {
+        let backend = Arc::new(Backend::new(
+            "test",
+            BackendConfig::default(),
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        ));
+        let response = JsonRpcResponse::error(Some(RequestId::Number(1)), -32000, "backend down");
+        let transport = Arc::new(MockTransport::new(response, Duration::from_millis(0)));
+        let transport_dyn: Arc<dyn Transport> = transport.clone();
+        *backend.transport.write() = Some(transport_dyn);
+
+        let result = backend.get_tools().await;
+
+        assert!(result.is_err());
+        assert!(!backend.has_cached_tools());
+        assert_eq!(transport.requests.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/capability/backend.rs
+++ b/src/capability/backend.rs
@@ -219,11 +219,12 @@ impl CapabilityBackend {
         }
 
         // Upsert each capability into the indexed store.
-        {
-            let mut caps = self.capabilities.write();
-            for cap in loaded {
+        for cap in loaded {
+            {
+                let mut caps = self.capabilities.write();
                 caps.upsert(cap);
             }
+            tokio::task::yield_now().await;
         }
 
         info!(backend = %self.name, count = count, path = path, "Loaded capabilities");

--- a/src/capability/definition/mod.rs
+++ b/src/capability/definition/mod.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
+use crate::protocol::ToolAnnotations;
 use crate::transform::TransformConfig;
 
 /// A capability definition describing how to call a REST API
@@ -754,6 +755,26 @@ pub struct CapabilityMetadata {
     #[serde(default)]
     pub read_only: bool,
 
+    /// Whether the operation may destructively modify user-visible state.
+    ///
+    /// When omitted, capability tools infer a conservative value from
+    /// `read_only`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destructive: Option<bool>,
+
+    /// Whether repeating the same call has no additional effect.
+    ///
+    /// When omitted, capability tools infer `true` for read-only operations and
+    /// `false` for write operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotent: Option<bool>,
+
+    /// Whether the operation interacts with external services or entities.
+    ///
+    /// API capabilities default to open-world because they call REST services.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_world: Option<bool>,
+
     /// Data types or entities this tool produces as output.
     ///
     /// Examples: `["teamId", "issueId", "userId"]`
@@ -900,7 +921,18 @@ impl CapabilityDefinition {
             } else {
                 Some(self.schema.output.clone())
             },
-            annotations: None,
+            annotations: Some(self.tool_annotations()),
+        }
+    }
+
+    fn tool_annotations(&self) -> ToolAnnotations {
+        let read_only = self.metadata.read_only;
+        ToolAnnotations {
+            title: None,
+            read_only_hint: Some(read_only),
+            destructive_hint: Some(self.metadata.destructive.unwrap_or(!read_only)),
+            idempotent_hint: Some(self.metadata.idempotent.unwrap_or(read_only)),
+            open_world_hint: Some(self.metadata.open_world.unwrap_or(true)),
         }
     }
 

--- a/src/capability/definition/tests.rs
+++ b/src/capability/definition/tests.rs
@@ -56,6 +56,55 @@ fn to_mcp_tool_single_tag_formats_correctly() {
 }
 
 #[test]
+fn to_mcp_tool_read_only_capability_has_protocol_annotations() {
+    let mut cap = make_capability("weather", "Get weather", vec!["forecast"]);
+    cap.metadata.read_only = true;
+
+    let annotations = cap
+        .to_mcp_tool()
+        .annotations
+        .expect("capability tools should be annotated");
+
+    assert_eq!(annotations.read_only_hint, Some(true));
+    assert_eq!(annotations.destructive_hint, Some(false));
+    assert_eq!(annotations.idempotent_hint, Some(true));
+    assert_eq!(annotations.open_world_hint, Some(true));
+}
+
+#[test]
+fn to_mcp_tool_write_capability_uses_conservative_defaults() {
+    let cap = make_capability("submit_form", "Submit a form", vec!["form"]);
+
+    let annotations = cap
+        .to_mcp_tool()
+        .annotations
+        .expect("capability tools should be annotated");
+
+    assert_eq!(annotations.read_only_hint, Some(false));
+    assert_eq!(annotations.destructive_hint, Some(true));
+    assert_eq!(annotations.idempotent_hint, Some(false));
+    assert_eq!(annotations.open_world_hint, Some(true));
+}
+
+#[test]
+fn to_mcp_tool_capability_metadata_can_override_annotation_defaults() {
+    let mut cap = make_capability("start_scan", "Start a scan", vec!["security"]);
+    cap.metadata.destructive = Some(false);
+    cap.metadata.idempotent = Some(false);
+    cap.metadata.open_world = Some(false);
+
+    let annotations = cap
+        .to_mcp_tool()
+        .annotations
+        .expect("capability tools should be annotated");
+
+    assert_eq!(annotations.read_only_hint, Some(false));
+    assert_eq!(annotations.destructive_hint, Some(false));
+    assert_eq!(annotations.idempotent_hint, Some(false));
+    assert_eq!(annotations.open_world_hint, Some(false));
+}
+
+#[test]
 fn build_description_with_empty_tags_is_plain() {
     let cap = make_capability("no_tags", "Plain description", vec![]);
     assert_eq!(cap.build_description(), "Plain description");

--- a/src/capability/executor/graphql.rs
+++ b/src/capability/executor/graphql.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use super::CapabilityExecutor;
 use super::rest::{ExecutionContext, ProtocolExecutor};
 use crate::capability::definition::ProtocolConfig;
+use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
 /// GraphQL protocol executor.
@@ -201,6 +202,7 @@ impl ProtocolExecutor for GraphqlExecutor<'_> {
                 "GraphQL endpoint URL not configured".to_string(),
             ));
         }
+        validate_url_not_ssrf(&graphql_config.endpoint)?;
 
         // Build the { query, variables } body
         let body = Self::build_body(graphql_config, &params)?;

--- a/src/capability/executor/jsonrpc.rs
+++ b/src/capability/executor/jsonrpc.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use super::CapabilityExecutor;
 use super::rest::{ExecutionContext, ProtocolExecutor};
 use crate::capability::definition::ProtocolConfig;
+use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
 /// JSON-RPC 2.0 protocol executor.
@@ -145,6 +146,7 @@ impl ProtocolExecutor for JsonRpcExecutor<'_> {
                 "JSON-RPC endpoint URL not configured".to_string(),
             ));
         }
+        validate_url_not_ssrf(&jsonrpc_config.endpoint)?;
 
         // Build the JSON-RPC 2.0 request body
         let body = Self::build_request(jsonrpc_config, &params)?;

--- a/src/capability/executor/mod.rs
+++ b/src/capability/executor/mod.rs
@@ -37,6 +37,7 @@ use super::response_cache::ResponseCache;
 use super::{CapabilityDefinition, ProviderConfig, RestConfig};
 use crate::oauth::{TokenInfo, TokenStorage};
 use crate::secrets::SecretResolver;
+use crate::security::validate_url_not_ssrf;
 use crate::transform::TransformPipeline;
 use crate::{Error, Result};
 
@@ -68,6 +69,15 @@ impl CapabilityExecutor {
             .pool_max_idle_per_host(10)
             .pool_idle_timeout(Duration::from_secs(90))
             .tcp_keepalive(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                if attempt.previous().len() >= 5 {
+                    return attempt.stop();
+                }
+                if let Err(e) = validate_url_not_ssrf(attempt.url().as_str()) {
+                    return attempt.error(e.to_string());
+                }
+                attempt.follow()
+            }))
             .build()
             .expect("Failed to create HTTP client")
     }
@@ -249,6 +259,7 @@ impl CapabilityExecutor {
         let params = effective_params.as_ref();
 
         let url = self.build_url(config, params)?;
+        validate_url_not_ssrf(&url)?;
         tracing::debug!(url = %url, method = %config.method, "Executing REST request");
 
         let method = config.method.parse::<Method>().map_err(|e| {

--- a/src/capability/loader.rs
+++ b/src/capability/loader.rs
@@ -60,6 +60,10 @@ impl CapabilityLoader {
             .await
             .map_err(|e| Error::Config(format!("Failed to read directory entry: {e}")))?
         {
+            // Large capability directories load in the background at startup;
+            // yield between entries so the gateway listener remains responsive.
+            tokio::task::yield_now().await;
+
             let path = entry.path();
 
             // Skip hidden files/directories

--- a/src/config/features/auth.rs
+++ b/src/config/features/auth.rs
@@ -4,6 +4,8 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{Error, Result};
+
 // ── Auth ───────────────────────────────────────────────────────────────────────
 
 /// Authentication configuration for gateway access.
@@ -41,23 +43,30 @@ impl Default for AuthConfig {
 
 impl AuthConfig {
     /// Resolve the bearer token (expand env vars, generate if `auto`).
-    #[must_use]
-    pub fn resolve_bearer_token(&self) -> Option<String> {
-        self.bearer_token.as_ref().map(|token| {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an `env:VAR_NAME` reference cannot be resolved.
+    pub fn resolve_bearer_token(&self) -> Result<Option<String>> {
+        self.bearer_token.as_ref().map_or(Ok(None), |token| {
             if token == "auto" {
                 use rand::RngExt;
                 let random_bytes: [u8; 32] = rand::rng().random();
-                format!(
+                Ok(Some(format!(
                     "mcp_{}",
                     base64::Engine::encode(
                         &base64::engine::general_purpose::URL_SAFE_NO_PAD,
                         random_bytes
                     )
-                )
+                )))
             } else if let Some(var_name) = token.strip_prefix("env:") {
-                env::var(var_name).unwrap_or_else(|_| token.clone())
+                env::var(var_name).map(Some).map_err(|_| {
+                    Error::ConfigValidation(format!(
+                        "auth.bearer_token references missing environment variable '{var_name}'"
+                    ))
+                })
             } else {
-                token.clone()
+                Ok(Some(token.clone()))
             }
         })
     }
@@ -85,16 +94,26 @@ pub struct ApiKeyConfig {
     /// Supports glob patterns. Acts as a blocklist on top of global policy.
     #[serde(default)]
     pub denied_tools: Option<Vec<String>>,
+    /// Whether this API key can use admin-only HTTP UI and management tools.
+    #[serde(default)]
+    pub admin: bool,
 }
 
 impl ApiKeyConfig {
     /// Resolve the API key (expand env vars).
-    #[must_use]
-    pub fn resolve_key(&self) -> String {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an `env:VAR_NAME` reference cannot be resolved.
+    pub fn resolve_key(&self) -> Result<String> {
         if let Some(var_name) = self.key.strip_prefix("env:") {
-            env::var(var_name).unwrap_or_else(|_| self.key.clone())
+            env::var(var_name).map_err(|_| {
+                Error::ConfigValidation(format!(
+                    "auth.api_keys[].key references missing environment variable '{var_name}'"
+                ))
+            })
         } else {
-            self.key.clone()
+            Ok(self.key.clone())
         }
     }
 
@@ -161,13 +180,20 @@ pub struct AgentDefinitionConfig {
 
 impl AgentDefinitionConfig {
     /// Resolve the HS256 secret, expanding `env:VAR_NAME` syntax.
-    #[must_use]
-    pub fn resolved_hs256_secret(&self) -> Option<String> {
-        self.hs256_secret.as_ref().map(|s| {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an `env:VAR_NAME` reference cannot be resolved.
+    pub fn resolved_hs256_secret(&self) -> Result<Option<String>> {
+        self.hs256_secret.as_ref().map_or(Ok(None), |s| {
             if let Some(var) = s.strip_prefix("env:") {
-                env::var(var).unwrap_or_else(|_| s.clone())
+                env::var(var).map(Some).map_err(|_| {
+                    Error::ConfigValidation(format!(
+                        "agent_auth.agents[].hs256_secret references missing environment variable '{var}'"
+                    ))
+                })
             } else {
-                s.clone()
+                Ok(Some(s.clone()))
             }
         })
     }

--- a/src/config/features/key_server.rs
+++ b/src/config/features/key_server.rs
@@ -4,6 +4,8 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 
+use crate::{Error, Result};
+
 // ── Constants ──────────────────────────────────────────────────────────────────
 
 const DEFAULT_TOKEN_TTL_SECS: u64 = 3600;
@@ -93,13 +95,20 @@ impl Default for KeyServerConfig {
 
 impl KeyServerConfig {
     /// Resolve the admin token, expanding `env:VAR_NAME` syntax.
-    #[must_use]
-    pub fn resolve_admin_token(&self) -> Option<String> {
-        self.admin_token.as_ref().map(|t| {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an `env:VAR_NAME` reference cannot be resolved.
+    pub fn resolve_admin_token(&self) -> Result<Option<String>> {
+        self.admin_token.as_ref().map_or(Ok(None), |t| {
             if let Some(var) = t.strip_prefix("env:") {
-                env::var(var).unwrap_or_else(|_| t.clone())
+                env::var(var).map(Some).map_err(|_| {
+                    Error::ConfigValidation(format!(
+                        "key_server.admin_token references missing environment variable '{var}'"
+                    ))
+                })
             } else {
-                t.clone()
+                Ok(Some(t.clone()))
             }
         })
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -287,6 +287,7 @@ impl Config {
         }
         self.validate_backend_names()?;
         self.validate_backend_urls()?;
+        self.validate_secret_env_refs()?;
         Ok(())
     }
 
@@ -338,6 +339,53 @@ impl Config {
                 TransportConfig::Stdio { .. } => {}
             }
         }
+        Ok(())
+    }
+
+    fn validate_secret_env_refs(&self) -> Result<()> {
+        if self.auth.enabled {
+            if let Some(token) = self.auth.bearer_token.as_deref() {
+                Self::validate_env_secret_ref("auth.bearer_token", token)?;
+            }
+            for key in &self.auth.api_keys {
+                Self::validate_env_secret_ref("auth.api_keys[].key", &key.key)?;
+            }
+        }
+
+        if self.agent_auth.enabled {
+            for agent in &self.agent_auth.agents {
+                if let Some(secret) = agent.hs256_secret.as_deref() {
+                    Self::validate_env_secret_ref("agent_auth.agents[].hs256_secret", secret)?;
+                }
+            }
+        }
+
+        if self.key_server.enabled
+            && let Some(token) = self.key_server.admin_token.as_deref()
+        {
+            Self::validate_env_secret_ref("key_server.admin_token", token)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_env_secret_ref(field: &str, value: &str) -> Result<()> {
+        let Some(var_name) = value.strip_prefix("env:") else {
+            return Ok(());
+        };
+
+        if var_name.is_empty() {
+            return Err(Error::ConfigValidation(format!(
+                "{field} uses an empty env: secret reference"
+            )));
+        }
+
+        env::var(var_name).map_err(|_| {
+            Error::ConfigValidation(format!(
+                "{field} references missing environment variable '{var_name}'"
+            ))
+        })?;
+
         Ok(())
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -163,6 +163,28 @@ fn validate_default_config_passes() {
 }
 
 #[test]
+fn validate_rejects_missing_env_backed_auth_secret() {
+    let config = Config {
+        auth: AuthConfig {
+            enabled: true,
+            bearer_token: Some("env:MCP_GATEWAY_TEST_SECRET_SHOULD_NOT_EXIST".to_string()),
+            ..AuthConfig::default()
+        },
+        ..Config::default()
+    };
+
+    let result = config.validate();
+
+    assert!(matches!(result, Err(crate::Error::ConfigValidation(_))));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("MCP_GATEWAY_TEST_SECRET_SHOULD_NOT_EXIST")
+    );
+}
+
+#[test]
 fn validate_rejects_empty_backend_name() {
     // GIVEN: a config with an empty backend name
     let mut config = Config::default();

--- a/src/gateway/auth.rs
+++ b/src/gateway/auth.rs
@@ -19,6 +19,7 @@ use governor::{
 use tracing::{debug, warn};
 
 use super::middleware::{bearer_unauthorized_response, rate_limited_response};
+use crate::Result;
 use crate::config::AuthConfig;
 use crate::key_server::KeyServer;
 
@@ -55,12 +56,18 @@ pub struct ResolvedApiKey {
     pub allowed_tools: Option<Vec<String>>,
     /// Denied tools (blocklist if Some)
     pub denied_tools: Option<Vec<String>>,
+    /// Admin-level UI and management tool access.
+    pub admin: bool,
 }
 
 impl ResolvedAuthConfig {
-    /// Create resolved config from `AuthConfig`
-    pub fn from_config(config: &AuthConfig) -> Self {
-        let bearer_token = config.resolve_bearer_token();
+    /// Create resolved config from `AuthConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any `env:VAR_NAME` secret reference cannot be resolved.
+    pub fn try_from_config(config: &AuthConfig) -> Result<Self> {
+        let bearer_token = config.resolve_bearer_token()?;
 
         // Log if auto-generated token
         if config.bearer_token.as_deref() == Some("auto")
@@ -72,15 +79,18 @@ impl ResolvedAuthConfig {
         let api_keys: Vec<ResolvedApiKey> = config
             .api_keys
             .iter()
-            .map(|k| ResolvedApiKey {
-                key: k.resolve_key(),
-                name: k.name.clone(),
-                rate_limit: k.rate_limit,
-                backends: k.backends.clone(),
-                allowed_tools: k.allowed_tools.clone(),
-                denied_tools: k.denied_tools.clone(),
+            .map(|k| {
+                Ok(ResolvedApiKey {
+                    key: k.resolve_key()?,
+                    name: k.name.clone(),
+                    rate_limit: k.rate_limit,
+                    backends: k.backends.clone(),
+                    allowed_tools: k.allowed_tools.clone(),
+                    denied_tools: k.denied_tools.clone(),
+                    admin: k.admin,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         // Pre-create rate limiters for clients with rate limits
         let rate_limiters = DashMap::new();
@@ -93,13 +103,22 @@ impl ResolvedAuthConfig {
             }
         }
 
-        Self {
+        Ok(Self {
             enabled: config.enabled,
             bearer_token,
             api_keys,
             public_paths: config.public_paths.clone(),
             rate_limiters,
-        }
+        })
+    }
+
+    /// Create resolved config from `AuthConfig`.
+    ///
+    /// Panics if a configured environment-backed secret is missing. Runtime startup
+    /// paths should prefer [`Self::try_from_config`] so the error is returned.
+    #[must_use]
+    pub fn from_config(config: &AuthConfig) -> Self {
+        Self::try_from_config(config).expect("auth config secret references should resolve")
     }
 
     /// Check if a path is public (bypasses auth)
@@ -121,6 +140,7 @@ impl ResolvedAuthConfig {
                 backends: vec!["*".to_string()],
                 allowed_tools: None,
                 denied_tools: None,
+                admin: true,
             });
         }
 
@@ -133,6 +153,7 @@ impl ResolvedAuthConfig {
                     backends: key.backends.clone(),
                     allowed_tools: key.allowed_tools.clone(),
                     denied_tools: key.denied_tools.clone(),
+                    admin: key.admin,
                 });
             }
         }
@@ -165,6 +186,8 @@ pub struct AuthenticatedClient {
     pub allowed_tools: Option<Vec<String>>,
     /// Denied tools (blocklist if Some). Supports glob patterns.
     pub denied_tools: Option<Vec<String>>,
+    /// Admin-level UI and management tool access.
+    pub admin: bool,
 }
 
 impl AuthenticatedClient {
@@ -182,7 +205,7 @@ impl AuthenticatedClient {
     /// - If both are None, fall back to global policy (caller's responsibility).
     ///
     /// Returns `Ok(())` if allowed, `Err(message)` if denied.
-    pub fn check_tool_scope(&self, server: &str, tool: &str) -> Result<(), String> {
+    pub fn check_tool_scope(&self, server: &str, tool: &str) -> std::result::Result<(), String> {
         let qualified = format!("{server}:{tool}");
 
         // If allowlist is set, ONLY tools in the list are permitted
@@ -253,6 +276,7 @@ pub async fn auth_middleware(
             backends: vec!["*".to_string()],
             allowed_tools: None,
             denied_tools: None,
+            admin: true,
         });
         return next.run(request).await;
     }
@@ -268,6 +292,7 @@ pub async fn auth_middleware(
             backends: vec!["*".to_string()],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         });
         return next.run(request).await;
     }
@@ -370,6 +395,7 @@ mod tests {
                     backends: vec!["tavily".to_string()],
                     allowed_tools: None,
                     denied_tools: None,
+                    admin: false,
                 },
                 ResolvedApiKey {
                     key: "key2".to_string(),
@@ -378,6 +404,7 @@ mod tests {
                     backends: vec![],
                     allowed_tools: None,
                     denied_tools: None,
+                    admin: false,
                 },
             ],
             public_paths: vec![],
@@ -428,6 +455,7 @@ mod tests {
             backends: vec!["tavily".to_string(), "brave".to_string()],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         };
 
         let client_unrestricted = AuthenticatedClient {
@@ -436,6 +464,7 @@ mod tests {
             backends: vec![], // empty = all access
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         };
 
         let client_wildcard = AuthenticatedClient {
@@ -444,6 +473,7 @@ mod tests {
             backends: vec!["*".to_string()],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         };
 
         // Restricted client
@@ -468,6 +498,7 @@ mod tests {
             backends: vec![],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         };
 
         // No restrictions = all tools allowed (fallback to global policy)
@@ -483,6 +514,7 @@ mod tests {
             backends: vec![],
             allowed_tools: Some(vec!["search_web".to_string(), "read_file".to_string()]),
             denied_tools: None,
+            admin: false,
         };
 
         // Tools in allowlist
@@ -502,6 +534,7 @@ mod tests {
             backends: vec![],
             allowed_tools: Some(vec!["search_*".to_string(), "read_*".to_string()]),
             denied_tools: None,
+            admin: false,
         };
 
         // Tools matching glob patterns
@@ -527,6 +560,7 @@ mod tests {
             backends: vec![],
             allowed_tools: None,
             denied_tools: Some(vec!["write_file".to_string(), "delete_file".to_string()]),
+            admin: false,
         };
 
         // Tools in denylist
@@ -546,6 +580,7 @@ mod tests {
             backends: vec![],
             allowed_tools: None,
             denied_tools: Some(vec!["filesystem_*".to_string(), "exec_*".to_string()]),
+            admin: false,
         };
 
         // Tools matching deny glob patterns
@@ -578,6 +613,7 @@ mod tests {
                 "search_*".to_string(),
             ]),
             denied_tools: None,
+            admin: false,
         };
 
         // Qualified match: only filesystem:read_file allowed, not other servers
@@ -599,6 +635,7 @@ mod tests {
                 "filesystem_write".to_string(),
                 "filesystem_delete".to_string(),
             ]),
+            admin: false,
         };
 
         // In allowlist and NOT in denylist
@@ -633,6 +670,7 @@ mod tests {
             backends: vec![],
             allowed_tools: Some(vec!["search_*".to_string()]),
             denied_tools: None,
+            admin: false,
         };
 
         let err = client_allow
@@ -649,6 +687,7 @@ mod tests {
             backends: vec![],
             allowed_tools: None,
             denied_tools: Some(vec!["exec_*".to_string()]),
+            admin: false,
         };
 
         let err = client_deny

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -3,9 +3,14 @@
 //! Implements `gateway_search` (Code Mode), `gateway_execute` (Code Mode),
 //! `gateway_list_tools`, `gateway_search_tools`, and the chain executor.
 
+use std::sync::Arc;
+
 use serde_json::{Value, json};
+use tracing::debug;
 
 use crate::autotag;
+use crate::backend::Backend;
+use crate::protocol::Tool;
 use crate::ranking::json_to_search_result;
 use crate::routing_profile::RoutingProfile;
 use crate::{Error, Result};
@@ -16,6 +21,7 @@ use super::super::meta_mcp_helpers::{
     build_search_response, build_suggestions, extract_bool_or, extract_optional_str,
     extract_required_str, extract_search_limit, is_glob_pattern, parse_code_mode_tool_ref,
     parse_tool_arguments, ranked_results_to_json, tool_matches_glob, tool_matches_query,
+    tool_name_matches_glob,
 };
 use super::MetaMcp;
 use super::support::{
@@ -30,6 +36,66 @@ struct CodeModeSearchOptions {
 }
 
 impl MetaMcp {
+    async fn backend_tools_for_discovery(
+        backend: &Arc<Backend>,
+        allow_empty_cache_fetch: bool,
+    ) -> Option<Arc<Vec<Tool>>> {
+        let tools = backend.get_cached_tools_snapshot();
+        if !tools.is_empty() {
+            Self::refresh_stale_backend_tools_in_background(backend);
+            return Some(tools);
+        }
+
+        if allow_empty_cache_fetch {
+            return match backend.get_tools_shared().await {
+                Ok(tools) if !tools.is_empty() => Some(tools),
+                Ok(_) => None,
+                Err(e) => {
+                    debug!(
+                        backend = %backend.name,
+                        error = %e,
+                        "On-demand backend tool-cache fill failed"
+                    );
+                    None
+                }
+            };
+        }
+
+        None
+    }
+
+    fn code_mode_backend_candidates(&self, query: &str) -> (Vec<Arc<Backend>>, bool) {
+        if let Some((server, _)) = query.split_once(':')
+            && !server.is_empty()
+            && !server.contains('*')
+            && !server.contains('?')
+        {
+            return self
+                .backends
+                .get(server)
+                .map_or_else(|| (Vec::new(), false), |backend| (vec![backend], true));
+        }
+
+        (self.backends.all(), false)
+    }
+
+    async fn refresh_stale_backend_tools(backend: Arc<Backend>) {
+        if let Err(e) = backend.get_tools_shared().await {
+            debug!(
+                backend = %backend.name,
+                error = %e,
+                "Background backend tool-cache refresh failed"
+            );
+        }
+    }
+
+    fn refresh_stale_backend_tools_in_background(backend: &Arc<Backend>) {
+        if !backend.has_cached_tools() {
+            let backend = Arc::clone(backend);
+            tokio::spawn(Self::refresh_stale_backend_tools(backend));
+        }
+    }
+
     fn current_search_state(&self, session_id: Option<&str>) -> String {
         session_id.map_or_else(
             || crate::gateway::state::DEFAULT_STATE.to_string(),
@@ -37,11 +103,17 @@ impl MetaMcp {
         )
     }
 
-    fn code_mode_tool_matches(tool: &crate::protocol::Tool, query: &str, use_glob: bool) -> bool {
+    fn code_mode_tool_matches(
+        server: &str,
+        tool: &crate::protocol::Tool,
+        query: &str,
+        use_glob: bool,
+    ) -> bool {
+        let tool_ref = format!("{server}:{}", tool.name).to_lowercase();
         if use_glob {
-            tool_matches_glob(tool, query)
+            tool_matches_glob(tool, query) || tool_name_matches_glob(&tool_ref, query)
         } else {
-            tool_matches_query(tool, query)
+            tool_matches_query(tool, query) || tool_ref.contains(query)
         }
     }
 
@@ -72,7 +144,7 @@ impl MetaMcp {
                     continue;
                 }
                 collect_tool_tags_for_code_mode(&tool, all_tags);
-                if Self::code_mode_tool_matches(&tool, query, options.use_glob) {
+                if Self::code_mode_tool_matches(&cap.name, &tool, query, options.use_glob) {
                     let mut entry =
                         build_code_mode_match_json(&cap.name, &tool, options.include_schema);
                     if cap_killed {
@@ -92,12 +164,15 @@ impl MetaMcp {
         matches: &mut Vec<Value>,
         all_tags: &mut Vec<String>,
     ) {
-        for backend in self.backends.all() {
-            if !backend.has_cached_tools() || !profile.backend_allowed(&backend.name) {
+        let (backends, allow_empty_cache_fetch) = self.code_mode_backend_candidates(query);
+        for backend in backends {
+            if !profile.backend_allowed(&backend.name) {
                 continue;
             }
             let backend_killed = self.kill_switch.is_killed(&backend.name);
-            if let Ok(tools) = backend.get_tools_shared().await {
+            if let Some(tools) =
+                Self::backend_tools_for_discovery(&backend, allow_empty_cache_fetch).await
+            {
                 let enriched: Vec<_> = tools
                     .iter()
                     .filter(|t| profile.tool_allowed(&t.name))
@@ -114,7 +189,7 @@ impl MetaMcp {
                     collect_tool_tags_for_code_mode(tool, all_tags);
                 }
                 for tool in enriched {
-                    if Self::code_mode_tool_matches(&tool, query, options.use_glob) {
+                    if Self::code_mode_tool_matches(&backend.name, &tool, query, options.use_glob) {
                         let mut entry = build_code_mode_match_json(
                             &backend.name,
                             &tool,
@@ -179,11 +254,11 @@ impl MetaMcp {
         all_tags: &mut Vec<String>,
     ) {
         for backend in self.backends.all() {
-            if !backend.has_cached_tools() || !profile.backend_allowed(&backend.name) {
+            if !profile.backend_allowed(&backend.name) {
                 continue;
             }
             let backend_killed = self.kill_switch.is_killed(&backend.name);
-            if let Ok(tools) = backend.get_tools_shared().await {
+            if let Some(tools) = Self::backend_tools_for_discovery(&backend, false).await {
                 let enriched: Vec<_> = tools
                     .iter()
                     .filter(|t| profile.tool_allowed(&t.name))
@@ -470,16 +545,14 @@ impl MetaMcp {
             }
         }
 
-        // MCP backend tools (only from cached/warm-started backends — no blocking starts)
+        // MCP backend tools use cached/warm-started snapshots. Stale non-empty
+        // snapshots stay visible while a background refresh updates the cache.
         for backend in self.backends.all() {
-            if !backend.has_cached_tools() {
-                continue;
-            }
             if !profile.backend_allowed(&backend.name) {
                 continue;
             }
             let backend_killed = self.kill_switch.is_killed(&backend.name);
-            if let Ok(tools) = backend.get_tools_shared().await {
+            if let Some(tools) = Self::backend_tools_for_discovery(&backend, false).await {
                 for tool in tools.iter() {
                     if !profile.tool_allowed(&tool.name) {
                         continue;

--- a/src/gateway/meta_mcp/surfaced.rs
+++ b/src/gateway/meta_mcp/surfaced.rs
@@ -85,6 +85,11 @@ impl MetaMcp {
 // ============================================================================
 
 impl MetaMcp {
+    /// Return the backend server name for a statically surfaced tool.
+    pub(crate) fn surfaced_tool_server(&self, tool_name: &str) -> Option<&str> {
+        self.surfaced_tools_map.get(tool_name).map(String::as_str)
+    }
+
     /// Resolve a surfaced tool config to a [`Tool`] schema.
     ///
     /// Returns `None` when:

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -362,6 +362,156 @@ async fn gateway_search_is_callable_regardless_of_code_mode_flag() {
     );
 }
 
+struct SearchTestTransport {
+    response: crate::protocol::JsonRpcResponse,
+}
+
+#[async_trait::async_trait]
+impl crate::transport::Transport for SearchTestTransport {
+    async fn request(
+        &self,
+        method: &str,
+        _params: Option<serde_json::Value>,
+    ) -> crate::Result<crate::protocol::JsonRpcResponse> {
+        assert_eq!(method, "tools/list");
+        Ok(self.response.clone())
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<serde_json::Value>) -> crate::Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+fn search_test_tool(name: &str) -> crate::protocol::Tool {
+    crate::protocol::Tool {
+        name: name.to_string(),
+        title: None,
+        description: Some(format!("{name} test tool")),
+        input_schema: json!({"type": "object"}),
+        output_schema: None,
+        annotations: None,
+    }
+}
+
+#[tokio::test]
+async fn gateway_search_includes_stale_non_empty_backend_cache() {
+    use crate::backend::Backend;
+    use crate::config::{BackendConfig, FailsafeConfig};
+    use crate::protocol::{JsonRpcResponse, ToolsListResult};
+    use crate::transport::Transport;
+
+    let registry = Arc::new(BackendRegistry::new());
+    let backend = Arc::new(Backend::new(
+        "stale_backend",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::ZERO,
+    ));
+    let response = JsonRpcResponse::success_serialized(
+        RequestId::Number(1),
+        ToolsListResult {
+            tools: vec![search_test_tool("search_flights")],
+            next_cursor: None,
+        },
+    );
+    let transport = Arc::new(SearchTestTransport { response });
+    let transport_dyn: Arc<dyn Transport> = transport;
+    backend.set_transport_for_test(transport_dyn);
+
+    backend.get_tools_shared().await.unwrap();
+    assert_eq!(backend.cached_tools_count(), 1);
+    assert!(
+        !backend.has_cached_tools(),
+        "zero TTL should make the cache stale immediately"
+    );
+
+    registry.register(backend);
+    let meta = MetaMcp::new(registry).with_code_mode(true);
+
+    let result = meta
+        .code_mode_search(
+            &json!({
+                "query": "search_flights",
+                "include_schema": false
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result["total"], 1);
+    assert_eq!(result["matches"][0]["tool"], "stale_backend:search_flights");
+
+    let by_server_glob = meta
+        .code_mode_search(
+            &json!({
+                "query": "stale_backend:*",
+                "include_schema": false
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(by_server_glob["total"], 1);
+    assert_eq!(
+        by_server_glob["matches"][0]["tool"],
+        "stale_backend:search_flights"
+    );
+}
+
+#[tokio::test]
+async fn gateway_search_server_qualified_query_fills_empty_backend_cache() {
+    use crate::backend::Backend;
+    use crate::config::{BackendConfig, FailsafeConfig};
+    use crate::protocol::{JsonRpcResponse, ToolsListResult};
+    use crate::transport::Transport;
+
+    let registry = Arc::new(BackendRegistry::new());
+    let backend = Arc::new(Backend::new(
+        "trvl",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(300),
+    ));
+    let response = JsonRpcResponse::success_serialized(
+        RequestId::Number(1),
+        ToolsListResult {
+            tools: vec![search_test_tool("search_flights")],
+            next_cursor: None,
+        },
+    );
+    let transport = Arc::new(SearchTestTransport { response });
+    let transport_dyn: Arc<dyn Transport> = transport;
+    backend.set_transport_for_test(transport_dyn);
+
+    assert_eq!(backend.cached_tools_count(), 0);
+    registry.register(backend);
+    let meta = MetaMcp::new(registry).with_code_mode(true);
+
+    let result = meta
+        .code_mode_search(
+            &json!({
+                "query": "trvl:*",
+                "include_schema": false
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result["total"], 1);
+    assert_eq!(result["matches"][0]["tool"], "trvl:search_flights");
+}
+
 #[tokio::test]
 async fn gateway_execute_missing_tool_and_chain_returns_tool_call_error() {
     // GIVEN: code mode disabled, calling gateway_execute with no tool/chain

--- a/src/gateway/meta_mcp_helpers.rs
+++ b/src/gateway/meta_mcp_helpers.rs
@@ -529,10 +529,14 @@ pub(crate) fn build_search_response(
     }
 }
 
-/// Extract the search limit from arguments, defaulting to 10.
+const DEFAULT_SEARCH_LIMIT: usize = 10;
+const MAX_SEARCH_LIMIT: usize = 25;
+
+/// Extract the search limit from arguments, defaulting to 10 and clamping to a
+/// hard maximum so discovery output stays bounded regardless of backend count.
 #[allow(clippy::cast_possible_truncation)]
 pub(crate) fn extract_search_limit(args: &Value) -> usize {
-    extract_u64_or(args, "limit", 10) as usize
+    (extract_u64_or(args, "limit", DEFAULT_SEARCH_LIMIT as u64) as usize).min(MAX_SEARCH_LIMIT)
 }
 
 /// Extract a required string parameter from JSON arguments.

--- a/src/gateway/meta_mcp_helpers_tests.rs
+++ b/src/gateway/meta_mcp_helpers_tests.rs
@@ -764,6 +764,12 @@ fn extract_search_limit_respects_custom_value() {
 }
 
 #[test]
+fn extract_search_limit_clamps_large_values() {
+    let args = json!({"limit": 500});
+    assert_eq!(extract_search_limit(&args), 25);
+}
+
+#[test]
 fn extract_search_limit_ignores_non_integer() {
     let args = json!({"limit": "not a number"});
     assert_eq!(extract_search_limit(&args), 10);

--- a/src/gateway/meta_mcp_tool_defs.rs
+++ b/src/gateway/meta_mcp_tool_defs.rs
@@ -592,7 +592,7 @@ pub(crate) fn build_code_mode_search_tool() -> Tool {
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum number of results to return (default 10)",
+                    "description": "Maximum number of results to return (default 10, hard-capped at 25)",
                     "default": 10
                 },
                 "include_schema": {

--- a/src/gateway/oauth/mod.rs
+++ b/src/gateway/oauth/mod.rs
@@ -144,17 +144,15 @@ pub async fn agent_auth_middleware(
 /// Check whether the [`AgentIdentity`] in `extensions` grants access to
 /// `(backend, tool, action)` and emit an audit log entry.
 ///
-/// Returns `Ok(())` on success or an `Err(Response)` (403) on denial.
+/// Returns `Ok(())` on success or a denial reason on failure.
 ///
 /// Call this from tool dispatch handlers, **after** the middleware has run.
-// `Response` is inherently large in axum; boxing it would complicate caller code.
-#[allow(clippy::result_large_err)]
-pub fn check_agent_scope_and_audit(
+pub fn check_agent_scope_and_audit_reason(
     identity: &AgentIdentity,
     backend: &str,
     tool: &str,
     action: &Action,
-) -> Result<(), Response> {
+) -> Result<(), String> {
     let raw_action = format!("{action:?}").to_lowercase();
 
     match check_scopes(&identity.scopes, &identity.client_id, backend, tool, action) {
@@ -186,9 +184,24 @@ pub fn check_agent_scope_and_audit(
                 action = %raw_action,
                 "Agent scope denied: {reason}"
             );
-            Err(forbidden_response(&reason))
+            Err(reason)
         }
     }
+}
+
+/// Check agent scope, emit audit, and convert denial into a `403` response.
+///
+/// Call this from Axum handlers that want a ready-to-return HTTP response.
+// `Response` is inherently large in axum; boxing it would complicate caller code.
+#[allow(clippy::result_large_err)]
+pub fn check_agent_scope_and_audit(
+    identity: &AgentIdentity,
+    backend: &str,
+    tool: &str,
+    action: &Action,
+) -> Result<(), Response> {
+    check_agent_scope_and_audit_reason(identity, backend, tool, action)
+        .map_err(|reason| forbidden_response(&reason))
 }
 
 // ── JWKS endpoint handler ─────────────────────────────────────────────────────

--- a/src/gateway/router/authorization.rs
+++ b/src/gateway/router/authorization.rs
@@ -1,0 +1,238 @@
+//! Shared authorization for backend tool invocations.
+
+use axum::http::StatusCode;
+use serde_json::Value;
+use tracing::warn;
+
+use super::AppState;
+use crate::gateway::auth::AuthenticatedClient;
+use crate::gateway::meta_mcp::MetaMcp;
+use crate::gateway::oauth::{
+    Action, AgentIdentity as OAuthAgentIdentity, check_agent_scope_and_audit_reason,
+};
+use crate::mtls::{CertIdentity, PolicyDecision};
+use crate::security::{validate_tool_name, validate_url_not_ssrf};
+
+pub(super) struct OwnedToolTarget {
+    pub server: String,
+    pub tool: String,
+    pub arguments: Value,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ToolTarget<'a> {
+    pub server: &'a str,
+    pub tool: &'a str,
+    pub arguments: &'a Value,
+}
+
+impl OwnedToolTarget {
+    pub(super) fn as_target(&self) -> ToolTarget<'_> {
+        ToolTarget {
+            server: &self.server,
+            tool: &self.tool,
+            arguments: &self.arguments,
+        }
+    }
+}
+
+pub(super) struct AuthorizationError {
+    pub code: i32,
+    pub status: StatusCode,
+    pub message: String,
+}
+
+impl AuthorizationError {
+    fn forbidden(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            status: StatusCode::FORBIDDEN,
+            message: message.into(),
+        }
+    }
+}
+
+pub(super) fn backend_tool_targets_for_call(
+    meta_mcp: &MetaMcp,
+    tool_name: &str,
+    arguments: &Value,
+) -> Vec<OwnedToolTarget> {
+    if let Some(server) = meta_mcp.surfaced_tool_server(tool_name) {
+        return vec![OwnedToolTarget {
+            server: server.to_string(),
+            tool: tool_name.to_string(),
+            arguments: arguments.clone(),
+        }];
+    }
+
+    match tool_name {
+        "gateway_invoke" => target_from_invoke_arguments(arguments)
+            .into_iter()
+            .collect(),
+        "gateway_execute" => targets_from_code_mode_arguments(arguments),
+        _ => Vec::new(),
+    }
+}
+
+pub(super) fn is_admin_meta_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "gateway_kill_server"
+            | "gateway_revive_server"
+            | "gateway_set_profile"
+            | "gateway_set_state"
+            | "gateway_reload_config"
+            | "gateway_reload_capabilities"
+    )
+}
+
+pub(super) fn require_admin_tool_access(
+    client: Option<&AuthenticatedClient>,
+    tool_name: &str,
+) -> Result<(), AuthorizationError> {
+    if client.is_some_and(|client| client.admin) {
+        return Ok(());
+    }
+
+    Err(AuthorizationError::forbidden(
+        -32600,
+        format!("Tool '{tool_name}' requires admin access"),
+    ))
+}
+
+pub(super) fn authorize_tool_target(
+    state: &AppState,
+    client: Option<&AuthenticatedClient>,
+    oauth_agent_identity: Option<&OAuthAgentIdentity>,
+    cert_identity: Option<&CertIdentity>,
+    target: ToolTarget<'_>,
+) -> Result<(), AuthorizationError> {
+    if target.server.is_empty() || target.tool.is_empty() {
+        return Ok(());
+    }
+
+    validate_tool_name(target.tool)
+        .map_err(|e| AuthorizationError::forbidden(-32600, e.clone()))?;
+
+    if let Some(client) = client
+        && !client.can_access_backend(target.server)
+    {
+        return Err(AuthorizationError::forbidden(
+            -32003,
+            format!(
+                "Client '{}' not authorized for backend '{}'",
+                client.name, target.server
+            ),
+        ));
+    }
+
+    state
+        .tool_policy
+        .check(target.server, target.tool)
+        .map_err(|e| AuthorizationError::forbidden(-32600, e.to_string()))?;
+
+    if let Some(client) = client {
+        client
+            .check_tool_scope(target.server, target.tool)
+            .map_err(|e| AuthorizationError::forbidden(-32600, e))?;
+    }
+
+    if !state.mtls_policy.is_empty() {
+        let decision = state
+            .mtls_policy
+            .evaluate(cert_identity, target.server, target.tool);
+        if decision == PolicyDecision::Deny {
+            let identity_label =
+                cert_identity.map_or("<unauthenticated>", |id| id.display_name.as_str());
+            warn!(
+                server = target.server,
+                tool = target.tool,
+                identity = identity_label,
+                "Tool invocation denied by mTLS policy"
+            );
+            return Err(AuthorizationError::forbidden(
+                -32600,
+                format!(
+                    "Tool '{}' on server '{}' is blocked by certificate policy",
+                    target.tool, target.server
+                ),
+            ));
+        }
+    }
+
+    if state.agent_auth.enabled {
+        let identity = oauth_agent_identity.ok_or_else(|| {
+            AuthorizationError::forbidden(
+                -32600,
+                "Agent authentication is enabled but no validated agent identity was found",
+            )
+        })?;
+        check_agent_scope_and_audit_reason(identity, target.server, target.tool, &Action::Execute)
+            .map_err(|e| AuthorizationError::forbidden(-32600, e))?;
+    }
+
+    if state.ssrf_protection
+        && let Some(backend) = state.backends.get(target.server)
+        && let Some(url) = backend.transport_url()
+    {
+        validate_url_not_ssrf(url)
+            .map_err(|e| AuthorizationError::forbidden(-32600, e.to_string()))?;
+    }
+
+    Ok(())
+}
+
+fn target_from_invoke_arguments(arguments: &Value) -> Option<OwnedToolTarget> {
+    Some(OwnedToolTarget {
+        server: arguments.get("server")?.as_str()?.to_string(),
+        tool: arguments.get("tool")?.as_str()?.to_string(),
+        arguments: arguments
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+    })
+}
+
+fn targets_from_code_mode_arguments(arguments: &Value) -> Vec<OwnedToolTarget> {
+    if let Some(chain) = arguments.get("chain").and_then(Value::as_array) {
+        return chain
+            .iter()
+            .filter_map(|step| {
+                let tool_ref = step.get("tool")?.as_str()?;
+                let (server, tool) = parse_qualified_tool_ref(tool_ref)?;
+                Some(OwnedToolTarget {
+                    server: server.to_string(),
+                    tool: tool.to_string(),
+                    arguments: step
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({})),
+                })
+            })
+            .collect();
+    }
+
+    let Some(tool_ref) = arguments.get("tool").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    let Some((server, tool)) = parse_qualified_tool_ref(tool_ref) else {
+        return Vec::new();
+    };
+
+    vec![OwnedToolTarget {
+        server: server.to_string(),
+        tool: tool.to_string(),
+        arguments: arguments
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+    }]
+}
+
+fn parse_qualified_tool_ref(tool_ref: &str) -> Option<(&str, &str)> {
+    let (server, tool) = tool_ref.split_once(':')?;
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server, tool))
+}

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -12,10 +12,26 @@ use serde_json::{Value, json};
 use tracing::{debug, error, warn};
 
 use super::AppState;
+use super::authorization::{ToolTarget, authorize_tool_target};
 use super::helpers::{build_http_error_response, build_http_response, parse_request};
+use crate::backend::normalize_tool_annotations;
 use crate::gateway::auth::AuthenticatedClient;
-use crate::protocol::{JsonRpcResponse, RequestId};
+use crate::gateway::oauth::AgentIdentity as OAuthAgentIdentity;
+use crate::mtls::CertIdentity;
+use crate::protocol::{JsonRpcResponse, RequestId, Tool};
+#[cfg(feature = "firewall")]
+use crate::security::firewall::FirewallAction;
 use crate::security::{sanitize_json_value, validate_tool_name};
+
+type BackendRejection = (StatusCode, Json<Value>);
+type BackendSecurityResult = Option<Result<Option<Value>, BackendRejection>>;
+
+#[derive(Clone, Copy)]
+struct BackendAuthContext<'a> {
+    client: Option<&'a AuthenticatedClient>,
+    oauth_agent_identity: Option<&'a OAuthAgentIdentity>,
+    cert_identity: Option<&'a CertIdentity>,
+}
 
 /// Apply tool policy, name validation, and input sanitization to a `tools/call`
 /// request arriving at the direct backend endpoint.
@@ -32,9 +48,11 @@ use crate::security::{sanitize_json_value, validate_tool_name};
 fn apply_backend_tool_call_security(
     state: &AppState,
     backend_name: &str,
+    auth: BackendAuthContext<'_>,
     params: Option<&Value>,
     id: &RequestId,
-) -> Option<Result<Value, (StatusCode, Json<Value>)>> {
+    sanitize: bool,
+) -> BackendSecurityResult {
     let params = params?;
     let tool_name = params.get("name").and_then(Value::as_str).unwrap_or("");
     if tool_name.is_empty() {
@@ -46,13 +64,59 @@ fn apply_backend_tool_call_security(
         return Some(Err(backend_security_error(id, &e)));
     }
 
-    if let Err(e) = state.tool_policy.check(backend_name, tool_name) {
-        warn!(backend = %backend_name, tool = %tool_name, "Tool blocked by policy");
-        return Some(Err(backend_security_error(id, &e.to_string())));
+    let arguments = params.get("arguments").unwrap_or(params);
+    let target = ToolTarget {
+        server: backend_name,
+        tool: tool_name,
+        arguments,
+    };
+    if let Err(e) = authorize_tool_target(
+        state,
+        auth.client,
+        auth.oauth_agent_identity,
+        auth.cert_identity,
+        target,
+    ) {
+        warn!(backend = %backend_name, tool = %tool_name, "Tool blocked by authorization");
+        return Some(Err(backend_security_error_with_status(
+            id, e.code, &e.message, e.status,
+        )));
+    }
+
+    #[cfg(feature = "firewall")]
+    if let Some(ref fw) = state.firewall {
+        let caller_name = auth.client.map_or("anonymous", |c| c.name.as_str());
+        let session_id = format!("direct:{backend_name}");
+        let verdict =
+            fw.check_request(&session_id, backend_name, tool_name, arguments, caller_name);
+        if verdict.action == FirewallAction::Warn {
+            warn!(
+                backend = %backend_name,
+                tool = %tool_name,
+                findings = verdict.findings.len(),
+                "Firewall: direct backend request warning"
+            );
+        }
+        if !verdict.allowed {
+            let desc = verdict
+                .findings
+                .first()
+                .map_or("Security firewall blocked this request", |f| {
+                    f.description.as_str()
+                });
+            return Some(Err(backend_security_error(
+                id,
+                &format!("Firewall blocked: {desc}"),
+            )));
+        }
+    }
+
+    if !sanitize {
+        return Some(Ok(None));
     }
 
     match sanitize_json_value(params) {
-        Ok(sanitized) => Some(Ok(sanitized)),
+        Ok(sanitized) => Some(Ok(Some(sanitized))),
         Err(e) => {
             warn!(backend = %backend_name, tool = %tool_name, "Input sanitization failed");
             Some(Err(backend_security_error(id, &e.to_string())))
@@ -63,6 +127,44 @@ fn apply_backend_tool_call_security(
 /// Build a `403 Forbidden` JSON-RPC error response for security rejections.
 fn backend_security_error(id: &RequestId, message: &str) -> (StatusCode, Json<Value>) {
     build_http_error_response(Some(id.clone()), -32600, message, StatusCode::FORBIDDEN)
+}
+
+fn backend_security_error_with_status(
+    id: &RequestId,
+    code: i32,
+    message: &str,
+    status: StatusCode,
+) -> (StatusCode, Json<Value>) {
+    build_http_error_response(Some(id.clone()), code, message, status)
+}
+
+/// Fill missing MCP tool annotation hints on direct backend `tools/list`
+/// responses before returning them to clients.
+fn normalize_tools_list_response(backend_name: &str, response: &mut JsonRpcResponse) {
+    if response.error.is_some() {
+        return;
+    }
+
+    let Some(result) = response.result.as_mut() else {
+        return;
+    };
+    let Some(tools_value) = result.get_mut("tools") else {
+        return;
+    };
+
+    let Ok(mut tools) = serde_json::from_value::<Vec<Tool>>(tools_value.clone()) else {
+        warn!(backend = %backend_name, "Backend tools/list result could not be normalized");
+        return;
+    };
+
+    normalize_tool_annotations(backend_name, &mut tools);
+
+    match serde_json::to_value(tools) {
+        Ok(normalized_tools) => *tools_value = normalized_tools,
+        Err(e) => {
+            warn!(backend = %backend_name, error = %e, "Failed to serialize normalized tools/list");
+        }
+    }
 }
 
 /// Backend handler (POST /mcp/{name})
@@ -77,6 +179,8 @@ pub(super) async fn backend_handler(
 
     // Extract authenticated client from extensions (injected by auth middleware)
     let client = request.extensions().get::<AuthenticatedClient>().cloned();
+    let cert_identity = request.extensions().get::<CertIdentity>().cloned();
+    let oauth_agent_identity = request.extensions().get::<OAuthAgentIdentity>().cloned();
 
     // Check backend access if auth is enabled
     if let Some(ref client) = client
@@ -156,12 +260,32 @@ pub(super) async fn backend_handler(
     // SECURITY: apply tool policy, name validation, and input sanitization to
     // tools/call requests unless the backend explicitly opts into pass-through
     // mode (passthrough: true in config — only for fully-trusted internals).
-    if method == "tools/call" && !backend.passthrough() {
-        match apply_backend_tool_call_security(&state, &name, params.as_ref(), &id) {
-            Some(Ok(sanitized_params)) => {
+    if method == "tools/call" {
+        match apply_backend_tool_call_security(
+            &state,
+            &name,
+            BackendAuthContext {
+                client: client.as_ref(),
+                oauth_agent_identity: oauth_agent_identity.as_ref(),
+                cert_identity: cert_identity.as_ref(),
+            },
+            params.as_ref(),
+            &id,
+            !backend.passthrough(),
+        ) {
+            Some(Ok(Some(sanitized_params))) => {
                 // Forward the sanitized params to the backend
                 return match backend.request(&method, Some(sanitized_params)).await {
-                    Ok(response) => build_http_response(&response, StatusCode::OK),
+                    Ok(mut response) => {
+                        scan_direct_backend_response(
+                            &state,
+                            &name,
+                            params.as_ref(),
+                            client.as_ref(),
+                            &mut response,
+                        );
+                        build_http_response(&response, StatusCode::OK)
+                    }
                     Err(e) => {
                         error!(backend = %name, error = %e, "Backend request failed");
                         let response =
@@ -171,19 +295,76 @@ pub(super) async fn backend_handler(
                 };
             }
             Some(Err(rejection)) => return rejection,
-            None => {} // no tool name present; fall through to normal forwarding
+            Some(Ok(None)) | None => {} // no tool name present; fall through to normal forwarding
         }
     }
 
     // Forward to backend
-    match backend.request(&method, params).await {
-        Ok(response) => build_http_response(&response, StatusCode::OK),
+    match backend.request(&method, params.clone()).await {
+        Ok(mut response) => {
+            if method == "tools/list" {
+                normalize_tools_list_response(&name, &mut response);
+            } else if method == "tools/call" {
+                scan_direct_backend_response(
+                    &state,
+                    &name,
+                    params.as_ref(),
+                    client.as_ref(),
+                    &mut response,
+                );
+            }
+            build_http_response(&response, StatusCode::OK)
+        }
         Err(e) => {
             error!(backend = %name, error = %e, "Backend request failed");
             let response = JsonRpcResponse::error(Some(id), e.to_rpc_code(), e.to_string());
             build_http_response(&response, StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
+}
+
+#[cfg(feature = "firewall")]
+fn scan_direct_backend_response(
+    state: &AppState,
+    backend_name: &str,
+    params: Option<&Value>,
+    client: Option<&AuthenticatedClient>,
+    response: &mut JsonRpcResponse,
+) {
+    let Some(ref fw) = state.firewall else {
+        return;
+    };
+    let Some(params) = params else {
+        return;
+    };
+    let Some(tool_name) = params.get("name").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(ref mut result) = response.result else {
+        return;
+    };
+
+    let caller_name = client.map_or("anonymous", |c| c.name.as_str());
+    let session_id = format!("direct:{backend_name}");
+    let verdict = fw.check_response(&session_id, backend_name, tool_name, result, caller_name);
+    if verdict.action == FirewallAction::Warn {
+        warn!(
+            backend = %backend_name,
+            tool = %tool_name,
+            findings = verdict.findings.len(),
+            "Firewall: direct backend response warning"
+        );
+    }
+}
+
+#[cfg(not(feature = "firewall"))]
+fn scan_direct_backend_response(
+    _state: &AppState,
+    _backend_name: &str,
+    _params: Option<&Value>,
+    _client: Option<&AuthenticatedClient>,
+    _response: &mut JsonRpcResponse,
+) {
 }
 
 /// GET /api/costs — REST endpoint for per-key and aggregate cost views.
@@ -239,4 +420,54 @@ pub(super) async fn costs_handler(
     };
 
     (StatusCode::OK, Json(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn normalize_tools_list_response_fills_direct_backend_proxy_annotations() {
+        let mut response = JsonRpcResponse::success(
+            RequestId::Number(1),
+            json!({
+                "tools": [
+                    {
+                        "name": "search",
+                        "description": "Search things",
+                        "inputSchema": {"type": "object"},
+                        "annotations": {"readOnlyHint": true}
+                    },
+                    {
+                        "name": "archive_chat",
+                        "description": "Archive a chat",
+                        "inputSchema": {"type": "object"},
+                        "annotations": {}
+                    }
+                ],
+                "nextCursor": "abc",
+                "extra": "preserved"
+            }),
+        );
+
+        normalize_tools_list_response("beeper", &mut response);
+
+        let result = response.result.expect("success result");
+        assert_eq!(result["nextCursor"], "abc");
+        assert_eq!(result["extra"], "preserved");
+
+        let search = &result["tools"][0]["annotations"];
+        assert_eq!(search["readOnlyHint"], true);
+        assert_eq!(search["destructiveHint"], false);
+        assert_eq!(search["idempotentHint"], true);
+        assert_eq!(search["openWorldHint"], true);
+
+        let archive = &result["tools"][1]["annotations"];
+        assert_eq!(archive["readOnlyHint"], false);
+        assert_eq!(archive["destructiveHint"], true);
+        assert_eq!(archive["idempotentHint"], false);
+        assert_eq!(archive["openWorldHint"], true);
+    }
 }

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -12,6 +12,10 @@ use serde_json::{Value, json};
 use tracing::{debug, info, warn};
 
 use super::AppState;
+use super::authorization::{
+    authorize_tool_target, backend_tool_targets_for_call, is_admin_meta_tool,
+    require_admin_tool_access,
+};
 use super::helpers::{
     attach_session_header, build_accepted_response, build_error_response,
     build_http_error_response, build_http_response, build_response, extract_tools_call_params,
@@ -21,14 +25,13 @@ use crate::gateway::auth::AuthenticatedClient;
 use crate::gateway::destructive_confirmation::{
     ConfirmationOutcome, is_destructive_meta_tool, require_destructive_confirmation,
 };
+use crate::gateway::oauth::AgentIdentity as OAuthAgentIdentity;
 use crate::gateway::streaming::create_sse_response;
 use crate::mtls::CertIdentity;
 use crate::protocol::JsonRpcResponse;
 #[cfg(feature = "firewall")]
 use crate::security::firewall::FirewallAction;
-use crate::security::{
-    extract_agent_identity, sanitize_json_value, validate_agent_identity, validate_url_not_ssrf,
-};
+use crate::security::{extract_agent_identity, sanitize_json_value, validate_agent_identity};
 
 /// GET /mcp handler - SSE stream for server→client notifications
 /// Per MCP spec 2025-03-26, servers MAY return SSE stream or 405 Method Not Allowed.
@@ -210,6 +213,10 @@ pub(super) async fn meta_mcp_handler(
     // Extract mTLS certificate identity (present when mTLS is active and a valid
     // client certificate was presented during the TLS handshake).
     let cert_identity = http_request.extensions().get::<CertIdentity>().cloned();
+    let oauth_agent_identity = http_request
+        .extensions()
+        .get::<OAuthAgentIdentity>()
+        .cloned();
 
     // === OWASP ASI03: per-agent identity extraction ===
     //
@@ -370,93 +377,47 @@ pub(super) async fn meta_mcp_handler(
         "tools/call" => {
             let (tool_name, arguments) = extract_tools_call_params(params.as_ref());
 
-            // Apply tool policy check and SSRF validation for gateway_invoke calls
-            if tool_name == "gateway_invoke"
-                && let Some(ref args) = params
+            if is_admin_meta_tool(tool_name)
+                && let Err(e) = require_admin_tool_access(client.as_ref(), tool_name)
             {
-                let server = args
-                    .get("arguments")
-                    .and_then(|a| a.get("server"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let tool = args
-                    .get("arguments")
-                    .and_then(|a| a.get("tool"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if !server.is_empty() && !tool.is_empty() {
-                    // Global policy check
-                    if let Err(e) = state.tool_policy.check(server, tool) {
-                        return build_error_response(
-                            Some(id),
-                            -32600,
-                            e.to_string(),
-                            &session_id,
-                            StatusCode::FORBIDDEN,
-                        );
-                    }
+                return build_error_response(Some(id), e.code, e.message, &session_id, e.status);
+            }
 
-                    // mTLS certificate-based policy check (defense-in-depth layer)
-                    if !state.mtls_policy.is_empty() {
-                        use crate::mtls::PolicyDecision;
-                        let decision =
-                            state
-                                .mtls_policy
-                                .evaluate(cert_identity.as_ref(), server, tool);
-                        if decision == PolicyDecision::Deny {
-                            let identity_label = cert_identity
-                                .as_ref()
-                                .map_or("<unauthenticated>", |id| id.display_name.as_str());
-                            warn!(
-                                server = server,
-                                tool = tool,
-                                identity = identity_label,
-                                "Tool invocation denied by mTLS policy"
-                            );
-                            return build_error_response(
-                                Some(id),
-                                -32600,
-                                format!(
-                                    "Tool '{tool}' on server '{server}' is blocked by \
-                                         certificate policy"
-                                ),
-                                &session_id,
-                                StatusCode::FORBIDDEN,
-                            );
-                        }
-                    }
-
-                    // Per-client tool scope check
-                    if let Some(ref c) = client
-                        && let Err(e) = c.check_tool_scope(server, tool)
-                    {
-                        return build_error_response(
-                            Some(id),
-                            -32600,
-                            e,
-                            &session_id,
-                            StatusCode::FORBIDDEN,
-                        );
-                    }
+            let backend_targets =
+                backend_tool_targets_for_call(&state.meta_mcp, tool_name, &arguments);
+            for target in &backend_targets {
+                if let Err(e) = authorize_tool_target(
+                    state.as_ref(),
+                    client.as_ref(),
+                    oauth_agent_identity.as_ref(),
+                    cert_identity.as_ref(),
+                    target.as_target(),
+                ) {
+                    return build_error_response(
+                        Some(id),
+                        e.code,
+                        e.message,
+                        &session_id,
+                        e.status,
+                    );
                 }
 
                 // Firewall: pre-invocation request scan
                 #[cfg(feature = "firewall")]
-                if let Some(ref fw) = state.firewall
-                    && !server.is_empty()
-                    && !tool.is_empty()
-                {
+                if let Some(ref fw) = state.firewall {
+                    let target = target.as_target();
                     let caller_name = client.as_ref().map_or("anonymous", |c| c.name.as_str());
-                    let invoke_args = args
-                        .get("arguments")
-                        .cloned()
-                        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-                    let verdict =
-                        fw.check_request(&session_id, server, tool, &invoke_args, caller_name);
+                    let verdict = fw.check_request(
+                        &session_id,
+                        target.server,
+                        target.tool,
+                        target.arguments,
+                        caller_name,
+                    );
                     if verdict.action == FirewallAction::Warn {
                         warn!(
-                            server = server,
-                            tool = tool,
+                            server = target.server,
+                            tool = target.tool,
                             findings = verdict.findings.len(),
                             "Firewall: request warning"
                         );
@@ -488,50 +449,10 @@ pub(super) async fn meta_mcp_handler(
                         );
                     }
                 }
-
-                // SSRF protection: validate backend URL before proxying
-                if state.ssrf_protection
-                    && !server.is_empty()
-                    && let Some(backend) = state.backends.get(server)
-                    && let Some(url) = backend.transport_url()
-                    && let Err(e) = validate_url_not_ssrf(url)
-                {
-                    return build_error_response(
-                        Some(id),
-                        -32600,
-                        e.to_string(),
-                        &session_id,
-                        StatusCode::FORBIDDEN,
-                    );
-                }
             }
 
             let api_key_name = client.as_ref().map(|c| c.name.as_str());
             let agent_id = agent_identity.as_ref().map(|a| a.id.as_str());
-
-            // Capture server/tool for post-invoke firewall scan (before borrows move).
-            #[cfg(feature = "firewall")]
-            let (fw_server, fw_tool, fw_caller) = {
-                let srv = params
-                    .as_ref()
-                    .and_then(|p| p.get("arguments"))
-                    .and_then(|a| a.get("server"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let tl = params
-                    .as_ref()
-                    .and_then(|p| p.get("arguments"))
-                    .and_then(|a| a.get("tool"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let cl = client
-                    .as_ref()
-                    .map_or("anonymous", |c| c.name.as_str())
-                    .to_string();
-                (srv, tl, cl)
-            };
 
             // OWASP ASI09 — destructive meta-tool confirmation gate.
             //
@@ -575,19 +496,26 @@ pub(super) async fn meta_mcp_handler(
             // Firewall: post-invocation response scan + credential redaction.
             #[cfg(feature = "firewall")]
             if let Some(ref fw) = state.firewall
-                && !fw_server.is_empty()
-                && !fw_tool.is_empty()
                 && let Some(ref mut result_val) = call_response.result
             {
-                let verdict =
-                    fw.check_response(&session_id, &fw_server, &fw_tool, result_val, &fw_caller);
-                if verdict.action == FirewallAction::Warn {
-                    warn!(
-                        server = %fw_server,
-                        tool = %fw_tool,
-                        findings = verdict.findings.len(),
-                        "Firewall: response warning"
+                let caller_name = client.as_ref().map_or("anonymous", |c| c.name.as_str());
+                for target in &backend_targets {
+                    let target = target.as_target();
+                    let verdict = fw.check_response(
+                        &session_id,
+                        target.server,
+                        target.tool,
+                        result_val,
+                        caller_name,
                     );
+                    if verdict.action == FirewallAction::Warn {
+                        warn!(
+                            server = target.server,
+                            tool = target.tool,
+                            findings = verdict.findings.len(),
+                            "Firewall: response warning"
+                        );
+                    }
                 }
             }
 

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -21,6 +21,7 @@ use crate::security::ToolPolicy;
 #[cfg(feature = "firewall")]
 use crate::security::firewall::Firewall;
 
+mod authorization;
 mod backend_handlers;
 mod handlers;
 pub(crate) mod helpers;

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -5,11 +5,13 @@ use super::helpers::{
 };
 use super::{AppState, create_router};
 use crate::backend::{Backend, BackendRegistry};
-use crate::config::{AuthConfig, BackendConfig, FailsafeConfig, StreamingConfig};
+use crate::config::{
+    ApiKeyConfig, AuthConfig, BackendConfig, FailsafeConfig, StreamingConfig, SurfacedToolConfig,
+};
 use crate::gateway::test_helpers::MetaMcp;
 use crate::gateway::{
-    AgentAuthState, AgentRegistry, GatewayKeyPair, NotificationMultiplexer, ProxyManager,
-    ResolvedAuthConfig,
+    AgentAuthState, AgentIdentity as OAuthAgentIdentity, AgentRegistry, GatewayKeyPair,
+    NotificationMultiplexer, ProxyManager, ResolvedAuthConfig,
 };
 use crate::mtls::{MtlsConfig, MtlsPolicy};
 use crate::protocol::{JsonRpcResponse, RequestId};
@@ -25,6 +27,8 @@ use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tower::ServiceExt;
+
+use super::authorization::{ToolTarget, authorize_tool_target, backend_tool_targets_for_call};
 
 fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Arc<AppState> {
     let backends = Arc::new(BackendRegistry::new());
@@ -64,6 +68,43 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
 
 fn test_router_app_state() -> Arc<AppState> {
     test_router_app_state_with_streaming(StreamingConfig::default())
+}
+
+fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
+    let backends = Arc::new(BackendRegistry::new());
+    let meta_mcp = Arc::new(MetaMcp::new(Arc::clone(&backends)));
+    let streaming_config = StreamingConfig::default();
+    let multiplexer = Arc::new(NotificationMultiplexer::new(
+        Arc::clone(&backends),
+        streaming_config.clone(),
+    ));
+    let proxy_manager = Arc::new(ProxyManager::new(Arc::clone(&multiplexer)));
+    let auth_config = Arc::new(ResolvedAuthConfig::from_config(&AuthConfig::default()));
+    let agent_auth = AgentAuthState::new(true, Arc::new(AgentRegistry::new()));
+    let gateway_key_pair = Arc::new(GatewayKeyPair::generate().expect("gateway key generation"));
+
+    Arc::new(AppState {
+        backends,
+        meta_mcp,
+        meta_mcp_enabled: true,
+        multiplexer,
+        proxy_manager,
+        streaming_config,
+        auth_config,
+        key_server: None,
+        tool_policy: Arc::new(crate::security::ToolPolicy::default()),
+        mtls_policy: Arc::new(MtlsPolicy::from_config(&MtlsConfig::default())),
+        sanitize_input: false,
+        ssrf_protection: false,
+        inflight: Arc::new(tokio::sync::Semaphore::new(8)),
+        agent_auth,
+        gateway_key_pair,
+        capability_dirs: Vec::new(),
+        config_path: None,
+        #[cfg(feature = "firewall")]
+        firewall: None,
+        agent_identity_config: crate::config::AgentIdentityConfig::default(),
+    })
 }
 
 fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
@@ -107,6 +148,60 @@ fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
     let state = test_router_app_state();
     state.backends.register(backend);
     state
+}
+
+fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
+    let backends = Arc::new(BackendRegistry::new());
+    let meta_mcp = Arc::new(MetaMcp::new(Arc::clone(&backends)));
+    let streaming_config = StreamingConfig::default();
+    let multiplexer = Arc::new(NotificationMultiplexer::new(
+        Arc::clone(&backends),
+        streaming_config.clone(),
+    ));
+    let proxy_manager = Arc::new(ProxyManager::new(Arc::clone(&multiplexer)));
+    let auth_config = Arc::new(ResolvedAuthConfig::from_config(auth));
+    let agent_auth = AgentAuthState::new(false, Arc::new(AgentRegistry::new()));
+    let gateway_key_pair = Arc::new(GatewayKeyPair::generate().expect("gateway key generation"));
+
+    Arc::new(AppState {
+        backends,
+        meta_mcp,
+        meta_mcp_enabled: true,
+        multiplexer,
+        proxy_manager,
+        streaming_config,
+        auth_config,
+        key_server: None,
+        tool_policy: Arc::new(crate::security::ToolPolicy::default()),
+        mtls_policy: Arc::new(MtlsPolicy::from_config(&MtlsConfig::default())),
+        sanitize_input: false,
+        ssrf_protection: false,
+        inflight: Arc::new(tokio::sync::Semaphore::new(8)),
+        agent_auth,
+        gateway_key_pair,
+        capability_dirs: Vec::new(),
+        config_path: None,
+        #[cfg(feature = "firewall")]
+        firewall: None,
+        agent_identity_config: crate::config::AgentIdentityConfig::default(),
+    })
+}
+
+fn scoped_auth_config(admin: bool) -> AuthConfig {
+    AuthConfig {
+        enabled: true,
+        bearer_token: None,
+        api_keys: vec![ApiKeyConfig {
+            key: "scoped-key".to_string(),
+            name: "scoped-client".to_string(),
+            rate_limit: 0,
+            backends: vec!["demo".to_string()],
+            allowed_tools: Some(vec!["allowed_tool".to_string()]),
+            denied_tools: None,
+            admin,
+        }],
+        public_paths: vec!["/health".to_string()],
+    }
 }
 
 struct RouterNotificationTestTransport {
@@ -725,6 +820,188 @@ async fn backend_handler_notification_failure_surfaces_error() {
         transport.notify_methods.lock().unwrap().as_slice(),
         ["notifications/initialized"]
     );
+}
+
+#[tokio::test]
+async fn backend_handler_tools_call_enforces_api_key_tool_scope() {
+    let backend = Arc::new(Backend::new(
+        "demo",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let transport = Arc::new(RouterNotificationTestTransport::success());
+    let transport_dyn: Arc<dyn Transport> = transport.clone();
+    backend.set_transport_for_test(transport_dyn);
+
+    let state = test_router_app_state_with_auth(&scoped_auth_config(false));
+    state.backends.register(backend);
+    let router = create_router(state);
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("authorization", "Bearer scoped-key")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "blocked_tool",
+                    "arguments": {}
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], -32600);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("allowlist"))
+    );
+    assert!(transport.request_methods.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn meta_mcp_gateway_execute_enforces_api_key_tool_scope() {
+    let router = create_router(test_router_app_state_with_auth(&scoped_auth_config(false)));
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("authorization", "Bearer scoped-key")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "gateway_execute",
+                    "arguments": {
+                        "tool": "demo:blocked_tool",
+                        "arguments": {}
+                    }
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], -32600);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("allowlist"))
+    );
+}
+
+#[tokio::test]
+async fn meta_mcp_management_tool_requires_admin_client() {
+    let router = create_router(test_router_app_state_with_auth(&scoped_auth_config(false)));
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("authorization", "Bearer scoped-key")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "gateway_reload_config",
+                    "arguments": {}
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("admin access"))
+    );
+}
+
+#[test]
+fn authorize_tool_target_enforces_agent_scope() {
+    let state = test_router_app_state();
+    let identity = OAuthAgentIdentity {
+        client_id: "agent-a".to_string(),
+        agent_name: "Agent A".to_string(),
+        scopes: vec![
+            crate::gateway::oauth::Scope::parse("tools:demo:allowed_tool:execute").unwrap(),
+        ],
+        raw_scopes: vec!["tools:demo:allowed_tool:execute".to_string()],
+    };
+    let args = json!({});
+
+    let result = authorize_tool_target(
+        state.as_ref(),
+        None,
+        Some(&identity),
+        None,
+        ToolTarget {
+            server: "demo",
+            tool: "blocked_tool",
+            arguments: &args,
+        },
+    );
+
+    assert!(
+        result.is_ok(),
+        "agent auth disabled should not enforce scopes"
+    );
+
+    let enabled_state = test_router_app_state_with_agent_auth_enabled();
+    let result = authorize_tool_target(
+        enabled_state.as_ref(),
+        None,
+        Some(&identity),
+        None,
+        ToolTarget {
+            server: "demo",
+            tool: "blocked_tool",
+            arguments: &args,
+        },
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn surfaced_tool_calls_resolve_to_backend_authorization_target() {
+    let meta = MetaMcp::new(Arc::new(BackendRegistry::new())).with_surfaced_tools(vec![
+        SurfacedToolConfig {
+            server: "demo".to_string(),
+            tool: "pinned_tool".to_string(),
+        },
+    ]);
+
+    let targets = backend_tool_targets_for_call(&meta, "pinned_tool", &json!({"x": 1}));
+
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].server, "demo");
+    assert_eq!(targets[0].tool, "pinned_tool");
 }
 
 #[tokio::test]

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -102,6 +102,8 @@ impl Gateway {
         config: Config,
         config_path: Option<std::path::PathBuf>,
     ) -> Result<Self> {
+        config.validate()?;
+
         let backends = Arc::new(BackendRegistry::new());
 
         // Register backends
@@ -330,50 +332,60 @@ impl Gateway {
             self.config.webhooks.clone(),
         )));
 
-        // Load capabilities if enabled
+        // Load capabilities if enabled. Capability directories can be large;
+        // when webhook route construction does not depend on them, populate the
+        // backend in the background so health/MCP endpoints bind promptly.
         let _capability_watcher: Option<CapabilityWatcher> = if self.config.capabilities.enabled {
             let executor = Arc::new(CapabilityExecutor::new());
             let cap_backend = Arc::new(CapabilityBackend::new(
                 &self.config.capabilities.name,
                 executor,
             ));
+            meta_mcp.set_capabilities(Arc::clone(&cap_backend));
 
-            let mut total_caps = 0;
-            for dir in &self.config.capabilities.directories {
-                match cap_backend.load_from_directory(dir).await {
-                    Ok(count) => {
-                        total_caps += count;
-                        debug!(directory = %dir, count = count, "Loaded capabilities");
+            let capability_dirs = self.config.capabilities.directories.clone();
+            let capability_name = self.config.capabilities.name.clone();
 
-                        // Register webhooks from capabilities
-                        if self.config.webhooks.enabled {
-                            for cap in cap_backend.list_capabilities() {
-                                if !cap.webhooks.is_empty() {
-                                    webhook_registry.write().register_capability(&cap);
-                                }
-                            }
+            let cap_backend_for_load = Arc::clone(&cap_backend);
+            let webhook_registry_for_load = Arc::clone(&webhook_registry);
+            let webhooks_enabled = self.config.webhooks.enabled;
+            tokio::spawn(async move {
+                // Let the HTTP listener bind before large capability scans start.
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+                let mut total_caps = 0;
+                for dir in &capability_dirs {
+                    match cap_backend_for_load.load_from_directory(dir).await {
+                        Ok(count) => {
+                            total_caps += count;
+                            debug!(directory = %dir, count = count, "Loaded capabilities");
+                        }
+                        Err(e) => {
+                            // Don't fail startup if capability dir doesn't exist
+                            debug!(directory = %dir, error = %e, "Failed to load capabilities");
                         }
                     }
-                    Err(e) => {
-                        // Don't fail startup if capability dir doesn't exist
-                        debug!(directory = %dir, error = %e, "Failed to load capabilities");
+                }
+
+                if webhooks_enabled {
+                    for cap in cap_backend_for_load.list_capabilities() {
+                        if !cap.webhooks.is_empty() {
+                            webhook_registry_for_load.write().register_capability(&cap);
+                        }
                     }
                 }
-            }
 
-            if total_caps > 0 {
-                info!(
-                    capabilities = total_caps,
-                    name = %self.config.capabilities.name,
-                    "Capability backend ready"
-                );
-            }
+                if total_caps > 0 {
+                    info!(
+                        capabilities = total_caps,
+                        name = %capability_name,
+                        "Capability backend ready"
+                    );
+                }
+            });
 
             // Start file watcher for hot-reload
-            let watcher = match CapabilityWatcher::start(
-                Arc::clone(&cap_backend),
-                shutdown_tx.subscribe(),
-            ) {
+            match CapabilityWatcher::start(Arc::clone(&cap_backend), shutdown_tx.subscribe()) {
                 Ok(w) => {
                     info!("Capability hot-reload enabled");
                     Some(w)
@@ -382,10 +394,7 @@ impl Gateway {
                     warn!(error = %e, "Failed to start capability watcher, hot-reload disabled");
                     None
                 }
-            };
-
-            meta_mcp.set_capabilities(cap_backend);
-            watcher
+            }
         } else {
             None
         };
@@ -417,7 +426,7 @@ impl Gateway {
         ));
         multiplexer.spawn_reaper_on();
         let proxy_manager = Arc::new(ProxyManager::new(Arc::clone(&multiplexer)));
-        let auth_config = Arc::new(ResolvedAuthConfig::from_config(&self.config.auth));
+        let auth_config = Arc::new(ResolvedAuthConfig::try_from_config(&self.config.auth)?);
 
         // Wire webhook registry into MetaMcp for gateway_webhook_status.
         if self.config.webhooks.enabled {
@@ -464,7 +473,7 @@ impl Gateway {
         let key_server = if self.config.key_server.enabled {
             let mut ks_config = self.config.key_server.clone();
             // Resolve admin token (expand env:VAR_NAME)
-            ks_config.admin_token = ks_config.resolve_admin_token();
+            ks_config.admin_token = ks_config.resolve_admin_token()?;
 
             let cleanup_interval = std::time::Duration::from_secs(ks_config.cleanup_interval_secs);
             let ks = Arc::new(KeyServer::new(ks_config));
@@ -489,7 +498,7 @@ impl Gateway {
         // Build agent registry from config.
         let agent_registry = Arc::new(AgentRegistry::new());
         for def in &self.config.agent_auth.agents {
-            let secret = def.resolved_hs256_secret();
+            let secret = def.resolved_hs256_secret()?;
             agent_registry.register(AgentDefinition {
                 client_id: def.client_id.clone(),
                 name: def.name.clone(),
@@ -581,9 +590,10 @@ impl Gateway {
 
         // Add webhook routes if enabled
         if self.config.webhooks.enabled {
-            let webhook_routes = webhook_registry
-                .read()
-                .create_routes(Arc::clone(&multiplexer));
+            let webhook_routes = WebhookRegistry::create_dynamic_routes(
+                Arc::clone(&webhook_registry),
+                Arc::clone(&multiplexer),
+            );
             app = app.merge(webhook_routes);
             info!(
                 enabled = true,
@@ -624,11 +634,7 @@ impl Gateway {
         {
             let warm_start_list =
                 build_warm_start_list(&self.backends, &self.config.meta_mcp.warm_start, true);
-            spawn_warm_start_task(
-                Arc::clone(&self.backends),
-                warm_start_list,
-                WarmStartMode::Http,
-            );
+            spawn_warm_start_task(&self.backends, warm_start_list, WarmStartMode::Http);
         }
 
         // Start health check task
@@ -837,11 +843,7 @@ impl Gateway {
         {
             let warm_start_list =
                 build_warm_start_list(&self.backends, &self.config.meta_mcp.warm_start, false);
-            spawn_warm_start_task(
-                Arc::clone(&self.backends),
-                warm_start_list,
-                WarmStartMode::Stdio,
-            );
+            spawn_warm_start_task(&self.backends, warm_start_list, WarmStartMode::Stdio);
         }
 
         info!("MCP Gateway stdio mode ready — reading JSON-RPC from stdin");

--- a/src/gateway/server/warmstart.rs
+++ b/src/gateway/server/warmstart.rs
@@ -29,17 +29,18 @@ pub(super) fn build_warm_start_list(
 }
 
 pub(super) fn spawn_warm_start_task(
-    backends: Arc<BackendRegistry>,
+    backends: &Arc<BackendRegistry>,
     warm_start_list: Vec<String>,
     mode: WarmStartMode,
 ) {
-    tokio::spawn(async move {
-        for name in warm_start_list {
+    for name in warm_start_list {
+        let backends = Arc::clone(backends);
+        tokio::spawn(async move {
             let Some(backend) = backends.get(&name) else {
                 if matches!(mode, WarmStartMode::Http) {
                     warn!(backend = %name, "Backend not found for warm-start");
                 }
-                continue;
+                return;
             };
 
             match backend.start().await {
@@ -63,8 +64,8 @@ pub(super) fn spawn_warm_start_task(
                 }
                 Err(e) => warn!(backend = %name, error = %e, "Warm-start failed"),
             }
-        }
-    });
+        });
+    }
 }
 
 fn resolve_warm_start_names(

--- a/src/gateway/ui/mod.rs
+++ b/src/gateway/ui/mod.rs
@@ -41,11 +41,11 @@ fn uptime_secs() -> u64 {
 
 /// Returns `true` when the caller has admin-level access.
 ///
-/// When auth is disabled the middleware sets name="anonymous" — treat
-/// that as admin (no point restricting with no auth configured).
-/// Only "public" (unauthenticated with auth enabled) is restricted.
+/// Admin access is explicit. The auth middleware marks the bearer token and
+/// auth-disabled anonymous client as admin; API keys must opt in with
+/// `admin: true`.
 fn is_admin(client: Option<&AuthenticatedClient>) -> bool {
-    client.is_some_and(|c| c.name != "public")
+    client.is_some_and(|c| c.admin)
 }
 
 /// Build the authenticated `/ui/api/*` and `/dashboard` sub-router.

--- a/src/gateway/webhooks/mod.rs
+++ b/src/gateway/webhooks/mod.rs
@@ -10,11 +10,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::{
     Router,
-    extract::State,
-    http::HeaderMap,
-    response::IntoResponse,
-    routing::{MethodFilter, on},
+    extract::{OriginalUri, State},
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{MethodFilter, any, on},
 };
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, error, info, warn};
@@ -165,6 +166,15 @@ impl WebhookRegistry {
         self.webhooks.get(path)
     }
 
+    /// Get a cloneable webhook handler tuple by path.
+    #[must_use]
+    pub fn get_cloned(
+        &self,
+        path: &str,
+    ) -> Option<(String, String, WebhookDefinition, Arc<EndpointStats>)> {
+        self.webhooks.get(path).cloned()
+    }
+
     /// Return status info for all registered endpoints, sorted by path.
     #[must_use]
     pub fn list_endpoints(&self) -> Vec<WebhookEndpointInfo> {
@@ -219,6 +229,26 @@ impl WebhookRegistry {
 
         router
     }
+
+    /// Create a dynamic dispatcher route for webhook paths.
+    ///
+    /// This allows the HTTP listener to bind before all capability files have
+    /// loaded. The registry is checked at request time, so endpoints become
+    /// available as soon as the capability loader registers them.
+    #[must_use = "the returned Router must be merged into the application router"]
+    pub fn create_dynamic_routes(
+        registry: Arc<RwLock<Self>>,
+        multiplexer: Arc<NotificationMultiplexer>,
+    ) -> Router<()> {
+        let base_path = registry.read().config.base_path.clone();
+        let route = format!("{base_path}/{{*path}}");
+        let state = DynamicWebhookHandlerState {
+            registry,
+            multiplexer,
+        };
+
+        Router::new().route(&route, any(dynamic_webhook_handler).with_state(state))
+    }
 }
 
 // ============================================================================
@@ -236,6 +266,13 @@ struct WebhookHandlerState {
     stats: Arc<EndpointStats>,
 }
 
+/// State for the dynamic webhook dispatcher.
+#[derive(Clone)]
+struct DynamicWebhookHandlerState {
+    registry: Arc<RwLock<WebhookRegistry>>,
+    multiplexer: Arc<NotificationMultiplexer>,
+}
+
 /// Map HTTP method string to axum `MethodFilter`.
 ///
 /// Defaults to POST for unrecognised method strings.
@@ -247,6 +284,55 @@ fn method_to_filter(method: &str) -> MethodFilter {
         "DELETE" => MethodFilter::DELETE,
         _ => MethodFilter::POST, // POST and any unknown method
     }
+}
+
+/// Check a request method against a configured webhook method.
+fn method_matches(actual: &Method, configured: &str) -> bool {
+    match configured.to_uppercase().as_str() {
+        "GET" => actual == Method::GET,
+        "PUT" => actual == Method::PUT,
+        "PATCH" => actual == Method::PATCH,
+        "DELETE" => actual == Method::DELETE,
+        _ => actual == Method::POST,
+    }
+}
+
+/// Dynamic webhook dispatcher used when capabilities load in the background.
+async fn dynamic_webhook_handler(
+    State(state): State<DynamicWebhookHandlerState>,
+    OriginalUri(uri): OriginalUri,
+    method: Method,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let path = uri.path().to_string();
+    let Some((capability_name, webhook_name, definition, webhook_stats)) =
+        state.registry.read().get_cloned(&path)
+    else {
+        return (StatusCode::NOT_FOUND, "Unknown webhook endpoint").into_response();
+    };
+
+    if !method_matches(&method, &definition.method) {
+        return (
+            StatusCode::METHOD_NOT_ALLOWED,
+            format!("Webhook endpoint expects {}", definition.method),
+        )
+            .into_response();
+    }
+
+    let config = state.registry.read().config.clone();
+    let handler_state = WebhookHandlerState {
+        multiplexer: Arc::clone(&state.multiplexer),
+        capability_name,
+        webhook_name,
+        definition,
+        config,
+        stats: webhook_stats,
+    };
+
+    webhook_handler(State(handler_state), headers, body)
+        .await
+        .into_response()
 }
 
 /// Webhook handler function.

--- a/src/key_server/mod.rs
+++ b/src/key_server/mod.rs
@@ -98,6 +98,7 @@ impl KeyServer {
                 Some(temp.scopes.tools.clone())
             },
             denied_tools: None,
+            admin: false,
         };
 
         let ev = AuditEvent::used(&temp, None);

--- a/src/mtls/cert_manager.rs
+++ b/src/mtls/cert_manager.rs
@@ -12,8 +12,12 @@
 //! default to PEM).
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use rcgen::string::Ia5String;
 use rcgen::{
@@ -274,15 +278,36 @@ impl CertGenerator {
     pub fn write_to_dir(cert: &GeneratedCert, dir: &Path, stem: &str) -> Result<()> {
         fs::create_dir_all(dir)
             .map_err(|e| Error::Config(format!("Cannot create dir '{}': {e}", dir.display())))?;
+        #[cfg(unix)]
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+            .map_err(|e| Error::Config(format!("Cannot set dir permissions: {e}")))?;
 
         fs::write(dir.join(format!("{stem}.crt")), &cert.cert_pem)
             .map_err(|e| Error::Config(format!("Cannot write cert: {e}")))?;
 
-        fs::write(dir.join(format!("{stem}.key")), &cert.key_pem)
-            .map_err(|e| Error::Config(format!("Cannot write key: {e}")))?;
+        write_private_key(&dir.join(format!("{stem}.key")), &cert.key_pem)?;
 
         Ok(())
     }
+}
+
+fn write_private_key(path: &Path, key_pem: &str) -> Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options
+        .open(path)
+        .map_err(|e| Error::Config(format!("Cannot write key: {e}")))?;
+    file.write_all(key_pem.as_bytes())
+        .map_err(|e| Error::Config(format!("Cannot write key: {e}")))?;
+
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|e| Error::Config(format!("Cannot set key permissions: {e}")))?;
+
+    Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -496,6 +521,26 @@ mod tests {
 
         let contents = fs::read_to_string(dir.path().join("myca.crt")).unwrap();
         assert!(contents.contains("BEGIN CERTIFICATE"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_to_dir_private_key_is_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = CertGenerator::init_ca(&CaParams {
+            cn: "CA",
+            validity_days: 365,
+        })
+        .unwrap();
+
+        CertGenerator::write_to_dir(&ca, dir.path(), "ca").unwrap();
+
+        let mode = fs::metadata(dir.path().join("ca.key"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     // ─── load_certs / load_private_key ────────────────────────────────────────

--- a/src/oauth/callback.rs
+++ b/src/oauth/callback.rs
@@ -231,8 +231,10 @@ async fn handle_callback(
         if let Some(tx) = state.tx.take() {
             let _ = tx.send(result);
         }
+        let escaped_error = escape_html(error);
+        let escaped_description = escape_html(description);
         return Html(format!(
-            "<html><body><h1>Authorization Failed</h1><p>{error}: {description}</p></body></html>"
+            "<html><body><h1>Authorization Failed</h1><p>{escaped_error}: {escaped_description}</p></body></html>"
         ));
     }
 
@@ -293,6 +295,21 @@ async fn handle_callback(
     )
 }
 
+fn escape_html(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +347,14 @@ mod tests {
         assert!(params.code.is_none());
         assert!(params.state.is_none());
         assert!(params.error.is_none());
+    }
+
+    #[test]
+    fn escape_html_escapes_provider_error_text() {
+        assert_eq!(
+            escape_html("<script>alert('x') & \"y\"</script>"),
+            "&lt;script&gt;alert(&#39;x&#39;) &amp; &quot;y&quot;&lt;/script&gt;"
+        );
     }
 
     // =========================================================================

--- a/src/security/firewall/redactor.rs
+++ b/src/security/firewall/redactor.rs
@@ -37,9 +37,9 @@ pub struct Redactor {
 
 /// (pattern, description) pairs.
 ///
-/// 11 credential patterns covering AWS keys, GitHub tokens (4 variants),
-/// Slack tokens, generic API keys, JWTs, private keys, bearer tokens, and
-/// database connection strings.
+/// 13 credential patterns covering AWS keys, GitHub tokens (4 variants),
+/// Slack tokens, generic API keys, JWTs, private keys, bearer tokens,
+/// database connection strings, `OpenAI` project keys, and Ethereum private keys.
 const CREDENTIAL_PATTERNS: &[(&str, &str)] = &[
     // AWS
     (r"(?:AKIA|ASIA)[A-Z0-9]{16}", "AWS Access Key ID"),
@@ -75,6 +75,10 @@ const CREDENTIAL_PATTERNS: &[(&str, &str)] = &[
         r"(?i)(?:postgres|mysql|mongodb|redis)://[^\s]{10,}",
         "Database Connection String",
     ),
+    // OpenAI project API keys (sk-proj-...)
+    (r"sk-proj-[A-Za-z0-9_-]{40,}", "OpenAI Project API Key"),
+    // Ethereum private key (0x + 64 hex nibbles = 32 bytes)
+    (r"0x[a-fA-F0-9]{64}", "Ethereum Private Key"),
 ];
 
 impl Redactor {
@@ -273,6 +277,33 @@ mod tests {
             findings
                 .iter()
                 .any(|f| f.description.contains("Database Connection"))
+        );
+    }
+
+    #[test]
+    fn detects_openai_project_key() {
+        let key = "sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJ1234567890";
+        let mut v = serde_json::json!({ "key": key });
+        let findings = redactor().scan_and_redact(&mut v);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.description.contains("OpenAI Project")),
+            "Expected OpenAI key detection"
+        );
+    }
+
+    #[test]
+    fn detects_ethereum_private_key() {
+        let key = format!(
+            "0x{}{}",
+            "ac0974bec39a17e36ba4a6b4d238ff944", "bacb478cbed5efcae784d7bf4f2ff80"
+        );
+        let mut v = serde_json::json!({ "pk": key });
+        let findings = redactor().scan_and_redact(&mut v);
+        assert!(
+            findings.iter().any(|f| f.description.contains("Ethereum")),
+            "Expected Ethereum key detection"
         );
     }
 

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -25,9 +25,10 @@ use super::Transport;
 use crate::gateway::trace;
 use crate::oauth::OAuthClient;
 use crate::protocol::{
-    JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId, is_version_mismatch_error,
-    negotiate_best_version, parse_supported_versions_from_error,
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
+    is_version_mismatch_error, negotiate_best_version, parse_supported_versions_from_error,
 };
+use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
 /// HTTP transport for MCP servers using SSE or Streamable HTTP protocol
@@ -106,7 +107,15 @@ impl HttpTransport {
             .pool_idle_timeout(Duration::from_secs(90))
             .tcp_keepalive(Duration::from_secs(30))
             .tcp_nodelay(true)
-            .redirect(reqwest::redirect::Policy::limited(5)) // Follow redirects
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                if attempt.previous().len() >= 5 {
+                    return attempt.stop();
+                }
+                if let Err(e) = validate_url_not_ssrf(attempt.url().as_str()) {
+                    return attempt.error(e.to_string());
+                }
+                attempt.follow()
+            }))
             .build()
             .map_err(|e| Error::Transport(e.to_string()))?;
 
@@ -250,8 +259,13 @@ impl HttpTransport {
             }
         }
 
-        // Send initialized notification
-        self.notify("notifications/initialized", None).await?;
+        // Some Streamable HTTP backends either close the initialize request
+        // immediately or do not implement client notifications. The gateway
+        // can still use request/response tools in that case, so notification
+        // delivery must not make backend startup fail.
+        if let Err(error) = self.notify("notifications/initialized", None).await {
+            debug!(url = %self.base_url, error = %error, "Initialized notification failed (ignored)");
+        }
 
         self.connected.store(true, Ordering::Relaxed);
         debug!(url = %self.base_url, streamable = %self.streamable_http, "HTTP transport initialized");
@@ -316,15 +330,15 @@ impl HttpTransport {
             debug!(method = %method, "Sending request without session ID");
         }
 
-        // User-supplied custom headers (SSE, send_request, and close; not notify).
-        if !matches!(mode, HeaderMode::Notify) {
-            for (key, value) in &self.headers {
-                if let (Ok(k), Ok(v)) = (
-                    key.parse::<reqwest::header::HeaderName>(),
-                    value.parse::<reqwest::header::HeaderValue>(),
-                ) {
-                    headers.insert(k, v);
-                }
+        // User-supplied custom headers apply to all calls, including
+        // notifications, because some backends require the same auth header for
+        // `notifications/initialized` as for normal requests.
+        for (key, value) in &self.headers {
+            if let (Ok(k), Ok(v)) = (
+                key.parse::<reqwest::header::HeaderName>(),
+                value.parse::<reqwest::header::HeaderValue>(),
+            ) {
+                headers.insert(k, v);
             }
         }
 
@@ -577,11 +591,11 @@ impl Transport for HttpTransport {
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<()> {
         let message_url = self.get_message_url();
 
-        let notification = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params
-        });
+        let notification = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+        };
 
         let headers = self.build_mcp_headers(HeaderMode::Notify).await?;
 

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -296,14 +296,14 @@ async fn build_headers_send_request_no_session() {
     );
 }
 
-/// notify mode: Content-Type + combined Accept, session forwarded, NO custom
-/// headers, NO x-trace-id even when ambient trace and custom headers exist.
+/// notify mode: Content-Type + combined Accept, session and custom headers
+/// forwarded, NO x-trace-id even when ambient trace exists.
 #[tokio::test]
-async fn build_headers_notify_excludes_custom_and_trace() {
+async fn build_headers_notify_includes_custom_but_excludes_trace() {
     use crate::gateway::trace;
 
     let mut custom = HashMap::new();
-    custom.insert("X-Should-Not-Appear".to_string(), "nope".to_string());
+    custom.insert("X-Notify-Auth".to_string(), "notify-token".to_string());
     let t = make_transport_with_headers("http://localhost", custom);
     *t.session_id.write() = Some("notify-sess".to_string());
 
@@ -318,9 +318,9 @@ async fn build_headers_notify_excludes_custom_and_trace() {
         map["mcp-session-id"], "notify-sess",
         "notify must include session header"
     );
-    assert!(
-        !map.contains_key("x-should-not-appear"),
-        "notify must NOT include custom headers"
+    assert_eq!(
+        map["x-notify-auth"], "notify-token",
+        "notify must include custom headers"
     );
     assert!(
         !map.contains_key("x-trace-id"),

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -21,8 +21,8 @@ use tracing::{debug, error, info, warn};
 
 use super::Transport;
 use crate::protocol::{
-    JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId, is_version_mismatch_error,
-    negotiate_best_version, parse_supported_versions_from_error,
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
+    is_version_mismatch_error, negotiate_best_version, parse_supported_versions_from_error,
 };
 use crate::{Error, Result};
 
@@ -42,6 +42,8 @@ pub struct StdioTransport {
     env: HashMap<String, String>,
     /// Working directory
     cwd: Option<String>,
+    /// Request timeout for initialize and JSON-RPC calls
+    request_timeout: std::time::Duration,
     /// Writer handle
     writer: Mutex<Option<tokio::process::ChildStdin>>,
     /// Negotiated protocol version (config override or auto-negotiated)
@@ -59,6 +61,7 @@ impl StdioTransport {
         command: &str,
         env: HashMap<String, String>,
         cwd: Option<String>,
+        request_timeout: std::time::Duration,
         protocol_version: Option<String>,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -69,6 +72,7 @@ impl StdioTransport {
             command: command.to_string(),
             env,
             cwd,
+            request_timeout,
             writer: Mutex::new(None),
             protocol_version: RwLock::new(protocol_version),
         })
@@ -80,12 +84,14 @@ impl StdioTransport {
     ///
     /// Returns an error if the command cannot be spawned or MCP initialization fails.
     pub async fn start(self: &Arc<Self>) -> Result<()> {
-        let parts: Vec<&str> = self.command.split_whitespace().collect();
+        let parts = shlex::split(&self.command).ok_or_else(|| {
+            Error::Config(format!("Invalid stdio command quoting: {}", self.command))
+        })?;
         if parts.is_empty() {
             return Err(Error::Config("Empty command".to_string()));
         }
 
-        let program = parts[0];
+        let program = parts[0].as_str();
         let args = &parts[1..];
 
         let mut cmd = Command::new(program);
@@ -118,6 +124,10 @@ impl StdioTransport {
             .stdout
             .take()
             .ok_or_else(|| Error::Transport("Failed to get stdout".to_string()))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get stderr".to_string()))?;
 
         *self.writer.lock().await = Some(stdin);
         *self.child.lock().await = Some(child);
@@ -151,8 +161,23 @@ impl StdioTransport {
             debug!("Stdio reader task ended");
         });
 
-        // Initialize with protocol version negotiation
-        self.initialize().await?;
+        let command = self.command.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                debug!(command = %command, line_len = line.len(), "Received line from stderr");
+            }
+        });
+
+        // Initialize with protocol version negotiation. If initialization
+        // fails, tear down the spawned process now; otherwise reader tasks keep
+        // the transport Arc alive and failed starts leak orphan MCP servers.
+        if let Err(error) = self.initialize().await {
+            if let Err(close_error) = self.close().await {
+                warn!(error = %close_error, "Failed to clean up stdio process after initialization error");
+            }
+            return Err(error);
+        }
 
         Ok(())
     }
@@ -383,7 +408,7 @@ impl Transport for StdioTransport {
         }
 
         // Wait for response with timeout
-        match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
+        match tokio::time::timeout(self.request_timeout, rx).await {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(_)) => Err(Error::Transport("Response channel closed".to_string())),
             Err(_) => {
@@ -394,11 +419,11 @@ impl Transport for StdioTransport {
     }
 
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<()> {
-        let notification = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params
-        });
+        let notification = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+        };
 
         let message = serde_json::to_string(&notification)?;
         self.write_message(&message).await
@@ -429,7 +454,13 @@ mod tests {
     use std::collections::HashMap;
 
     fn make_transport(cmd: &str) -> Arc<StdioTransport> {
-        StdioTransport::new(cmd, HashMap::new(), None, None)
+        StdioTransport::new(
+            cmd,
+            HashMap::new(),
+            None,
+            std::time::Duration::from_secs(30),
+            None,
+        )
     }
 
     // =========================================================================
@@ -450,14 +481,27 @@ mod tests {
     fn new_with_env_and_cwd() {
         let mut env = HashMap::new();
         env.insert("NODE_ENV".to_string(), "test".to_string());
-        let t = StdioTransport::new("node index.js", env, Some("/tmp".to_string()), None);
+        let t = StdioTransport::new(
+            "node index.js",
+            env,
+            Some("/tmp".to_string()),
+            std::time::Duration::from_secs(45),
+            None,
+        );
         assert_eq!(t.env.get("NODE_ENV").unwrap(), "test");
         assert_eq!(t.cwd.as_deref(), Some("/tmp"));
+        assert_eq!(t.request_timeout, std::time::Duration::from_secs(45));
     }
 
     #[test]
     fn new_with_explicit_protocol_version() {
-        let t = StdioTransport::new("echo", HashMap::new(), None, Some("2025-06-18".to_string()));
+        let t = StdioTransport::new(
+            "echo",
+            HashMap::new(),
+            None,
+            std::time::Duration::from_secs(30),
+            Some("2025-06-18".to_string()),
+        );
         assert_eq!(*t.protocol_version.read(), Some("2025-06-18".to_string()));
     }
 

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -35,7 +35,9 @@ use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use super::Transport;
-use crate::protocol::{JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId};
+use crate::protocol::{
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
+};
 use crate::{Error, Result};
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -79,11 +81,11 @@ impl McpFrame {
             McpFrame::Request(req) => serde_json::to_string(req)?,
             McpFrame::Response(res) => serde_json::to_string(res)?,
             McpFrame::Notification { method, params } => {
-                serde_json::to_string(&serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "method": method,
-                    "params": params,
-                }))?
+                serde_json::to_string(&JsonRpcNotification {
+                    jsonrpc: "2.0".to_string(),
+                    method: method.clone(),
+                    params: params.clone(),
+                })?
             }
             McpFrame::Ping => r#"{"type":"ping"}"#.to_string(),
             McpFrame::Pong => r#"{"type":"pong"}"#.to_string(),

--- a/src/transport/websocket_tests.rs
+++ b/src/transport/websocket_tests.rs
@@ -141,6 +141,7 @@ fn notification_serialises_without_id() {
     let v: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert_eq!(v["method"], "notifications/initialized");
     assert!(v.get("id").is_none());
+    assert!(v.get("params").is_none());
 }
 
 #[test]

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -22,6 +22,7 @@ fn test_auth_config_resolution() {
             backends: vec!["tavily".to_string()],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         }],
         public_paths: vec!["/health".to_string()],
     };
@@ -73,6 +74,7 @@ fn test_api_key_auth_with_restrictions() {
                 backends: vec!["tavily".to_string(), "brave".to_string()],
                 allowed_tools: None,
                 denied_tools: None,
+                admin: false,
             },
             ApiKeyConfig {
                 key: "unrestricted-key".to_string(),
@@ -81,6 +83,7 @@ fn test_api_key_auth_with_restrictions() {
                 backends: vec![], // empty = all access
                 allowed_tools: None,
                 denied_tools: None,
+                admin: false,
             },
         ],
         public_paths: vec![],
@@ -116,6 +119,7 @@ fn test_rate_limiting() {
             backends: vec![],
             allowed_tools: None,
             denied_tools: None,
+            admin: false,
         }],
         public_paths: vec![],
     };
@@ -194,6 +198,7 @@ fn test_client_backend_access_patterns() {
         backends: vec!["*".to_string()],
         allowed_tools: None,
         denied_tools: None,
+        admin: false,
     };
     assert!(wildcard_client.can_access_backend("anything"));
     assert!(wildcard_client.can_access_backend("tavily"));
@@ -205,6 +210,7 @@ fn test_client_backend_access_patterns() {
         backends: vec![],
         allowed_tools: None,
         denied_tools: None,
+        admin: false,
     };
     assert!(all_access_client.can_access_backend("anything"));
 
@@ -215,6 +221,7 @@ fn test_client_backend_access_patterns() {
         backends: vec!["backend-a".to_string(), "backend-b".to_string()],
         allowed_tools: None,
         denied_tools: None,
+        admin: false,
     };
     assert!(restricted_client.can_access_backend("backend-a"));
     assert!(restricted_client.can_access_backend("backend-b"));

--- a/tests/tool_scope_tests.rs
+++ b/tests/tool_scope_tests.rs
@@ -18,6 +18,7 @@ fn test_no_tool_restrictions() {
         backends: vec![],
         allowed_tools: None,
         denied_tools: None,
+        admin: false,
     };
 
     // All tools should be allowed (fallback to global policy)
@@ -39,6 +40,7 @@ fn test_allowlist_exact_match() {
             "list_directory".to_string(),
         ]),
         denied_tools: None,
+        admin: false,
     };
 
     // Tools in allowlist should be permitted
@@ -71,6 +73,7 @@ fn test_allowlist_glob_patterns() {
         backends: vec![],
         allowed_tools: Some(vec!["search_*".to_string(), "read_*".to_string()]),
         denied_tools: None,
+        admin: false,
     };
 
     // Tools matching glob patterns should be allowed
@@ -102,6 +105,7 @@ fn test_denylist_exact_match() {
             "delete_file".to_string(),
             "execute_command".to_string(),
         ]),
+        admin: false,
     };
 
     // Tools in denylist should be blocked
@@ -137,6 +141,7 @@ fn test_denylist_glob_patterns() {
         backends: vec![],
         allowed_tools: None,
         denied_tools: Some(vec!["filesystem_*".to_string(), "exec_*".to_string()]),
+        admin: false,
     };
 
     // Tools matching deny patterns should be blocked
@@ -170,6 +175,7 @@ fn test_qualified_name_matching() {
             "database:*".to_string(),
         ]),
         denied_tools: None,
+        admin: false,
     };
 
     // Qualified match: filesystem:read_file allowed, but not on other servers
@@ -201,6 +207,7 @@ fn test_allowlist_and_denylist_combination() {
             "filesystem_write".to_string(),
             "filesystem_delete".to_string(),
         ]),
+        admin: false,
     };
 
     // In allowlist AND NOT in denylist: allowed
@@ -237,6 +244,7 @@ fn test_api_key_config_with_tool_scopes() {
         backends: vec![],
         allowed_tools: Some(vec!["search_*".to_string(), "read_*".to_string()]),
         denied_tools: Some(vec!["read_secrets".to_string()]),
+        admin: false,
     };
 
     // Verify config fields are set correctly
@@ -256,6 +264,7 @@ fn test_empty_allowlist() {
         backends: vec![],
         allowed_tools: Some(vec![]), // Empty allowlist = nothing allowed
         denied_tools: None,
+        admin: false,
     };
 
     // All tools should be denied with empty allowlist
@@ -272,6 +281,7 @@ fn test_empty_denylist() {
         backends: vec![],
         allowed_tools: None,
         denied_tools: Some(vec![]), // Empty denylist = no additional blocks
+        admin: false,
     };
 
     // Empty denylist should not block anything (falls back to global policy)
@@ -292,6 +302,7 @@ fn test_pattern_matching_edge_cases() {
             "*ends_with_this".to_string(), // This should NOT match (only suffix * supported)
         ]),
         denied_tools: None,
+        admin: false,
     };
 
     // Prefix glob works


### PR DESCRIPTION
## Summary
- upgrade vulnerable rustls-webpki lockfile entry and add a CI cargo-audit gate
- enforce backend/tool authorization consistently across direct routes, Meta-MCP calls, API key scopes, mTLS, agent scopes, firewall checks, and admin-only management surfaces
- fail closed for missing env-backed auth/key-server/agent secrets
- harden SSRF coverage for redirects and capability REST/GraphQL/JSON-RPC execution
- tighten mTLS private-key file permissions, escape OAuth callback errors, and avoid caching JSON-RPC list errors as empty metadata
- include supporting tests/docs and related runtime hygiene fixes validated with the same DoD pass

## Validation
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= cargo test --all-features`
- `cargo audit` (no vulnerabilities; existing allowed rand warning remains)
- `git diff --cached --check` before commit
- `git diff --cached | gitleaks detect --pipe --redact --no-banner --exit-code 1`
- `trufflehog filesystem --no-update --results=verified --fail .`
- `/opt/homebrew/bin/gitnexus status` after commit: up to date

## DoD Notes
- Local CODE gates are green for tests, lint, type/build, formatting, dependency audit, and diff secret scan.
- `/opt/homebrew/bin/gitnexus detect_changes` is not available in the installed CLI and returns `unknown command`; impact/status/analyze were used directly with the real binary.
- GitNexus analyze updated the local index for commit `52ed7a5a`.

## KPI Impact
Operators can safely rely on configured client scopes, agent scopes, SSRF protection, admin boundaries, TLS validation, and generated mTLS key material without the bypasses reported in the review.
