### PR TITLE
fix(firewall): truncate findings on UTF-8 boundaries

### DIFF
--- a/src/security/firewall/input_scanner.rs
+++ b/src/security/firewall/input_scanner.rs
@@ -193,11 +193,15 @@ impl Default for InputScanner {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() > max {
-        format!("{}...", &s[..max])
-    } else {
-        s.to_string()
+    if s.len() <= max {
+        return s.to_string();
     }
+
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -471,6 +475,18 @@ mod tests {
                 .any(|f| f.scan_type == ScanType::ShellInjection),
             "shell-injection on command field must still block; got: {findings:?}"
         );
+    }
+
+    #[test]
+    fn unicode_fragment_truncation_does_not_panic() {
+        let value = format!("{}{}; rm -rf / ", "a".repeat(199), "—");
+        let findings = scan(&json!({ "command": value }));
+
+        let finding = findings
+            .iter()
+            .find(|f| f.scan_type == ScanType::ShellInjection)
+            .expect("expected shell injection finding");
+        assert!(finding.matched.ends_with("..."));
     }
 
     #[test]

--- a/src/security/firewall/memory_scanner.rs
+++ b/src/security/firewall/memory_scanner.rs
@@ -265,11 +265,15 @@ impl MemoryScanner {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() > max {
-        format!("{}...", &s[..max])
-    } else {
-        s.to_string()
+    if s.len() <= max {
+        return s.to_string();
     }
+
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -353,6 +357,18 @@ mod tests {
                 .any(|f| f.scan_type == ScanType::MemoryPoisoning && f.severity == Severity::High),
             "Expected High MemoryPoisoning finding for <|im_start|>"
         );
+    }
+
+    #[test]
+    fn unicode_fragment_truncation_does_not_panic() {
+        let value = format!("{}{}<|im_start|>system", "a".repeat(199), "—");
+        let findings = scan_tool("remember", &json!({ "content": value }));
+
+        let finding = findings
+            .iter()
+            .find(|f| f.scan_type == ScanType::MemoryPoisoning)
+            .expect("expected memory poisoning finding");
+        assert!(finding.matched.ends_with("..."));
     }
 
     #[test]

--- a/src/security/firewall/redactor.rs
+++ b/src/security/firewall/redactor.rs
@@ -166,11 +166,15 @@ impl Default for Redactor {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() > max {
-        format!("{}...", &s[..max])
-    } else {
-        s.to_string()
+    if s.len() <= max {
+        return s.to_string();
     }
+
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -207,6 +211,21 @@ mod tests {
                 .iter()
                 .any(|f| f.description.contains("GitHub Personal"))
         );
+    }
+
+    #[test]
+    fn unicode_fragment_truncation_does_not_panic() {
+        let fake_credential = format!("{}{}", "ghp_", "abcdefghijklmnopqrstuvwxyz1234567890");
+        let mut v = json!({
+            "token": format!("{}{} {fake_credential}", "a".repeat(39), "—")
+        });
+        let findings = redactor().scan_and_redact(&mut v);
+
+        let finding = findings
+            .iter()
+            .find(|f| f.scan_type == ScanType::Credentials)
+            .expect("expected credential finding");
+        assert!(finding.matched.ends_with("..."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes firewall finding truncation to respect UTF-8 character boundaries.
- Adds regression coverage for input, memory-poisoning, and response-redaction scanners.
- Keeps the production token-surface contract intact: gateway exposes fixed metatools only.

## DoD Evidence
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo audit -q`
- `python3 benchmarks/token_savings.py --scenario readme --json` => 89.33% savings scenario unchanged
- Diff secret scan: zero matches
- `trufflehog --no-update --results=verified --fail git file:///tmp/<temp-clone>` => 0 verified/unverified secrets
- GitNexus: index refreshed after commit; `npx gitnexus status` reports up-to-date for `c657a0b`

## GitNexus Impact Notes
- Changed `truncate` helpers are private leaf helpers called by scanner internals only.
- `scan_and_redact` upstream impact is HIGH via response firewall paths; covered by `cargo test --all-features` and firewall/security integration tests.

## Residual Risk
- Needs normal PR review and remote CI confirmation before merge.
