### PR TITLE
security: fix CodeQL alerts (cleartext token storage + workflow permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Version tag (e.g., v2.0.1)'
         required: true
 
+# Least-privilege default for all jobs (CodeQL actions/missing-workflow-permissions).
+# Jobs needing more (release, publish, npm-publish) override locally.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/src/gateway/ui/index.html
+++ b/src/gateway/ui/index.html
@@ -479,7 +479,9 @@ tr:hover td { background: var(--bg3); }
 
 <script>
 // Auth
-let apiKey = localStorage.getItem('mcpgw_key') || '';
+let apiKey = ''; // held in memory only for this session; never persisted to
+                 // web storage (a Bearer token in localStorage is readable by
+                 // any XSS and survives on disk — re-enter on reload instead).
 const authDot = document.getElementById('auth-dot');
 const authLabel = document.getElementById('auth-label');
 const authBtn = document.getElementById('auth-btn');
@@ -507,8 +509,6 @@ authBtn.addEventListener('click', (e) => {
   const key = prompt('Enter API key (Bearer token):');
   if (key !== null) {
     apiKey = key.trim();
-    if (apiKey) localStorage.setItem('mcpgw_key', apiKey);
-    else localStorage.removeItem('mcpgw_key');
     updateAuthUI();
     refreshAll();
   }


### PR DESCRIPTION
Fixes the open CodeQL alerts on mcp-gateway (our most-popular public repo).

## js/clear-text-storage-of-sensitive-data (error)
src/gateway/ui/index.html stored the Bearer API key in localStorage, which is XSS-readable and persists on disk. Now held in memory only for the session (re-enter on reload). No web-storage of the token remains.

## actions/missing-workflow-permissions (4 warnings)
release.yml jobs (verify, build, publish, homebrew-update) had no permissions block. Added a top-level least-privilege default: contents read. The release job keeps contents write; npm-publish keeps id-token write; publish uses CARGO_REGISTRY_TOKEN and homebrew-update uses a tap PAT, so contents read suffices for both.

YAML validated. Built in an isolated worktree off origin/main; local uncommitted changes were not touched.

Generated with Claude Code
