### PR TITLE
fix(claims): sync capability_count 112 to 113 (knowledge YAML drift)

### DIFF
--- a/benchmarks/public_claims.json
+++ b/benchmarks/public_claims.json
@@ -1,11 +1,11 @@
 {
-  "last_verified": "2026-04-22",
+  "last_verified": "2026-05-19",
   "meta_tools": {
     "minimum": 14,
     "readme_benchmark": 16,
     "with_webhook_status": 17
   },
-  "capability_count": 112,
+  "capability_count": 113,
   "startup_benchmark": {
     "command": "hyperfine --shell=none --warmup 3 --runs 20 'target/release/mcp-gateway --help'",
     "mean_ms": 8.0,

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -1,6 +1,6 @@
 # MCP Gateway Built-in Capabilities
 
-mcp-gateway currently ships **112 built-in capabilities** (marketed publicly as **110+**), derived from the tracked YAML inventory under `capabilities/` excluding `examples/`.
+mcp-gateway currently ships **113 built-in capabilities** (marketed publicly as **110+**), derived from the tracked YAML inventory under `capabilities/` excluding `examples/`.
 
 ## Categories
 
@@ -13,7 +13,7 @@ mcp-gateway currently ships **112 built-in capabilities** (marketed publicly as 
 | **food/** | 1 |
 | **google/** | 21 |
 | **infrastructure/** | 1 |
-| **knowledge/** | 15 |
+| **knowledge/** | 16 |
 | **linear/** | 13 |
 | **media/** | 10 |
 | **productivity/** | 25 |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -15,7 +15,7 @@ Public quantitative claims are tracked in [benchmarks/public_claims.json](../ben
 | Claim | Value | Source |
 |------|-------|--------|
 | Meta-tools exposed to the AI | 14 minimum / 16 README benchmark / 17 with webhook status | `benchmarks/public_claims.json` |
-| Built-in capability YAMLs | 112 total (marketed as 110+) | `benchmarks/public_claims.json` + `find capabilities -name '*.yaml' -not -path '*/examples/*' \| wc -l` |
+| Built-in capability YAMLs | 113 total (marketed as 110+) | `benchmarks/public_claims.json` + `find capabilities -name '*.yaml' -not -path '*/examples/*' \| wc -l` |
 | Startup time | ~8ms | `hyperfine --shell=none --warmup 3 --runs 20 'target/release/mcp-gateway --help'` |
 | README token-savings scenario | 100 tools → ~1600 gateway tokens → **89% savings** | `python benchmarks/token_savings.py --scenario readme` |
 

--- a/docs/COMMUNITY_REGISTRY.md
+++ b/docs/COMMUNITY_REGISTRY.md
@@ -6,7 +6,7 @@ Share, discover, and install capability definitions from the community.
 
 ### From the Built-in Registry
 
-All 110+ built-in capabilities ship with mcp-gateway. The exact tracked inventory is currently 112 YAMLs. Browse what is available:
+All 110+ built-in capabilities ship with mcp-gateway. The exact tracked inventory is currently 113 YAMLs. Browse what is available:
 
 ```bash
 # List everything


### PR DESCRIPTION
## Summary

4-file atomic update to sync canonical capability inventory:

- `benchmarks/public_claims.json` — capability_count 112 → 113, last_verified bumped
- `capabilities/README.md` — top line 112 → 113, knowledge row 15 → 16
- `docs/COMMUNITY_REGISTRY.md` — "currently 112 YAMLs" → 113
- `docs/BENCHMARKS.md` — "112 total" → 113

## Root cause

`knowledge/` category gained 1 YAML since last claim audit. The `public_claims_validation` CI test caught the drift cleanly — exactly the failure mode that test was built for.

## Marketed floor unchanged

113 / 10 * 10 = 110, so "marketed publicly as 110+" stays accurate. Only the exact-inventory lines moved.

## Test plan
- [x] `cargo test --test public_claims_validation` → 7/7 PASS (was 5/7 with 2 capability-count tests failing)
- [x] Manually verified each per-category count via `fd -e yaml -t f . capabilities/ -E '*/examples/*'`

## Linked
- MIK-4390 (public-repo health sweep) — clears 2nd of 3 red flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
