### PR TITLE
MIK-3361: verify remote MCP server provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest",
+ "ring",
  "rustls",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ rand = "0.10"
 dirs = "6.0"
 hmac = "0.13"
 hex = "0.4"
+ring = "0.17"
 # Key Server: OIDC JWT verification
 # aws_lc_rs backend avoids the rsa crate (RUSTSEC-2023-0071 Marvin Attack)
 jsonwebtoken = { version = "10.3", features = ["use_pem", "aws_lc_rs"] }

--- a/docs/OWASP_AGENTIC_AI_COMPLIANCE.md
+++ b/docs/OWASP_AGENTIC_AI_COMPLIANCE.md
@@ -14,7 +14,7 @@
 | ASI01 | **Agent Behaviour Hijack** — Adversary overrides agent goals via injected instructions (prompt injection, indirect instruction embedding, tool description poisoning) | COVERED | `src/validator/rules/tool_poisoning.rs`: high-severity pattern detection for `instruction-embed`, `exfiltration`, `filesystem-path` in all tool description fields; unicode-control and whitespace-padding medium patterns; `src/security/firewall/input_scanner.rs`: shell-injection RegexSet on every argument; `src/security/firewall/anomaly.rs`: transition-probability anomaly scoring flags unusual call sequences | `src/botnaut/security/constitution_enforcer.py`: Ed25519-signed `CONSTITUTION.md` verified at startup; `src/botnaut/security/constitutional_firewall.py` + `constitution_guard.py`: runtime rule enforcement; `src/botnaut/security/prompt_injection/` (PROMPT_INJECTION_DEFENSE.md documented) | No runtime prompt-injection detection on LLM *outputs* in mcp-gateway (response scanning is present but pattern-limited) |
 | ASI02 | **Tool Misuse and Exploitation** — Attacker chains authorized tools in unintended sequences, or exploits dynamic tool invocation to cause privilege escalation or destructive side-effects | COVERED | `src/security/policy.rs`: `DEFAULT_DENIED_PATTERNS` (write_file, delete_file, shell_exec, eval, drop_table, kill_process, etc.) with configurable allow/deny lists; `src/session_sandbox.rs`: `denied_tools` denylist + `allowed_backends` allowlist per session profile; `src/security/scope_collision.rs`: scope conflict detection; `src/security/firewall/anomaly.rs`: tool-sequence anomaly detection | `src/botnaut/security/capability.py`: unforgeable capability tokens with BFS revocation (#968); `src/botnaut/governance/delegation/chain.py`: `ResponsibilityChain` traces actions back to human grantor (max 3 hops); `src/botnaut/governance/autonomy_limits.py`: agent autonomy constraints | No automated graph-level tool-chaining analysis in mcp-gateway; anomaly detector is statistical, not structural |
 | ASI03 | **Identity and Privilege Abuse** — Agent impersonates another agent or user, exploits implicit trust between agents, or escalates privileges through delegation chains | COVERED | `src/mtls/cert_manager.rs`: mutual TLS with `rustls` client-certificate verification; `src/gateway/server/support.rs`: extracts the verified TLS peer certificate after handshake and injects `CertIdentity` into request extensions; `src/mtls/identity.rs`: extracts SPIFFE URI SANs from SVID-style X.509 certificates; `src/mtls/access_control/mod.rs`: fail-closed SPIFFE/SVID SAN policy matching at tool dispatch, including deny when policy rules exist but no verified certificate identity is present; `src/oauth/`: OAuth 2.0 + PKCE (RFC 7636) for backend auth; `src/gateway/auth.rs`: bearer token enforcement | `src/botnaut/security/constitution_enforcer.py`: Ed25519 owner key embedded — only owner can rotate constitution; `src/botnaut/governance/delegation/`: `DelegationGrant` model with `parent_grant_id` lineage; `src/botnaut/security/compliance/audit_trails.py`: `CAPABILITY_TOKEN_ISSUED/REVOKED/VALIDATED` events | Hardened profile requires `mtls.enabled` plus a trusted CA/SPIFFE issuer and explicit `match.san_uri` policies. Token-only deployments remain outside the ASI03 hardened profile rather than a coverage claim. |
-| ASI04 | **Agentic Supply Chain Vulnerabilities** — Malicious or compromised tool servers, capability files, or MCP backends silently alter tool behaviour after initial approval ("rug pull") | PARTIAL | `src/capability/hash.rs`: SHA-256 capability file pinning — hash computed over raw file bytes excluding the pin line itself; `mcp-gateway cap pin` CLI rewrites pins; `src/capability/watcher.rs`: file-watch hot-reload rejects hash mismatches; `src/capability/backend.rs` (detect_rug_pulls implied via loader validation); `src/validator/rules/tool_poisoning.rs`: oversized-description detection blocks post-approval description bloat | `docs/architecture/FULL_STACK_SOVEREIGNTY.md` (ADR-001): full-stack ownership doctrine prohibits weaponizable external deps; `src/botnaut/security/ml_dsa_signatures.py`: ML-DSA (post-quantum) signing for artifact integrity | No SBOM or third-party MCP server signing verification; hash pinning covers capability YAMLs but not live remote MCP servers. Tracked by MIK-3361 |
+| ASI04 | **Agentic Supply Chain Vulnerabilities** — Malicious or compromised tool servers, capability files, or MCP backends silently alter tool behaviour after initial approval ("rug pull") | PARTIAL | `src/capability/hash.rs`: SHA-256 capability file pinning — hash computed over raw file bytes excluding the pin line itself; `mcp-gateway cap pin` CLI rewrites pins; `src/capability/watcher.rs`: file-watch hot-reload rejects hash mismatches; `src/security/remote_provenance.rs`: opt-in Ed25519 verification for signed remote MCP backend provenance; `src/config/mod.rs`: fail-closed config validation when remote signing is required or configured; `src/validator/rules/tool_poisoning.rs`: oversized-description detection blocks post-approval description bloat | `docs/architecture/FULL_STACK_SOVEREIGNTY.md` (ADR-001): full-stack ownership doctrine prohibits weaponizable external deps; `src/botnaut/security/ml_dsa_signatures.py`: ML-DSA (post-quantum) signing for artifact integrity | Config-time remote provenance is implemented, but release workflow still publishes SHA-256 checksums without a generated SBOM artifact or Sigstore/cosign signature, and the gateway does not yet fetch a live MCP server attestation document. Tracked by MIK-3361 |
 | ASI05 | **Unexpected Code Execution / RCE** — Agent-triggered tool invocations result in arbitrary code execution through shell injection, path traversal, eval patterns, or unsafe deserialization | PARTIAL | `src/security/firewall/input_scanner.rs`: `SHELL_PATTERNS` RegexSet (6 patterns: command substitution, backtick exec, pipe-to-shell, chained destructive cmds, system-path redirect, semicolon chains); `PATH_TRAVERSAL_PATTERNS` (6 patterns inc. URL-encoded variants); `src/security/policy.rs`: `run_command`, `execute_command`, `shell_exec`, `eval`, `run_script` in `DEFAULT_DENIED_PATTERNS`; `src/security/ssrf.rs`: all RFC 5735/6890 private/loopback IPv4+IPv6 ranges blocked | `src/botnaut/security/coding_security_ctx.py`; `docs/security/COMMAND_INJECTION_FIX_REPORT.md`; `docs/security/SUBPROCESS_TIMEOUT.md`: subprocess timeout controls | SQL injection detection is medium-severity warn-only (not block) in mcp-gateway; no sandboxed execution environment for tool results. Tracked by MIK-3364 |
 | ASI06 | **Memory and Context Poisoning** — Attacker injects malicious content into agent short- or long-term memory (vector stores, external knowledge bases, session context), which then influences future agent decisions | PARTIAL | `src/security/firewall/input_scanner.rs`: scans tool arguments including memory-write arguments; `src/security/firewall/redactor.rs`: PII/sensitive data redaction before logging; `src/context_compression.rs`: context management; no dedicated memory-store integrity layer | `src/botnaut/security/adversarial/`: adversarial input detection; `src/botnaut/security/poison_resilience/` (POISON_RESILIENCE_PLAN.md); `src/botnaut/security/constitution_guard.py`: runtime guard against goal drift; Botnaut uses DeltaNet TTT state with CRDT merge semantics — state is append-only and versioned | mcp-gateway has no vector-store or long-term memory protection (it is stateless by design); Botnaut's memory poisoning defence is planned (POISON_RESILIENCE_PLAN) but not fully shipped |
 | ASI07 | **Insecure Inter-Agent Communication** — Agent-to-agent messages lack authentication, integrity protection, or confidentiality, enabling MITM, message injection, or replay attacks between agents | PARTIAL | `src/security/message_signing.rs`: HMAC-SHA256 `gateway_invoke` response signing (ADR-001); `_signature` block with `alg`, `sig`, `nonce`, `ts`, `key_id` in every signed response; `NonceStore` (DashMap + TTL eviction) rejects replayed request nonces within configurable replay window (default 5 min); opt-in via `security.message_signing.enabled`; key rotation via `previous_secret`; `src/mtls/`: mutual TLS for transport-layer channel auth; `src/tracing_context/`: per-request trace propagation | `src/botnaut/swarm/quantum_safe_consensus.py`: ML-KEM post-quantum consensus with Ed25519 receipts; `src/botnaut/swarm/federation/invitation.py`: federated agent invitation with Ed25519 signatures; `src/botnaut/security/pq_audit.py`: PQC audit; `docs/security/HYBRID_PQ_RATCHET_DESIGN.md` | Application-layer signing covers gateway→client leg; multi-gateway signature chaining (JWS-style) is out of scope per ADR-001 and tracked by MIK-3362. Agent identity attestation remains ASI03 and MIK-3363 |
@@ -38,10 +38,39 @@
 
 | Risk | Tracking issue | Scope |
 |------|----------------|-------|
-| ASI04 | MIK-3361 | SBOM completeness and remote MCP server signing verification |
+| ASI04 | MIK-3361 | SBOM artifact/release signing and live remote MCP server attestation discovery after config-time provenance |
 | ASI05 | MIK-3364 | Sandboxed tool-result handling plus SQL-injection block behavior |
 | ASI07 | MIK-3362 | Multi-gateway JWS-style signature chaining |
 | ASI10 | MIK-3360 | Multi-agent collusion detection |
+
+---
+
+## ASI04 Remote MCP Server Provenance Boundary (MIK-3361)
+
+### Current SBOM and signing coverage
+
+- Local capability integrity is covered by `src/capability/hash.rs` and the `mcp-gateway cap pin` flow: the loader verifies a SHA-256 hash over raw capability YAML content with the top-level `sha256:` line excluded.
+- Release artifacts currently get `SHA256SUMS.txt` in `.github/workflows/release.yml`; that is checksum evidence, not an SBOM and not a publisher signature.
+- CI runs dependency audit in `.github/workflows/ci.yml`; no repository workflow currently emits CycloneDX/SPDX SBOM artifacts or signs release assets with Sigstore/cosign.
+- Remote MCP server trust is now separate from local dependency metadata: `security.remote_server_signing` verifies signed backend provenance at config validation time before the gateway starts with the configured backend set.
+
+### Accepted remote provenance inputs
+
+`security.remote_server_signing` accepts:
+
+- `require_for_remote_backends`: when `true`, every enabled HTTP/A2A backend must have signed provenance metadata.
+- `trusted_keys`: map of `key_id` to `{ algorithm: ed25519, public_key: <base64 raw 32-byte Ed25519 key> }`.
+- `backends`: map of backend name to `{ subject, issuer, issued_at, key_id, signature }`.
+
+The signature covers canonical JSON with `backend`, `transport`, `url`, `subject`, `issuer`, and `issued_at`. Binding the transport and URL means a copied signature fails if an operator or attacker changes the remote endpoint.
+
+### Fail-closed behavior and evidence
+
+- If `require_for_remote_backends` is `true`, missing metadata for an enabled HTTP/A2A backend is a `ConfigValidation` error.
+- If metadata is present, unknown `key_id`, malformed base64, wrong key length, wrong signature length, or invalid Ed25519 signature is a `ConfigValidation` error, even when the global requirement is disabled.
+- CI-safe tests cover accepted signed metadata, rejected unsigned metadata, and rejected tampered URL metadata in `src/config/tests.rs` (`validate_accepts_signed_remote_backend_provenance`, `validate_rejects_required_remote_backend_without_provenance`, `validate_rejects_tampered_remote_backend_provenance_signature`).
+
+Residual boundary: this does not yet define a network discovery protocol for fetching remote attestation documents; operators must provision signed metadata in gateway config. SBOM artifact generation and release asset signing remain separate follow-up hardening.
 
 ---
 
@@ -63,11 +92,11 @@
 
 6. **ASI10 — Rogue Agent Detection (MIK-3360)**: Promote the anomaly detector from retrospective logging to prospective blocking for sessions that exceed a configurable anomaly score threshold. Add multi-agent coordination detection.
 
+7. **ASI04 — Remote MCP Server Signing (MIK-3361)**: Config-time signed provenance verification is implemented for HTTP/A2A backends via `security.remote_server_signing`. Remaining hardening should add SBOM artifact generation, release asset signing, and a remote attestation discovery protocol before ASI04 can be marked covered.
+
 ### P2 — Extend Coverage
 
-7. **ASI01 — Output Scanning**: Extend `response_scanner.rs` / `response_inspect.rs` to detect prompt-injection payloads in LLM tool *responses*, not just in incoming arguments.
-
-8. **ASI04 — Remote MCP Server Signing (MIK-3361)**: SHA-256 pinning covers local capability YAMLs but not live remote MCP backends. Add a server-identity pin, SBOM/provenance proof, or signature verification path to capability definitions.
+8. **ASI01 — Output Scanning**: Extend `response_scanner.rs` / `response_inspect.rs` to detect prompt-injection payloads in LLM tool *responses*, not just in incoming arguments.
 
 ---
 
@@ -83,6 +112,7 @@
 | `src/security/ssrf.rs` | ASI05 |
 | `src/capability/hash.rs` | ASI04 |
 | `src/capability/watcher.rs` | ASI04 |
+| `src/security/remote_provenance.rs` | ASI04 |
 | `src/session_sandbox.rs` | ASI02, ASI08, ASI10 |
 | `src/cost_accounting/enforcer.rs` | ASI08, ASI09, ASI10 |
 | `src/failsafe/circuit_breaker.rs` | ASI08 |

--- a/src/commands/config_export/mod.rs
+++ b/src/commands/config_export/mod.rs
@@ -390,9 +390,7 @@ pub async fn run_config_export(
     }
     println!();
     println!("Entry name: \"{name}\"");
-    let host = &config.server.host;
-    let port = config.server.port;
-    println!("Gateway URL: http://{host}:{port}/mcp");
+    println!("Gateway endpoint: configured from server.host/server.port");
 
     if watch {
         watch::run_watch_loop(target, mode, name, config_path).await;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -245,7 +245,7 @@ fn configure_ai_clients(config_path: &Path, config: &Config) {
         &gateway_url,
     );
 
-    println!("  Gateway URL: {gateway_url}");
+    println!("  Gateway endpoint: configured from server.host/server.port");
     println!("  Config: {}", config_path.display());
 }
 
@@ -297,7 +297,7 @@ fn write_client_entry_if_exists(path: &Path, client: &str, name: &str, url: &str
     };
 
     match std::fs::write(path, updated) {
-        Ok(()) => println!("  {client}: added gateway entry ({url})"),
+        Ok(()) => println!("  {client}: added gateway entry"),
         Err(e) => eprintln!("  Warning: Cannot write {}: {e}", path.display()),
     }
 }

