### PR TITLE
fix: return structuredContent for tools with outputSchema

### DIFF
--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -742,7 +742,7 @@ impl MetaMcp {
             return match result {
                 Ok(content) => {
                     use super::meta_mcp_helpers::wrap_tool_success;
-                    wrap_tool_success(id, &content)
+                    wrap_tool_success(id, &content, false)
                 }
                 Err(e) => JsonRpcResponse::error(Some(id), e.to_rpc_code(), e.to_string()),
             };
@@ -803,7 +803,10 @@ impl MetaMcp {
         };
 
         match result {
-            Ok(content) => wrap_tool_success(id, &content),
+            Ok(content) => {
+                let has_output_schema = tool_name == "gateway_search_tools";
+                wrap_tool_success(id, &content, has_output_schema)
+            }
             Err(e) => JsonRpcResponse::error(Some(id), e.to_rpc_code(), e.to_string()),
         }
     }

--- a/src/gateway/meta_mcp_helpers.rs
+++ b/src/gateway/meta_mcp_helpers.rs
@@ -650,12 +650,22 @@ pub(crate) fn build_circuit_breaker_stats_json(server: &str, stats: &CircuitBrea
 }
 
 /// Wrap a successful tool result `Value` into a `JsonRpcResponse`.
-pub(crate) fn wrap_tool_success(id: RequestId, content: &Value) -> JsonRpcResponse {
+///
+/// When `has_output_schema` is `true`, the response includes `structuredContent`
+/// with the raw JSON value, as required by the MCP spec (2025-06-18) for tools
+/// that declare an `outputSchema`. The text `content` is always included as a
+/// fallback for clients that don't support structured output.
+pub(crate) fn wrap_tool_success(id: RequestId, content: &Value, has_output_schema: bool) -> JsonRpcResponse {
     let result = ToolsCallResult {
         content: vec![Content::Text {
             text: serde_json::to_string_pretty(content).unwrap_or_default(),
             annotations: None,
         }],
+        structured_content: if has_output_schema {
+            Some(content.clone())
+        } else {
+            None
+        },
         is_error: false,
     };
     JsonRpcResponse::success_serialized(id, result)

--- a/src/gateway/meta_mcp_helpers_tests.rs
+++ b/src/gateway/meta_mcp_helpers_tests.rs
@@ -946,20 +946,21 @@ fn build_stats_response_custom_price() {
 fn wrap_tool_success_produces_valid_response() {
     let id = RequestId::Number(1);
     let content = json!({"servers": []});
-    let response = wrap_tool_success(id, &content);
+    let response = wrap_tool_success(id, &content, false);
     assert!(response.error.is_none());
     assert!(response.result.is_some());
 
     let result: ToolsCallResult = serde_json::from_value(response.result.unwrap()).unwrap();
     assert!(!result.is_error);
     assert_eq!(result.content.len(), 1);
+    assert!(result.structured_content.is_none());
 }
 
 #[test]
 fn wrap_tool_success_content_is_pretty_json() {
     let id = RequestId::Number(42);
     let content = json!({"key": "value"});
-    let response = wrap_tool_success(id, &content);
+    let response = wrap_tool_success(id, &content, false);
 
     let result: ToolsCallResult = serde_json::from_value(response.result.unwrap()).unwrap();
     if let Content::Text { text, .. } = &result.content[0] {
@@ -970,6 +971,20 @@ fn wrap_tool_success_content_is_pretty_json() {
     } else {
         panic!("Expected text content");
     }
+}
+
+#[test]
+fn wrap_tool_success_with_output_schema_includes_structured_content() {
+    let id = RequestId::Number(99);
+    let content = json!({"matches": [{"server": "ado", "tool": "list_projects", "description": "List projects", "score": 1.0}]});
+    let response = wrap_tool_success(id, &content, true);
+
+    let result: ToolsCallResult = serde_json::from_value(response.result.unwrap()).unwrap();
+    assert!(!result.is_error);
+    // Must have both content (text fallback) and structuredContent
+    assert_eq!(result.content.len(), 1);
+    let sc = result.structured_content.expect("structuredContent must be present when has_output_schema is true");
+    assert_eq!(sc["matches"][0]["server"], "ado");
 }
 
 // ── tool_matches_query synonym expansion ────────────────────────────

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -274,8 +274,17 @@ pub struct ToolsCallParams {
 /// Tools call result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolsCallResult {
-    /// Content items
+    /// Content items (text representation for backward compatibility)
     pub content: Vec<Content>,
+    /// Structured JSON content matching the tool's `outputSchema`.
+    ///
+    /// Per the MCP spec (2025-06-18), when a tool declares an `outputSchema`,
+    /// the response **must** include `structuredContent` with a JSON object
+    /// that conforms to that schema. Clients that enforce this requirement
+    /// (e.g. the Python SDK `mcp>=1.24.0`, Kiro) will reject responses that
+    /// omit this field when `outputSchema` is present.
+    #[serde(rename = "structuredContent", skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
     /// Whether result is an error
     #[serde(rename = "isError", default)]
     pub is_error: bool,


### PR DESCRIPTION
## Summary

Fixes #158 - gateway_search_tools declares an outputSchema but the response never includes structuredContent, causing MCP clients that enforce the spec to reject it with -32600.

## Changes

- **src/protocol/messages.rs**: Added optional structured_content field to ToolsCallResult, serialized as structuredContent per the MCP spec (2025-06-18)
- **src/gateway/meta_mcp_helpers.rs**: Added has_output_schema parameter to wrap_tool_success. When true, populates structuredContent with the raw JSON value alongside the text content fallback
- **src/gateway/meta_mcp/mod.rs**: Updated dispatch to pass has_output_schema=true for gateway_search_tools (the only meta-tool with outputSchema)
- **src/gateway/meta_mcp_helpers_tests.rs**: Updated existing tests, added new test verifying structuredContent is present when has_output_schema is true

## Approach

Rather than removing the outputSchema from gateway_search_tools (which would lose the schema contract), this fix makes wrap_tool_success schema-aware. A simple boolean parameter controls whether structuredContent is populated. The text content is always included as a backward-compatible fallback.

This is forward-compatible: if more meta-tools gain outputSchema in the future, they just need to pass true at their call site.