### PR TITLE
chore: add MCP registry metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,3 +53,37 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  publish-mcp-registry:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Set release metadata
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}:${VERSION}"
+          jq --arg version "$VERSION" --arg image "$IMAGE" \
+            '.version = $version
+             | .packages[0].version = $version
+             | .packages[0].identifier = $image' \
+            server.json > server.tmp
+          mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN touch src/main.rs && cargo build --release
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim
 
+LABEL io.modelcontextprotocol.server.name="io.github.MikkoParkkola/mcp-gateway"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \

--- a/server.json
+++ b/server.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.MikkoParkkola/mcp-gateway",
+  "title": "MCP Gateway",
+  "description": "Universal MCP gateway with Meta-MCP discovery, routing, and REST API capabilities.",
+  "repository": {
+    "url": "https://github.com/MikkoParkkola/mcp-gateway",
+    "source": "github",
+    "id": "1141522724"
+  },
+  "websiteUrl": "https://github.com/MikkoParkkola/mcp-gateway#readme",
+  "version": "2.11.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/mikkoparkkola/mcp-gateway:2.11.0",
+      "version": "2.11.0",
+      "runtimeHint": "docker",
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        },
+        {
+          "type": "positional",
+          "value": "--stdio"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add official MCP Registry `server.json` metadata for `io.github.MikkoParkkola/mcp-gateway`.
- Add the required OCI ownership label to the Docker image.
- Publish to the MCP Registry from the Docker workflow on version tags after the GHCR image build completes.

## Validation
- `jq . server.json`
- `npx --yes ajv-cli@5.0.0 validate --strict=false -s /tmp/mcp-server.schema.json -d server.json`
- `/tmp/mcp-publisher validate`
- `actionlint .github/workflows/docker.yml`
- `git diff --check`
- `/opt/homebrew/bin/gitnexus status`

## Notes
- Docker static build check could not run locally because the Docker daemon is not running; CI Docker build is expected to cover this.
- This handles the repo-side official registry metadata for #119. Browser/account-gated mcp.so and Glama/Smithery claim/update steps remain manual.

Refs #119
