### PR TITLE
ci(release): enable npm trusted publishing + provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,9 @@ jobs:
   npm-publish:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write     # OIDC for npm trusted publishing + provenance attestation
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -213,9 +216,12 @@ jobs:
           echo "Setting npm version to ${VERSION}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC trusted publishing + provenance)
         working-directory: npm
-        run: npm publish --access public
+        # npm CLI auto-detects OIDC when id-token:write is granted and a trusted
+        # publisher is configured on npmjs.com for @mikkoparkkola/mcp-gateway.
+        # NODE_AUTH_TOKEN remains as fallback until trusted publishing is enabled.
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

npmjs recommends OIDC-based trusted publishing over long-lived tokens. This PR adds `id-token: write` to the npm-publish job and switches to `npm publish --provenance`.

- npm CLI auto-detects OIDC when both: id-token:write is granted (this PR) AND a trusted publisher is configured on npmjs.com for the package
- NODE_AUTH_TOKEN env var stays as fallback during the transition so nothing breaks before the trusted publisher is configured
- Provenance attaches a signed attestation linking each published package to the exact GitHub Actions run that built it (`npm audit signatures` verifies)

## Manual one-time config on npmjs.com (required before NPM_TOKEN can be removed)

1. https://www.npmjs.com/package/@mikkoparkkola/mcp-gateway/access
2. Trusted Publisher -> GitHub Actions
3. Repository: MikkoParkkola/mcp-gateway
4. Workflow filename: release.yml
5. Environment name: (leave blank)

## AC

- AC.NPM.1: npm-publish job has permissions.id-token = write
- AC.NPM.2: publish command uses --provenance flag
- AC.NPM.3: NODE_AUTH_TOKEN remains during transition (no regression vs PR #201)
- AC.NPM.4: after trusted publisher config on npmjs.com, next release publishes with OIDC; provenance shows on https://www.npmjs.com/package/@mikkoparkkola/mcp-gateway page
- AC.NPM.5: once OIDC verified live, NPM_TOKEN repo secret can be deleted in a follow-up

## ROI

- Value: removes long-lived publish credential (eliminates rotation, scope creep, token leak blast radius); npm provenance gives consumers cryptographic build provenance
- Cost: 8 LoC + one npmjs.com web form
- Fail-fast: NODE_AUTH_TOKEN fallback keeps token-based publish working until trusted publisher is configured
