### PR TITLE
fix(linear_get_issue): set cache ttl to 0 (claim protocol read-after-write)

### DIFF
--- a/capabilities/linear/linear_get_issue.yaml
+++ b/capabilities/linear/linear_get_issue.yaml
@@ -79,7 +79,11 @@ providers:
 
 cache:
   strategy: exact
-  ttl: 30
+  # ttl: 0 — Symphony+ claim protocol (symphony-plus#111) re-fetches the
+  # issue immediately after posting a claim marker to verify it won.
+  # A non-zero cache returns the stale pre-post state and breaks every
+  # paired/pool dispatch with 'claim marker not visible after post'.
+  ttl: 0
 
 metadata:
   category: productivity


### PR DESCRIPTION
Symphony+'s claim protocol posts a marker via `linear_create_comment` then re-fetches via `linear_get_issue` to verify it won the comment-timeline race. With `ttl: 30` the re-fetch returns stale pre-post issue JSON, the marker is not in the comments, `verify_claim` returns `Missing`, and every paired/pool dispatch aborts with 'claim marker not visible after post (replication lag?)'.

Setting `ttl: 0` fixes the read-after-write hole. Per-call cost on Linear's API is negligible.