### PR TITLE
fix(capabilities/linear): remove createAsUser + displayIconUrl from create_issue mutation

### DIFF
--- a/capabilities/linear/linear_create_issue.yaml
+++ b/capabilities/linear/linear_create_issue.yaml
@@ -43,12 +43,10 @@ schema:
         description: "Due date in YYYY-MM-DD format"
       createAsUser:
         type: string
-        description: "Display name for agent attribution (AIG compliance). Default: Claude Elite"
-        default: "Claude Elite"
+        description: "DEPRECATED: ignored. Linear's IssueCreateInput accepts this only for OAuth-app auth; with personal API key the mutation silent-fails (server validation error swallowed by response_path projection). See linear/SKILL.md silent-failure trap (2026-04-30 bisect)."
       displayIconUrl:
         type: string
-        description: "Avatar URL for agent identity"
-        default: "https://www.anthropic.com/images/icons/safari-pinned-tab.svg"
+        description: "DEPRECATED: ignored. Same constraint as createAsUser."
     required: [title, teamId]
   output:
     type: object
@@ -104,8 +102,12 @@ providers:
             stateId: "{stateId}"
             estimate: "{estimate}"
             dueDate: "{dueDate}"
-            createAsUser: "{createAsUser}"
-            displayIconUrl: "{displayIconUrl}"
+            # createAsUser + displayIconUrl intentionally omitted — Linear's
+            # IssueCreateInput accepts those fields only for OAuth-app auth.
+            # With a personal API key, including them triggers a server-side
+            # validation error which the REST provider's response_path
+            # projection silently swallows (caller sees empty {} success).
+            # Bisect: MIK-3179/3180/3181, 2026-04-30.
       response_path: data.issueCreate
 
 cache:


### PR DESCRIPTION
## Summary

Linear's \`IssueCreateInput\` documents accept \`createAsUser\` and \`displayIconUrl\`, but the API only honors them when the caller is authenticated as an OAuth application. With a personal API key (the common gateway deployment via \`LINEAR_API_KEY\`), Linear rejects the mutation with a server-side validation error.

The REST provider's \`response_path: data.issueCreate\` projection swallows the error: \`response.data.issueCreate\` is null when validation fails, the projection extracts nothing, and the caller sees a "successful" empty \`{}\` response while no issue is actually created.

This bug has been silently breaking every \`linear_create_issue\` call through the gateway since the schema added defaults for those two fields.

## Bisect (2026-04-30, personal API key)

| Payload | Result |
|---|---|
| minimal: title + teamId + description | MIK-3179 created |
| minimal + priority + stateId + labelIds + estimate | MIK-3180 created |
| full payload + createAsUser + displayIconUrl | empty {} (3x) |
| full payload, omit createAsUser + displayIconUrl | MIK-3181 created |

## Acceptance criteria

- [x] \`linear_create_issue\` with priority + state + labels + estimate succeeds against personal API key (MIK-3181 verified)
- [x] Backward compat: callers that still pass \`createAsUser\` / \`displayIconUrl\` are unaffected (fields kept in input schema, marked DEPRECATED, no longer projected into the GraphQL variables)
- [ ] CI green

## Follow-up (not in this PR)

The REST provider should surface GraphQL \`errors[]\` whenever \`response_path\` projects a null value. That would have caught this in the first call instead of via a 3-issue bisect. Tracked in \`~/.claude/skills/linear/SKILL.md\` and Linear MIK-3181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)