### PR TITLE
docs(MIK-4696): add "vs Anthropic MCP Tunnels" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ The base discovery quartet (`gateway_list_servers`, `gateway_list_tools`, `gatew
 | **Kong / Portkey** | General API gateways | Not MCP-aware. No meta-tool discovery, no tool search, no capability YAML system. |
 | **Building fewer MCP servers** | Reduce tool count manually | You lose capabilities. Gateway lets you keep everything and pay the token cost of the compact Meta-MCP surface. |
 
+## vs Anthropic MCP Tunnels
+
+On 2026-05-19 Anthropic shipped [Claude Managed Agents](https://claude.com/blog/claude-managed-agents-updates) with self-hosted sandboxes (public beta) and [MCP tunnels](https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview) (research preview). MCP tunnels let a Claude agent reach a single MCP server inside a private network through one outbound connection from a lightweight gateway -- no inbound firewall rules, no public endpoint, encrypted end-to-end.
+
+mcp-gateway and Anthropic's MCP tunnel sit at **different layers** and **compose**. The tunnel is reachability plumbing for **one** private MCP server. mcp-gateway is the aggregation, routing, capability-namespacing and observability layer across many MCP and REST backends. When both are deployed, **mcp-gateway becomes the private MCP server that Anthropic's tunnel exposes** -- one tunnel, one outbound connection, every backend behind it.
+
+| Concern | Anthropic MCP tunnel | mcp-gateway | Boundary |
+|---|---|---|---|
+| **Backend topology** | Single MCP server per tunnel, exposed through one outbound connection ([overview](https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview)) | N-backend aggregation: 110+ REST capabilities + multiple MCP backends behind a compact 14-16 tool Meta-MCP surface (`src/gateway/`, `capabilities/*.yaml`) | Different primitive: 1-server reachability vs many-backend aggregation |
+| **Tool routing** | Opaque pass-through; the agent sees whatever tool list the tunneled server publishes | Capability namespacing + dynamic `gateway_search_tools` / `gateway_invoke` discovery (`src/gateway/`); SHA-256 pinning per capability (`src/capability/hash.rs`) | Different layer: transport reachability vs tool-surface curation and integrity |
+| **Observability** | Per-tunnel session telemetry from Anthropic's side | Unified `trace_id` and cost-accounting across every backend invocation (`src/cost_accounting/`, `src/gateway/`) | Scope distinction: per-tunnel session vs cross-backend trace correlation |
+
+**Complementary, not a replacement.** A team that wants Claude Managed Agents to reach a private-network deployment of mcp-gateway uses the tunnel for reachability and mcp-gateway for fan-out, capability hygiene, OWASP Agentic AI controls ([docs/OWASP_AGENTIC_AI_COMPLIANCE.md](docs/OWASP_AGENTIC_AI_COMPLIANCE.md)), and unified cost / trace telemetry. The two solve adjacent problems.
+
 ## Security
 
 Connecting N MCP servers to an agent means accepting N attack surfaces. Tool poisoning, rug pulls, and exfiltration via hidden instructions in tool descriptions are demonstrated attacks, not hypotheticals. Invariant Labs' writeup ([MCP Security Notification: Tool Poisoning Attacks](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks)) and Simon Willison's summary ([MCP has prompt injection security problems](https://simonwillison.net/2025/Apr/9/mcp-prompt-injection/)) lay out the threat model.
@@ -536,6 +550,7 @@ Reference: [Anthropic SKILL.md spec](https://docs.claude.com/en/docs/claude-code
 | [Benchmarks](docs/BENCHMARKS.md) | Performance measurements |
 | [Changelog](CHANGELOG.md) | Release history |
 | [OWASP Agentic AI Compliance](docs/OWASP_AGENTIC_AI_COMPLIANCE.md) | Risk coverage matrix |
+| [vs Anthropic MCP Tunnels](#vs-anthropic-mcp-tunnels) | Where mcp-gateway and Anthropic's MCP tunnel compose (different layers, complementary) |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Positions mcp-gateway relative to Anthropic's MCP tunnels (research preview, shipped 2026-05-19 in [Claude Managed Agents](https://claude.com/blog/claude-managed-agents-updates)) as a complementary, different-layer primitive. Tunnel = reachability for one private MCP server. mcp-gateway = N-backend aggregation, capability namespacing, unified `trace_id`. The two compose: mcp-gateway becomes the private MCP server that the tunnel exposes.

Linear: [MIK-4696](https://linear.app/parm/issue/MIK-4696)

## Changes

- `README.md` +14 lines: new `## vs Anthropic MCP Tunnels` section after the existing `### Why not...` table (README.md:68-82) with a 3-row comparison matrix (backend topology, tool routing, observability) and an explicit coexistence paragraph.
- `README.md` +1 line: documentation-index callout linking to the new section (README.md:553).

## Acceptance Criteria

- [x] **MIK-4696.MCPGW.1** -- README "vs Anthropic MCP Tunnels" section with 3-row comparison matrix covering (1) single-server tunnel vs N-backend aggregation, (2) opaque routing vs capability namespacing, (3) per-tunnel observability vs unified `trace_id`. V: README.md:68-82 (`## vs Anthropic MCP Tunnels` section + table rows "Backend topology", "Tool routing", "Observability").
- [x] **MIK-4696.MCPGW.2** -- Coexistence stated explicitly as complementary, not competitive replacement. V: README.md:71 ("mcp-gateway becomes the private MCP server that Anthropic's tunnel exposes -- one tunnel, one outbound connection, every backend behind it") and README.md:81 ("Complementary, not a replacement").
- [x] **MIK-4696.MCPGW.3** -- Documentation index entry linking to the new section. V: README.md:553 (`| [vs Anthropic MCP Tunnels](#vs-anthropic-mcp-tunnels) | Where mcp-gateway and Anthropic's MCP tunnel compose ... |`).
- [x] **MIK-4696.MCPGW.4** -- Both Anthropic citations correct. V: README.md:70 links to https://claude.com/blog/claude-managed-agents-updates (blog) and https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview (tunnels overview); the latter is re-cited inside the matrix row for "Backend topology" (README.md:74).

## Tone audit

PUBLIC-TONE compliant. No forbidden words (`competitive moat`, `beat`, `crush`, `destroy`, `outperform`, `superior`, `kill`, `dominant`). Uses approved framing: "different layers", "different primitive", "scope distinction", "complementary".

## Test plan

- [ ] Render README.md on GitHub; verify the new section appears between `### Why not...` and `## Security`, table renders with 4 columns, and the in-page `#vs-anthropic-mcp-tunnels` anchor link in the Documentation index resolves.
- [ ] Confirm external links resolve: https://claude.com/blog/claude-managed-agents-updates and https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview.
- [ ] CI green (no Rust changes; markdown-only).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>