### PR TITLE
ci(release): upgrade npm CLI before OIDC trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,10 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 20 bundles npm 10.x; OIDC trusted publishing requires npm >= 11.5.1.
+      - name: Upgrade npm CLI for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Sync npm package version to git tag
         working-directory: npm
         run: |


### PR DESCRIPTION
## Summary
- npm-publish job ships Node 20, whose bundled npm 10.x is too old for OIDC trusted publishing (requires npm >= 11.5.1).
- v2.12.1 published cleanly to crates.io, GitHub, and Homebrew, but npm stayed at 2.12.0: provenance signed OK, then the registry PUT returned E404 because the old CLI could not complete the OIDC handshake.
- Adds `npm install -g npm@latest` after setup-node so publish runs on a compatible CLI.

Pairs with the GitHub Actions trusted-publisher policy now registered on npmjs.com for `@mikkoparkkola/mcp-gateway` against `release.yml`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, re-run release: `gh workflow run release.yml -f tag=v2.12.1`
- [ ] Confirm `npm dist-tags` latest advances to 2.12.1