### PR TITLE
Trim initialize routing guide keyword dump

### DIFF
--- a/src/gateway/meta_mcp_helpers.rs
+++ b/src/gateway/meta_mcp_helpers.rs
@@ -210,21 +210,20 @@ pub(crate) fn build_discovery_preamble(tool_count: usize, server_count: usize) -
 
 /// Build dynamic routing instructions from capability metadata.
 ///
-/// Groups capabilities by `metadata.category`, listing representative tools
-/// and the union of their tags as search keywords. Returns an empty string
-/// when no capabilities are provided.
+/// Groups capabilities by `metadata.category` and lists representative tools.
+/// Returns an empty string when no capabilities are provided.
 pub(crate) fn build_routing_instructions(
     capabilities: &[crate::capability::CapabilityDefinition],
     capability_backend_name: &str,
 ) -> String {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeMap;
 
     if capabilities.is_empty() {
         return String::new();
     }
 
     // Group tools by category, preserving insertion order via BTreeMap
-    let mut by_category: BTreeMap<String, (Vec<String>, BTreeSet<String>)> = BTreeMap::new();
+    let mut by_category: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
     for cap in capabilities {
         let category = if cap.metadata.category.is_empty() {
@@ -233,13 +232,10 @@ pub(crate) fn build_routing_instructions(
             cap.metadata.category.clone()
         };
 
-        let entry = by_category.entry(category).or_default();
-        entry
-            .0
+        by_category
+            .entry(category)
+            .or_default()
             .push(format!("{}/{}", capability_backend_name, cap.name));
-        for tag in &cap.metadata.tags {
-            entry.1.insert(tag.clone());
-        }
     }
 
     // Also track chains_with hints per category: source_tool -> [downstream_tools]
@@ -252,19 +248,14 @@ pub(crate) fn build_routing_instructions(
 
     let mut lines = vec!["\nRouting Guide (by task type):".to_string()];
 
-    for (category, (tools, tags)) in &by_category {
-        let tool_sample = tools.iter().take(3).cloned().collect::<Vec<_>>().join(", ");
-        let suffix = if tools.len() > 3 {
-            format!(" (+{})", tools.len() - 3)
+    for (category, tools) in &by_category {
+        let tool_sample = tools.iter().take(2).cloned().collect::<Vec<_>>().join(", ");
+        let suffix = if tools.len() > 2 {
+            format!(" (+{})", tools.len() - 2)
         } else {
             String::new()
         };
         lines.push(format!("- {category}: {tool_sample}{suffix}"));
-
-        if !tags.is_empty() {
-            let tag_list = tags.iter().cloned().collect::<Vec<_>>().join(", ");
-            lines.push(format!("  Search keywords: {tag_list}"));
-        }
     }
 
     if !chains.is_empty() {

--- a/src/gateway/meta_mcp_helpers_tests.rs
+++ b/src/gateway/meta_mcp_helpers_tests.rs
@@ -405,7 +405,7 @@ fn routing_instructions_groups_by_category() {
 }
 
 #[test]
-fn routing_instructions_includes_tags_as_keywords() {
+fn routing_instructions_omits_per_category_search_keywords() {
     let caps = vec![make_capability_def(
         "brave_search",
         "search",
@@ -413,12 +413,47 @@ fn routing_instructions_includes_tags_as_keywords() {
     )];
     let result = build_routing_instructions(&caps, "fulcrum");
     assert!(result.contains("search"));
-    assert!(result.contains("web"));
-    assert!(result.contains("brave"));
+    assert!(result.contains("fulcrum/brave_search"));
+    assert!(!result.contains("Search keywords:"));
+    assert!(!result.contains("web"));
 }
 
 #[test]
-fn routing_instructions_truncates_tools_to_three_per_category() {
+fn routing_instructions_dense_catalog_stays_below_initialize_budget() {
+    let mut caps = Vec::new();
+    for category_index in 0..40 {
+        for tool_index in 0..10 {
+            caps.push(make_capability_def(
+                &format!("tool_{category_index}_{tool_index}_with_long_descriptive_name"),
+                &format!("category_{category_index}"),
+                &[
+                    "aggregator",
+                    "astronomy",
+                    "biodiversity",
+                    "climate",
+                    "forecast",
+                    "historical",
+                    "observation",
+                    "temperature",
+                    "weather",
+                    "workflow",
+                ],
+            ));
+        }
+    }
+
+    let result = build_routing_instructions(&caps, "fulcrum");
+
+    assert!(
+        result.len() < 6_000,
+        "routing guide was {} bytes",
+        result.len()
+    );
+    assert!(!result.contains("Search keywords:"));
+}
+
+#[test]
+fn routing_instructions_truncates_tools_to_two_per_category() {
     let caps = vec![
         make_capability_def("tool_a", "search", &[]),
         make_capability_def("tool_b", "search", &[]),
@@ -426,7 +461,7 @@ fn routing_instructions_truncates_tools_to_three_per_category() {
         make_capability_def("tool_d", "search", &[]),
     ];
     let result = build_routing_instructions(&caps, "fulcrum");
-    assert!(result.contains("(+1)"), "Should show overflow count");
+    assert!(result.contains("(+2)"), "Should show overflow count");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove redundant per-category Search keywords lines from initialize routing instructions
- Keep compact category samples and preserve Composition chains
- Add regression coverage for keyword omission and <6KB dense routing guide budget

## Validation
- cargo fmt --check
- git diff --check
- cargo test --quiet
- cargo clippy --all-targets -- -D warnings

Linear: MIK-3504