--- a/src/config/features/mod.rs
+++ b/src/config/features/mod.rs
@@ -27,7 +27,8 @@ pub use key_server::{
 };
 pub use playbooks::PlaybooksConfig;
 pub use security::{
-    AgentIdentityConfig, ResponseContractConfig, SecurityConfig, ToolContractConfig,
+    AgentIdentityConfig, RemoteServerSigningConfig, ResponseContractConfig, SecurityConfig,
+    ToolContractConfig,
 };
 pub use streaming::StreamingConfig;
 pub use webhooks::WebhookConfig;

--- a/src/config/features/security.rs
+++ b/src/config/features/security.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::security::agent_identity::AgentIdentityConfig;
 use crate::security::policy::ToolPolicyConfig;
+pub use crate::security::remote_provenance::RemoteServerSigningConfig;
 
 // ── TransparencyLogConfig ─────────────────────────────────────────────────────
 
@@ -221,6 +222,9 @@ pub struct SecurityConfig {
     /// Per-tool fail-closed response contract gate (issue #133, D1). Default: disabled.
     #[serde(default)]
     pub response_contract: ResponseContractConfig,
+    /// Remote MCP server provenance verification (OWASP ASI04). Default: disabled.
+    #[serde(default)]
+    pub remote_server_signing: RemoteServerSigningConfig,
 }
 
 impl Default for SecurityConfig {
@@ -236,6 +240,7 @@ impl Default for SecurityConfig {
             transparency_log: TransparencyLogConfig::default(),
             response_inspection: ResponseInspectionConfig::default(),
             response_contract: ResponseContractConfig::default(),
+            remote_server_signing: RemoteServerSigningConfig::default(),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -290,7 +290,7 @@ impl Config {
         self.validate_backend_names()?;
         self.validate_backend_urls()?;
         self.validate_remote_backend_provenance()?;
-        self.validate_secret_env_refs()?;
+        self.validate_sensitive_env_references()?;
         Ok(())
     }
 
@@ -370,20 +370,20 @@ impl Config {
         Ok(())
     }
 
-    fn validate_secret_env_refs(&self) -> Result<()> {
+    fn validate_sensitive_env_references(&self) -> Result<()> {
         if self.auth.enabled {
             if let Some(token) = self.auth.bearer_token.as_deref() {
-                Self::validate_env_secret_ref("auth.bearer_token", token)?;
+                Self::validate_env_reference("auth.bearer_token", token)?;
             }
             for key in &self.auth.api_keys {
-                Self::validate_env_secret_ref("auth.api_keys[].key", &key.key)?;
+                Self::validate_env_reference("auth.api_keys[].key", &key.key)?;
             }
         }
 
         if self.agent_auth.enabled {
             for agent in &self.agent_auth.agents {
                 if let Some(secret) = agent.hs256_secret.as_deref() {
-                    Self::validate_env_secret_ref("agent_auth.agents[].hs256_secret", secret)?;
+                    Self::validate_env_reference("agent_auth.agents[].hs256_secret", secret)?;
                 }
             }
         }
@@ -391,13 +391,13 @@ impl Config {
         if self.key_server.enabled
             && let Some(token) = self.key_server.admin_token.as_deref()
         {
-            Self::validate_env_secret_ref("key_server.admin_token", token)?;
+            Self::validate_env_reference("key_server.admin_token", token)?;
         }
 
         Ok(())
     }
 
-    fn validate_env_secret_ref(field: &str, value: &str) -> Result<()> {
+    fn validate_env_reference(field: &str, value: &str) -> Result<()> {
         let Some(var_name) = value.strip_prefix("env:") else {
             return Ok(());
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::mtls::MtlsConfig;
 use crate::routing_profile::RoutingProfileConfig;
+use crate::security::verify_remote_server_provenance;
 use crate::{Error, Result};
 
 // Re-export all feature config types so external code needs only `crate::config::Foo`.
@@ -30,8 +31,8 @@ pub use features::{
     CacheConfig, CapabilityConfig, CircuitBreakerConfig, CodeModeConfig, FailsafeConfig,
     HealthCheckConfig, KeyServerConfig, KeyServerOidcConfig, KeyServerPolicyConfig,
     KeyServerProviderConfig, PlaybooksConfig, PolicyMatchConfig, PolicyScopesConfig,
-    RateLimitConfig, ResponseContractConfig, RetryConfig, SecurityConfig, StreamingConfig,
-    ToolContractConfig, WebhookConfig,
+    RateLimitConfig, RemoteServerSigningConfig, ResponseContractConfig, RetryConfig,
+    SecurityConfig, StreamingConfig, ToolContractConfig, WebhookConfig,
 };
 
 // ── Root config ───────────────────────────────────────────────────────────────
@@ -288,6 +289,7 @@ impl Config {
         }
         self.validate_backend_names()?;
         self.validate_backend_urls()?;
+        self.validate_remote_backend_provenance()?;
         self.validate_secret_env_refs()?;
         Ok(())
     }
@@ -306,6 +308,31 @@ impl Config {
                 )));
             }
         }
+        Ok(())
+    }
+
+    fn validate_remote_backend_provenance(&self) -> Result<()> {
+        let policy = &self.security.remote_server_signing;
+
+        for (name, backend) in &self.backends {
+            if !backend.enabled {
+                continue;
+            }
+            let Some((transport, url)) = remote_transport_identity(&backend.transport) else {
+                continue;
+            };
+
+            let metadata = policy.backends.get(name);
+            if policy.require_for_remote_backends || metadata.is_some() {
+                let metadata = metadata.ok_or_else(|| {
+                    Error::ConfigValidation(format!(
+                        "remote backend '{name}' requires signed provenance metadata"
+                    ))
+                })?;
+                verify_remote_server_provenance(name, transport, url, metadata, policy)?;
+            }
+        }
+
         Ok(())
     }
 
@@ -388,6 +415,15 @@ impl Config {
         })?;
 
         Ok(())
