### PR TITLE
ci(release): drop NPM_TOKEN fallback now that trusted publishing is live

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,12 +218,10 @@ jobs:
 
       - name: Publish to npm (OIDC trusted publishing + provenance)
         working-directory: npm
-        # npm CLI auto-detects OIDC when id-token:write is granted and a trusted
-        # publisher is configured on npmjs.com for @mikkoparkkola/mcp-gateway.
-        # NODE_AUTH_TOKEN remains as fallback until trusted publishing is enabled.
+        # Trusted publisher is configured on npmjs.com for
+        # @mikkoparkkola/mcp-gateway against this workflow. npm CLI auto-detects
+        # OIDC via id-token:write — no NODE_AUTH_TOKEN required.
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   homebrew-update:
     needs: release


### PR DESCRIPTION
## Summary
- Trusted publisher for `@mikkoparkkola/mcp-gateway` is configured on npmjs.com against `.github/workflows/release.yml`.
- OIDC + `id-token: write` is sufficient for `npm publish --provenance`.
- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` was kept transiently during the cutover (PR #202) and is now redundant.

## Why
- Long-lived `NPM_TOKEN` is a standing credential we no longer need.
- Recovery keys for the trusted publisher are stored in 1Password.
- Reduces blast radius: removing the token fallback means the only path to publish is via the GitHub Actions OIDC trust, which is per-workflow-file.

## Follow-up
- After the next release publishes cleanly via OIDC: `gh secret delete NPM_TOKEN --repo MikkoParkkola/mcp-gateway` and archive the 1Password backup as deprecated.

## Test plan
- [ ] CI green on this PR
- [ ] Next tag push (`v2.13.x`) publishes to npm via OIDC with provenance attestation
- [ ] `npm view @mikkoparkkola/mcp-gateway` shows the new version with a valid provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)