### PR TITLE
chore(claude-md): update Decisions-Locked License row to dual-license (MIK-3038)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 | **Dual MCP + A2A transport** | Cross-provider agent messaging (#145, MIK-2970) | Treat A2A as an afterthought; avoid compiling it out of default builds |
 | **Capability definitions public (mcp-gateway) / private (mcp-gateway-private)** | Public catalog for community; private API credentials / deploy configs | Mix private capabilities into the public catalog |
 | **`cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`** gates | Zero-debt discipline in Rust source | Ship code with lints suppressed ad hoc |
-| **License: MIT** | Maximum adoption for infrastructure | Relicense without explicit user direction |
+| **Mixed per-file licensing: MIT core + PolyForm Noncommercial 1.0.0 EE** | Core gateway stays MIT for adoption; security firewall, agent-identity, data-flow, message-signing, policy, response-inspect/scanner, scope-collision, tool-integrity, cost-accounting, key-server, and transparency-log paths require commercial terms for commercial use (see [LICENSE-EE.md](LICENSE-EE.md), v2.11.0+) | Collapse package metadata back to plain MIT |
 
 ## Anti-Patterns (things agents get wrong in this repo)
 


### PR DESCRIPTION
## Summary

`CLAUDE.md:145` Decisions-Locked table still claimed `License: MIT | Relicense without explicit user direction`. Stale post-v2.11.0: `LICENSE-EE.md` landed Path C dual-licensing (MIT core + PolyForm Noncommercial 1.0.0 for designated EE-marked files).

Updated row mirrors the equivalent decision row at `nab/CLAUDE.md:82` (where nab adopted the same dual-license posture) and enumerates EE-coverage paths from `LICENSE-EE.md` so an agent reading `CLAUDE.md` does not need to cross-reference to know which modules ship under which license.

## Closes

Linear [MIK-3038](https://linear.app/parm/issue/MIK-3038/chore-update-claudemd-decisions-locked-rows-in-nab-and-mcp-gateway-to) ([P0-production], Urgent).

Acceptance criteria from MIK-3038:

- [x] Row updated to MIT core + PolyForm Noncommercial 1.0.0 EE; references LICENSE-EE.md
- [x] No other edits creep in (1-line diff, single row in single table)

## Verification

```
diff --stat
 CLAUDE.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Reversibility

Trivial — single-row revert.

## Source / citation

- Stale row: `CLAUDE.md:145` (pre-fix)
- Mirror reference: `nab/CLAUDE.md:82`
- Authority on EE coverage: `LICENSE-EE.md` lines 18-30 (Enterprise Edition coverage section, "Active as of v2.11.0 (2026-04-25). See MIK-3034, MIK-3036.")

Generated with [Claude Code](https://claude.com/claude-code)