### PR TITLE
Fix Linear MCP wrapper schema validation

### DIFF
--- a/capabilities/linear/linear_add_comment.yaml
+++ b/capabilities/linear/linear_add_comment.yaml
@@ -19,6 +19,10 @@ schema:
       comment:
         type: object
 
+transform:
+  project:
+    - comment
+
 auth:
   required: true
   type: api_key
@@ -51,6 +55,7 @@ providers:
         variables:
           issueId: "{issueId}"
           body: "{body}"
+      response_path: data.commentCreate
 
 cache:
   strategy: none

--- a/capabilities/linear/linear_create_issue.yaml
+++ b/capabilities/linear/linear_create_issue.yaml
@@ -57,6 +57,10 @@ schema:
         type: object
         description: Created issue
 
+transform:
+  project:
+    - issue
+
 auth:
   required: true
   type: api_key
@@ -102,6 +106,7 @@ providers:
             dueDate: "{dueDate}"
             createAsUser: "{createAsUser}"
             displayIconUrl: "{displayIconUrl}"
+      response_path: data.issueCreate
 
 cache:
   strategy: none

--- a/capabilities/linear/linear_get_issue.yaml
+++ b/capabilities/linear/linear_get_issue.yaml
@@ -19,6 +19,12 @@ schema:
         type: object
         description: Full issue details
 
+transform:
+  project:
+    - nodes[0]
+  rename:
+    nodes[0]: issue
+
 auth:
   required: true
   type: api_key
@@ -69,6 +75,7 @@ providers:
           }
         variables:
           term: "{identifier}"
+      response_path: data.searchIssues
 
 cache:
   strategy: exact

--- a/capabilities/linear/linear_get_teams.yaml
+++ b/capabilities/linear/linear_get_teams.yaml
@@ -13,6 +13,12 @@ schema:
         type: array
         description: List of teams with states and labels
 
+transform:
+  project:
+    - nodes
+  rename:
+    nodes: teams
+
 auth:
   required: true
   type: api_key
@@ -41,6 +47,7 @@ providers:
               }
             }
           }
+      response_path: data.teams
 
 cache:
   strategy: exact

--- a/capabilities/linear/linear_list_projects.yaml
+++ b/capabilities/linear/linear_list_projects.yaml
@@ -12,6 +12,12 @@ schema:
       projects:
         type: array
 
+transform:
+  project:
+    - nodes
+  rename:
+    nodes: projects
+
 auth:
   required: true
   type: api_key
@@ -46,6 +52,7 @@ providers:
             }
           }
         variables: {}
+      response_path: data.projects
 
 cache:
   strategy: exact

--- a/capabilities/linear/linear_search_issues.yaml
+++ b/capabilities/linear/linear_search_issues.yaml
@@ -24,6 +24,12 @@ schema:
         type: array
         description: Matching issues
 
+transform:
+  project:
+    - nodes
+  rename:
+    nodes: issues
+
 auth:
   required: true
   type: api_key
@@ -62,6 +68,7 @@ providers:
           term: "{query}"
           first: "{first|50}"
           after: "{after|}"
+      response_path: data.searchIssues
 
 cache:
   strategy: exact

--- a/capabilities/linear/linear_update_issue.yaml
+++ b/capabilities/linear/linear_update_issue.yaml
@@ -48,6 +48,10 @@ schema:
       issue:
         type: object
 
+transform:
+  project:
+    - issue
+
 auth:
   required: true
   type: api_key
@@ -91,6 +95,7 @@ providers:
             parentId: "{parentId}"
             estimate: "{estimate}"
             dueDate: "{dueDate}"
+      response_path: data.issueUpdate
 
 cache:
   strategy: none

--- a/capabilities/linear/linear_viewer.yaml
+++ b/capabilities/linear/linear_viewer.yaml
@@ -18,6 +18,13 @@ schema:
       displayName:
         type: string
 