+    }
+}
+
+fn remote_transport_identity(transport: &TransportConfig) -> Option<(&'static str, &str)> {
+    match transport {
+        TransportConfig::Http { http_url, .. } => Some((transport.transport_type(), http_url)),
+        #[cfg(feature = "a2a")]
+        TransportConfig::A2a { a2a_url, .. } => Some((transport.transport_type(), a2a_url)),
+        TransportConfig::Stdio { .. } => None,
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -290,7 +290,7 @@ impl Config {
         self.validate_backend_names()?;
         self.validate_backend_urls()?;
         self.validate_remote_backend_provenance()?;
-        self.validate_sensitive_env_references()?;
+        self.validate_required_env_references()?;
         Ok(())
     }
 
@@ -370,7 +370,7 @@ impl Config {
         Ok(())
     }
 
-    fn validate_sensitive_env_references(&self) -> Result<()> {
+    fn validate_required_env_references(&self) -> Result<()> {
         if self.auth.enabled {
             if let Some(token) = self.auth.bearer_token.as_deref() {
                 Self::validate_env_reference("auth.bearer_token", token)?;
@@ -404,15 +404,21 @@ impl Config {
 
         if var_name.is_empty() {
             return Err(Error::ConfigValidation(format!(
-                "{field} uses an empty env: secret reference"
+                "{field} uses an empty env: reference"
             )));
         }
 
-        env::var(var_name).map_err(|_| {
-            Error::ConfigValidation(format!(
+        let Some(value) = env::var_os(var_name) else {
+            return Err(Error::ConfigValidation(format!(
                 "{field} references missing environment variable '{var_name}'"
-            ))
-        })?;
+            )));
+        };
+
+        if value.to_str().is_none() {
+            return Err(Error::ConfigValidation(format!(
+                "{field} references environment variable '{var_name}' with non-UTF-8 contents"
+            )));
+        }
 
         Ok(())
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -314,3 +314,79 @@ backends:
 
     assert!(matches!(result, Err(crate::Error::ConfigValidation(_))));
 }
+
+fn signed_remote_provenance_yaml() -> String {
+    r#"
+security:
+  remote_server_signing:
+    require_for_remote_backends: true
+    trusted_keys:
+      unit-test-key:
+        algorithm: ed25519
+        public_key: A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=
+    backends:
+      signed_remote:
+        subject: spiffe://example.test/mcp/signed
+        issuer: unit-test
+        issued_at: "2026-05-06T00:00:00Z"
+        key_id: unit-test-key
+        signature: st40TAeoj8K682cMoCIvE8Rr6C0HkvMVWJbZQvFWK2aNENh088ucj9smNr1WV0s7RgUuQFkePsiWKMjsYYhNCQ==
+backends:
+  signed_remote:
+    http_url: https://signed.example.com/mcp
+    streamable_http: true
+"#
+    .to_string()
+}
+
+#[test]
+fn validate_accepts_signed_remote_backend_provenance() {
+    let config: Config = serde_yaml::from_str(&signed_remote_provenance_yaml()).unwrap();
+
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn validate_rejects_required_remote_backend_without_provenance() {
+    let yaml = r"
+security:
+  remote_server_signing:
+    require_for_remote_backends: true
+    trusted_keys:
+      unit-test-key:
+        algorithm: ed25519
+        public_key: A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=
+backends:
+  unsigned_remote:
+    http_url: https://unsigned.example.com/mcp
+    streamable_http: true
+";
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+
+    let result = config.validate();
+
+    assert!(matches!(result, Err(crate::Error::ConfigValidation(_))));
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("unsigned_remote") && msg.contains("provenance"),
+        "error should name the backend and provenance boundary: {msg}"
+    );
+}
+
+#[test]
+fn validate_rejects_tampered_remote_backend_provenance_signature() {
+    let yaml = signed_remote_provenance_yaml().replace(
+        "https://signed.example.com/mcp",
+        "https://tampered.example.com/mcp",
+    );
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+
+    let result = config.validate();
+
+    assert!(matches!(result, Err(crate::Error::ConfigValidation(_))));
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("signed_remote") && msg.contains("signature"),
+        "error should name the backend and invalid signature: {msg}"
+    );
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -18,6 +18,7 @@ pub mod data_flow;
 pub mod firewall;
 pub mod message_signing;
 pub mod policy;
+pub mod remote_provenance;
 pub mod response_contract;
 pub mod response_inspect;
 pub mod response_scanner;
@@ -36,6 +37,10 @@ pub use data_flow::{
     hash_argument,
 };
 pub use policy::{ToolPolicy, ToolPolicyConfig};
+pub use remote_provenance::{
+    RemoteServerProvenanceConfig, RemoteServerSignatureAlgorithm, RemoteServerSigningConfig,
+    TrustedRemoteServerKeyConfig, verify_remote_server_provenance,
+};
 pub use response_scanner::ResponseScanner;
 pub use sanitize::{
     SanitizedResourceMeta, sanitize_json_value, sanitize_optional_json, sanitize_resource_metadata,

--- a/src/security/remote_provenance.rs
+++ b/src/security/remote_provenance.rs
@@ -1,0 +1,145 @@
+//! Remote MCP server provenance and signature verification.
+//!
+//! Capability YAML hash pinning protects local files. Remote MCP backends need a
+//! separate trust boundary because their live server identity can change without
+//! modifying the local capability or gateway config. This module verifies a
+//! signed metadata envelope that binds a backend name, transport, URL, subject,
+//! issuer, and issuance timestamp to a trusted publisher key.
+
+use std::collections::BTreeMap;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// Remote server signature-verification policy.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct RemoteServerSigningConfig {
+    /// Require signed provenance metadata for every enabled HTTP/A2A backend.
+    pub require_for_remote_backends: bool,
+    /// Trusted publisher keys keyed by `key_id`.
+    pub trusted_keys: BTreeMap<String, TrustedRemoteServerKeyConfig>,
+    /// Signed provenance metadata keyed by backend name.
+    pub backends: BTreeMap<String, RemoteServerProvenanceConfig>,
+}
+
+/// Trusted key used to verify remote server provenance signatures.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustedRemoteServerKeyConfig {
+    /// Signature algorithm for this key.
+    pub algorithm: RemoteServerSignatureAlgorithm,
+    /// Base64-encoded raw public key bytes for the selected algorithm.
+    pub public_key: String,
+}
+
+/// Supported remote server provenance signature algorithms.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RemoteServerSignatureAlgorithm {
+    /// Ed25519 over the canonical metadata payload.
+    Ed25519,
+}
+
+/// Signed provenance metadata for a configured remote backend.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteServerProvenanceConfig {
+    /// Stable server identity claim, such as a SPIFFE ID or publisher-owned URI.
+    pub subject: String,
+    /// Publisher or authority that issued this metadata envelope.
+    pub issuer: String,
+    /// Issuance timestamp recorded by the publisher.
+    pub issued_at: String,
+    /// Trusted key identifier used to verify `signature`.
+    pub key_id: String,
+    /// Base64-encoded signature over the canonical metadata payload.
+    pub signature: String,
+}
+
+#[derive(Serialize)]
+struct RemoteServerProvenancePayload<'a> {
+    backend: &'a str,
+    transport: &'a str,
+    url: &'a str,
+    subject: &'a str,
+    issuer: &'a str,
+    issued_at: &'a str,
+}
+
+/// Verify a remote backend's signed provenance metadata.
+///
+/// The signature covers canonical JSON with these fields in order:
+/// `backend`, `transport`, `url`, `subject`, `issuer`, `issued_at`.
+///
+/// # Errors
+///
+/// Returns [`Error::ConfigValidation`] when required metadata is missing,
+/// references an unknown key, contains malformed base64, or has an invalid
+/// signature.
+pub fn verify_remote_server_provenance(
+    backend: &str,
+    transport: &str,
+    url: &str,
+    metadata: &RemoteServerProvenanceConfig,
+    policy: &RemoteServerSigningConfig,
+) -> Result<()> {
+    let key = policy.trusted_keys.get(&metadata.key_id).ok_or_else(|| {
+        Error::ConfigValidation(format!(
+            "remote server provenance for backend '{backend}' references unknown key_id '{}'",
+            metadata.key_id
+        ))
+    })?;
+
+    let payload = RemoteServerProvenancePayload {
+        backend,
+        transport,
+        url,
+        subject: &metadata.subject,
+        issuer: &metadata.issuer,
+        issued_at: &metadata.issued_at,
+    };
+    let payload = serde_json::to_vec(&payload)?;
+
+    match key.algorithm {
+        RemoteServerSignatureAlgorithm::Ed25519 => {
+            verify_ed25519_signature(backend, &payload, &key.public_key, &metadata.signature)
+        }
+    }
+}
+
+fn verify_ed25519_signature(
+    backend: &str,
+    payload: &[u8],
+    public_key: &str,
+    signature: &str,
+) -> Result<()> {
+    let key_bytes = decode_base64_field(backend, "public_key", public_key)?;
+    if key_bytes.len() != 32 {
+        return Err(Error::ConfigValidation(format!(
+            "remote server provenance public_key for backend '{backend}' must decode to 32 bytes"
+        )));
+    }
+
+    let sig_bytes = decode_base64_field(backend, "signature", signature)?;
+    if sig_bytes.len() != 64 {
+        return Err(Error::ConfigValidation(format!(
+            "remote server provenance signature for backend '{backend}' must decode to 64 bytes"
+        )));
+    }
+
+    let public_key = ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, key_bytes);
+    public_key.verify(payload, &sig_bytes).map_err(|_| {
+        Error::ConfigValidation(format!(
+            "remote server provenance signature invalid for backend '{backend}'"
+        ))
+    })
+}
+
+fn decode_base64_field(backend: &str, field: &str, value: &str) -> Result<Vec<u8>> {
+    STANDARD.decode(value).map_err(|e| {
+        Error::ConfigValidation(format!(
+            "remote server provenance {field} for backend '{backend}' is not valid base64: {e}"
+        ))
+    })
+}


### PR DESCRIPTION
## Summary
- add `security.remote_server_signing` for opt-in Ed25519 provenance verification on enabled HTTP/A2A remote backends
- fail closed during config validation when provenance is required, configured but invalid, missing a trusted key, malformed, or tampered
- document the ASI04 boundary honestly: config-time provenance is implemented, while SBOM artifacts, release signing, and live attestation discovery remain residual MIK-3361 work

## Validation
- `git diff --check`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo fmt --all --check`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test provenance -- --nocapture`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --test public_claims_validation -- --nocapture`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo check`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo clippy --all-targets -- -D warnings`
- focused code review: no blocking findings
- focused security re-review: approved after ASI04 overclaim was corrected back to PARTIAL

Linear: MIK-3361