### PR TITLE
ci: least-privilege permissions on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to ci.yml. Clears the CodeQL `actions/missing-workflow-permissions` alerts for this workflow. Read-only is sufficient — CI only builds and tests.

release.yml/docker.yml deliberately untouched: their sensitive jobs already declare per-job permissions, and a blanket top-level block there could under-privilege the publish/homebrew jobs. Tracked separately.