+transform:
+  project:
+    - id
+    - name
+    - email
+    - displayName
+
 auth:
   required: true
   type: api_key
@@ -37,6 +44,7 @@ providers:
         Content-Type: "application/json"
       body:
         query: "{ viewer { id name email displayName active admin url } }"
+      response_path: data.viewer
 
 cache:
   strategy: exact

--- a/src/capability/backend.rs
+++ b/src/capability/backend.rs
@@ -363,16 +363,7 @@ impl CapabilityBackend {
             .execute(&capability, validation.coerced)
             .await?;
 
-        let text = serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string());
-
-        Ok(ToolsCallResult {
-            content: vec![Content::Text {
-                text,
-                annotations: None,
-            }],
-            structured_content: None,
-            is_error: false,
-        })
+        Ok(build_success_tool_result(&capability, result))
     }
 
     /// Check if a capability exists — O(1) via the name index.
@@ -436,6 +427,18 @@ impl CapabilityBackend {
         }
 
         detected
+    }
+}
+
+fn build_success_tool_result(capability: &CapabilityDefinition, result: Value) -> ToolsCallResult {
+    let text = serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string());
+    ToolsCallResult {
+        content: vec![Content::Text {
+            text,
+            annotations: None,
+        }],
+        structured_content: (!capability.schema.output.is_null()).then_some(result),
+        is_error: false,
     }
 }
 
@@ -516,6 +519,7 @@ pub struct CapabilityBackendStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn make_backend() -> CapabilityBackend {
         let executor = Arc::new(CapabilityExecutor::new());
@@ -726,6 +730,58 @@ providers:
         assert_eq!(reload_count, 1);
         assert!(backend.has_capability("alpha"));
         assert_eq!(backend.get_tools().len(), 1);
+    }
+
+    #[test]
+    fn build_success_tool_result_populates_structured_content_when_output_schema_exists() {
+        let yaml = r#"
+name: linear_get_issue_test
+description: Test capability with output schema
+schema:
+  input:
+    type: object
+    properties:
+      identifier:
+        type: string
+    required: [identifier]
+  output:
+    type: object
+    properties:
+      issue:
+        type: object
+        properties:
+          id:
+            type: string
+          title:
+            type: string
+        required: [id, title]
+    required: [issue]
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: "https://api.example.com"
+      path: /issue
+      method: GET
+"#;
+        let cap = crate::capability::parse_capability(yaml).unwrap();
+        let result = build_success_tool_result(
+            &cap,
+            json!({ "issue": { "id": "abc", "title": "Test issue" } }),
+        );
+
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({ "issue": { "id": "abc", "title": "Test issue" } }))
+        );
+        let text = match &result.content[0] {
+            Content::Text { text, .. } => text,
+            other => panic!("expected text content, got {other:?}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(text).expect("text should be JSON");
+        assert_eq!(parsed["issue"]["id"], json!("abc"));
+        assert_eq!(parsed["issue"]["title"], json!("Test issue"));
     }
 
     #[test]

--- a/src/capability/definition/tests.rs
+++ b/src/capability/definition/tests.rs
@@ -1078,3 +1078,258 @@ fn response_transform_included_in_serialization_when_non_empty() {
     // THEN: response_transform key is present
     assert!(yaml.contains("response_transform"));
 }
+
+fn load_repo_capability(relative_path: &str) -> CapabilityDefinition {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    serde_yaml::from_str(&yaml)
+        .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()))
+}
+
+fn assert_linear_capability_shape(
+    relative_path: &str,
+    expected_response_path: &str,
+    raw_after_response_path: serde_json::Value,
+    expected_shaped: serde_json::Value,
+) {
+    let cap = load_repo_capability(relative_path);
+    let provider = cap
+        .providers
+        .get("primary")
+        .unwrap_or_else(|| panic!("{relative_path} missing primary provider"));
+
+    assert_eq!(
+        provider.config.response_path.as_deref(),
+        Some(expected_response_path),
+        "{relative_path} should keep the GraphQL extraction path wired",
+    );
+
+    let pipeline = crate::transform::TransformPipeline::compile(&cap.transform);
+    let shaped = pipeline.apply(raw_after_response_path);
+    assert_eq!(
+        shaped, expected_shaped,
+        "{relative_path} should shape payloads to its declared output schema",
+    );
+
+    let validation = crate::capability::validate_output(&shaped, &cap.schema.output);
+    assert!(
+        validation.is_valid(),
+        "{}",
+        validation.format_error(&cap.schema.output)
+    );
+}
+
+#[test]
+fn linear_capability_payload_shapes_match_declared_output_schemas() {
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_create_issue.yaml",
+        "data.issueCreate",
+        serde_json::json!({
+            "success": true,
+            "issue": {
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Created issue",
+                "url": "https://linear.app/parm/issue/MIK-1/test",
+                "state": { "name": "Backlog" },
+                "team": { "key": "MIK" },
+                "priority": 4,
+                "priorityLabel": "Low"
+            }
+        }),
+        serde_json::json!({
+            "issue": {
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Created issue",
+                "url": "https://linear.app/parm/issue/MIK-1/test",
+                "state": { "name": "Backlog" },
+                "team": { "key": "MIK" },
+                "priority": 4,
+                "priorityLabel": "Low"
+            }
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_update_issue.yaml",
+        "data.issueUpdate",
+        serde_json::json!({
+            "success": true,
+            "issue": {
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Updated issue",
+                "url": "https://linear.app/parm/issue/MIK-1/test",
+                "state": { "name": "Canceled" },
+                "priority": 4,
+                "priorityLabel": "Low",
+                "assignee": { "name": "mikko.parkkola" }
+            }
+        }),
+        serde_json::json!({
+            "issue": {
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Updated issue",
+                "url": "https://linear.app/parm/issue/MIK-1/test",
+                "state": { "name": "Canceled" },
+                "priority": 4,
+                "priorityLabel": "Low",
+                "assignee": { "name": "mikko.parkkola" }
+            }
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_add_comment.yaml",
+        "data.commentCreate",
+        serde_json::json!({
+            "success": true,
+            "comment": {
+                "id": "comment-1",
+                "body": "ok",
+                "createdAt": "2026-04-29T10:13:21.226Z",
+                "user": { "name": "mikko.parkkola@iki.fi" },
+                "issue": { "identifier": "MIK-1", "title": "Validation" }
+            }
+        }),
+        serde_json::json!({
+            "comment": {
+                "id": "comment-1",
+                "body": "ok",
+                "createdAt": "2026-04-29T10:13:21.226Z",
+                "user": { "name": "mikko.parkkola@iki.fi" },
+                "issue": { "identifier": "MIK-1", "title": "Validation" }
+            }
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_get_issue.yaml",
+        "data.searchIssues",
+        serde_json::json!({
+            "nodes": [{
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Validation",
+                "comments": { "nodes": [] },
+                "children": { "nodes": [] }
+            }]
+        }),
+        serde_json::json!({
+            "issue": {
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Validation",
+                "comments": { "nodes": [] },
+                "children": { "nodes": [] }
+            }
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_search_issues.yaml",
+        "data.searchIssues",
+        serde_json::json!({
+            "nodes": [{
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Validation",
+                "url": "https://linear.app/parm/issue/MIK-1/test"
+            }],
+            "pageInfo": { "hasNextPage": false, "endCursor": "cursor-1" }
+        }),
+        serde_json::json!({
+            "issues": [{
+                "id": "issue-1",
+                "identifier": "MIK-1",
+                "title": "Validation",
+                "url": "https://linear.app/parm/issue/MIK-1/test"
+            }]
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_get_teams.yaml",
+        "data.teams",
+        serde_json::json!({
+            "nodes": [{
+                "id": "team-1",
+                "name": "Mikko",
+                "key": "MIK",
+                "description": null,
+                "states": { "nodes": [] },
+                "labels": { "nodes": [] }
+            }]
+        }),
+        serde_json::json!({
+            "teams": [{
+                "id": "team-1",
+                "name": "Mikko",
+                "key": "MIK",
+                "description": null,
+                "states": { "nodes": [] },
+                "labels": { "nodes": [] }
+            }]
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_list_projects.yaml",
+        "data.projects",
+        serde_json::json!({
+            "nodes": [{
+                "id": "project-1",
+                "name": "Gateway",
+                "description": "Validation",
+                "state": "planned",
+                "progress": 0.5,
+                "completedAt": null,
+                "startDate": null,
+                "targetDate": null,
+                "teams": { "nodes": [] },
+                "lead": null,
+                "projectMilestones": { "nodes": [] },
+                "url": "https://linear.app/parm/project/test"
+            }]
+        }),
+        serde_json::json!({
+            "projects": [{
+                "id": "project-1",
+                "name": "Gateway",
+                "description": "Validation",
+                "state": "planned",
+                "progress": 0.5,
+                "completedAt": null,
+                "startDate": null,
+                "targetDate": null,
+                "teams": { "nodes": [] },
+                "lead": null,
+                "projectMilestones": { "nodes": [] },
+                "url": "https://linear.app/parm/project/test"
+            }]
+        }),
+    );
+
+    assert_linear_capability_shape(
+        "capabilities/linear/linear_viewer.yaml",
+        "data.viewer",
+        serde_json::json!({
+            "id": "user-1",
+            "name": "mikko.parkkola@iki.fi",
+            "email": "mikko.parkkola@iki.fi",
+            "displayName": "mikko.parkkola",
+            "active": true,
+            "admin": true,
+            "url": "https://linear.app/parm/profiles/mikko.parkkola"
+        }),
+        serde_json::json!({
+            "id": "user-1",
+            "name": "mikko.parkkola@iki.fi",
+            "email": "mikko.parkkola@iki.fi",
+            "displayName": "mikko.parkkola"
+        }),
+    );
+}

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -46,9 +46,18 @@ fn enforce_output_schema(
         return Ok(result);
     };
 
-    let validation = validate_output(&result, schema);
+    if result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Ok(result);
+    }
+
+    let validation_target = extract_output_validation_target(&result).unwrap_or_else(|| result.clone());
+    let validation = validate_output(&validation_target, schema);
     if validation.is_valid() {
-        Ok(validation.coerced)
+        Ok(apply_validated_output(result, validation.coerced))
     } else {
         Err(Error::json_rpc(
             -32603,
@@ -58,6 +67,44 @@ fn enforce_output_schema(
             ),
         ))
     }
+}
+
+fn extract_output_validation_target(result: &Value) -> Option<Value> {
+    if let Some(structured) = result.get("structuredContent") {
+        return Some(structured.clone());
+    }
+
+    let content = result.get("content")?.as_array()?;
+    if content.len() != 1 {
+        return None;
+    }
+    let text = content[0].get("text")?.as_str()?;
+    serde_json::from_str::<Value>(text).ok()
+}
+
+fn apply_validated_output(result: Value, validated: Value) -> Value {
+    let Some(obj) = result.as_object() else {
+        return validated;
+    };
+    if !(obj.contains_key("content") || obj.contains_key("structuredContent")) {
+        return validated;
+    }
+
+    let mut obj = obj.clone();
+    obj.insert("structuredContent".to_owned(), validated.clone());
+    if let Some(content) = obj.get_mut("content").and_then(Value::as_array_mut)
+        && content.len() == 1
+        && let Some(text_obj) = content[0].as_object_mut()
+        && text_obj.get("type").and_then(Value::as_str) == Some("text")
+    {
+        text_obj.insert(
+            "text".to_owned(),
+            Value::String(
+                serde_json::to_string_pretty(&validated).unwrap_or_else(|_| validated.to_string()),
+            ),
+        );
+    }
+    Value::Object(obj)
 }
 
 /// Monotonically increasing request counter for load-balanced cache key slot selection.
@@ -1276,6 +1323,71 @@ mod response_transform_tests {
         assert!(message.contains("violated its declared output schema"));
         assert!(message.contains("Tool result validation failed"));
         assert!(message.contains("exfil"));
+    }
+
+    #[test]
+    fn enforce_output_schema_validates_structured_content_inside_mcp_result() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "issue": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    },
+                    "required": ["id"]
+                }
+            },
+            "required": ["issue"]
+        });
+
+        let result = enforce_output_schema(
+            "fulcrum",
+            "linear_get_issue",
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": "{\"issue\":{\"id\":\"abc\"}}"
+                }],
+                "structuredContent": { "issue": { "id": "abc" } },
+                "isError": false
+            }),
+            Some(&schema),
+        )
+        .expect("structuredContent should be validated, not the MCP envelope");
+
+        assert_eq!(result["structuredContent"]["issue"]["id"], json!("abc"));
+        assert_eq!(
+            result["content"][0]["text"],
+            json!("{\n  \"issue\": {\n    \"id\": \"abc\"\n  }\n}")
+        );
+    }
+
+    #[test]
+    fn enforce_output_schema_skips_mcp_error_envelopes() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "issue": { "type": "object" }
+            }
+        });
+
+        let result = enforce_output_schema(
+            "fulcrum",
+            "linear_get_issue",
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": "bad input"
+                }],
+                "isError": true
+            }),
+            Some(&schema),
+        )
+        .expect("tool-error MCP envelope should bypass output validation");
+
+        assert_eq!(result["isError"], json!(true));
+        assert_eq!(result["content"][0]["text"], json!("bad input"));
     }
 
     #[tokio::test]

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -54,7 +54,8 @@ fn enforce_output_schema(
         return Ok(result);
     }
 
-    let validation_target = extract_output_validation_target(&result).unwrap_or_else(|| result.clone());
+    let validation_target =
+        extract_output_validation_target(&result).unwrap_or_else(|| result.clone());
     let validation = validate_output(&validation_target, schema);
     if validation.is_valid() {
         Ok(apply_validated_output(result, validation.coerced))

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -58,7 +58,7 @@ fn enforce_output_schema(
         extract_output_validation_target(&result).unwrap_or_else(|| result.clone());
     let validation = validate_output(&validation_target, schema);
     if validation.is_valid() {
-        Ok(apply_validated_output(result, validation.coerced))
+        Ok(apply_validated_output(&result, validation.coerced))
     } else {
         Err(Error::json_rpc(
             -32603,
@@ -83,7 +83,7 @@ fn extract_output_validation_target(result: &Value) -> Option<Value> {
     serde_json::from_str::<Value>(text).ok()
 }
 
-fn apply_validated_output(result: Value, validated: Value) -> Value {
+fn apply_validated_output(result: &Value, validated: Value) -> Value {
     let Some(obj) = result.as_object() else {
         return validated;
     };


### PR DESCRIPTION
## Summary
- validate declared output schemas against MCP structuredContent or parsed JSON text payloads instead of the outer wrapper envelope
- preserve MCP error envelopes without schema enforcement so upstream tool errors surface correctly
- shape Linear capability GraphQL responses to match their declared output schemas and add regression coverage

Linear: MIK-3167

## Validation
- cargo fmt --all -- --check
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo clippy --all-features -- -D warnings
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --all-features gateway::meta_mcp::invoke::response_transform_tests
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --all-features capability::definition::tests::linear_capability_payload_shapes_match_declared_output_schemas
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --all-features