### PR TITLE
ci: gate builds + releases on known dependency + image vulnerabilities

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -1,0 +1,36 @@
+# osv-scanner allowlist — the pressure valve for the CI security gate.
+#
+# The gate fails the build on ANY known, fixable vulnerability in the
+# dependency tree. It runs in two places:
+#   - release.yml `security-gate` job -> blocks the crates.io publish (and the
+#     transitively-`needs:`-ed binary/npm/Homebrew jobs) if a vuln is present
+#   - docker.yml  `security-gate` job -> blocks the GHCR image build/push
+#
+# Scope (verified by local run 2026-06-05): Rust crates — osv-scanner reads
+# Cargo.lock and checks every dependency against OSV. The OSV data for Rust is
+# sourced from the RustSec advisory DB, so this overlaps the existing
+# `cargo audit` job in ci.yml; the value here is gating the RELEASE/PUBLISH
+# paths (crates.io publish, GHCR image) that cargo audit does not currently
+# block, not replacing the PR-time cargo audit gate. NOT covered:
+# github-actions advisories (our actions are SHA-pinned, which is itself the
+# mitigation) and Docker base-image OS-layer CVEs (osv-scanner reads lockfiles,
+# not image layers — that is what the trivy image scan in docker.yml covers).
+#
+# Failing on any fixable vuln is intentional: a new build must include the
+# security fixes that are available. Dependabot's `cargo` updater PROPOSES the
+# bump PR; this gate DISPOSES — it refuses to ship until the fix is merged.
+#
+# When a vulnerability has NO upstream fix yet, or is verified unreachable, it
+# would otherwise block every release indefinitely. Add a time-boxed exception
+# here instead of weakening the gate. Each entry MUST carry a reason and an
+# ignoreUntil review date — expired entries re-trigger the gate automatically.
+#
+# Format (https://google.github.io/osv-scanner/configuration/):
+#
+#   [[IgnoredVulns]]
+#   id = "RUSTSEC-2024-0001"
+#   ignoreUntil = 2026-07-01   # review by this date; after it the gate fires again
+#   reason = "No patched release upstream yet; unreachable. Reviewed 2026-06-05 by <who>."
+#
+# Keep this list EMPTY unless a vuln genuinely has no fix. The right fix for a
+# fixable vuln is to bump the dependency, not to ignore it.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,27 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Dependency-vulnerability gate for the image build. ci.yml runs `cargo audit`
+  # on every PR/push; this re-scans the Cargo.lock against OSV so the published
+  # image's Rust deps are gated. Pairs with the trivy step below, which gates the
+  # base-image OS/library CVEs (osv-scanner reads lockfiles, not image layers).
+  # Exceptions are time-boxed in .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block image on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Rust dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   build:
+    needs: security-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,6 +63,30 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
+
+      # Build the image once and load it into the local daemon so trivy can scan
+      # the actual artifact's layers BEFORE anything is pushed. This is the
+      # image half of the vulnerability gate — osv-scanner (above) gates the Rust
+      # deps; trivy gates the base-image OS/library CVEs. The push step reuses the
+      # gha build cache, so the second build is a cache hit, not a rebuild.
+      - name: Build image for vulnerability scan (load locally, no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy image scan (block push on fixable HIGH/CRITICAL CVEs)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,14 +74,18 @@ jobs:
         with:
           context: .
           load: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          # IMAGE_NAME = github.repository carries the original-case owner
+          # (MikkoParkkola); Docker tags must be lowercase, so use a lowercase
+          # literal for the ephemeral local scan tag (the pushed image uses the
+          # metadata-action's already-lowercased tags).
+          tags: ${{ env.REGISTRY }}/mikkoparkkola/mcp-gateway:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy image scan (block push on fixable HIGH/CRITICAL CVEs)
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          image-ref: ${{ env.REGISTRY }}/mikkoparkkola/mcp-gateway:scan
           format: table
           exit-code: "1"
           severity: HIGH,CRITICAL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,30 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Release backstop for the dependency-vulnerability gate. ci.yml runs
+  # `cargo audit` on every PR/push (RustSec advisories); this re-scans the
+  # Cargo.lock against OSV at tag time so a known fixable vuln cannot ship via
+  # the release/publish path, which `cargo audit` does not currently gate. Every
+  # publishing job below is transitively `needs:`-ed to `verify`, which
+  # `needs:` this gate — so the GitHub release, crates.io publish, npm publish,
+  # and Homebrew formula bump all block if a known fixable vuln is present.
+  # Exceptions are time-boxed in .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block release on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Rust dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   verify:
+    needs: security-gate
     runs-on: ubuntu-latest
 
     steps:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# trivy image-scan allowlist — pressure valve for the Docker CVE gate.
+#
+# The `build` job in docker.yml builds the image, scans it with trivy, and only
+# pushes if no FIXABLE HIGH/CRITICAL OS/library CVE is present. Unfixed CVEs (no
+# patched package upstream yet) are ignored via `ignore-unfixed: true`, so a CVE
+# you cannot fix never blocks a release.
+#
+# Add an entry here only to suppress a FIXABLE finding you are explicitly
+# accepting, with a reason + review date. One CVE id per line:
+#   CVE-2024-12345  # accepted: <reason>; review 2026-07-01
+#
+# Keep this empty. The right fix for a fixable base-image CVE is to bump the
+# base image (FROM debian:bookworm-slim -> newer) or the offending package, not
+# ignore it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ FROM debian:bookworm-slim
 
 LABEL io.modelcontextprotocol.server.name="io.github.MikkoParkkola/mcp-gateway"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

Adds a dependency-vulnerability gate (osv-scanner) and an image-layer CVE gate
(trivy) to the **release/publish** paths, which currently ship without a
vulnerability scan in their critical path.

This mirrors the security-gate pattern landed in MikkoParkkola/trvl (PR #141),
adapted for this Rust repo (Cargo.lock + Debian-based image).

## Why

**A:** Audit of the three workflows (`ci.yml`, `docker.yml`, `release.yml`):

- `ci.yml` already runs `cargo audit` (RustSec) on every PR/push, and its
  tag-time `docker` job `needs:` that audit. That PR-time dep gate is **kept
  as-is** — this PR does not touch it.
- `release.yml` `publish` job (`cargo publish` to crates.io) chains
  `verify → build → release → publish`. **None** of those depend on a
  vulnerability scan — the crates.io / npm / Homebrew publish path was ungated.
- `docker.yml` `build` job builds **and pushes** the GHCR image on every push
  to `main` and on tags, with **no** dependency scan and **no** image-layer
  (base-image OS/library CVE) scan. `cargo audit` cannot see Debian base-image
  CVEs.

**I:** Filling those two gaps without duplicating the existing PR-time gate or
weakening it.

## Changes

- `.github/osv-scanner.toml` — empty allowlist (Rust-flavored), documented.
- `.trivyignore` — empty allowlist, documented.
- `release.yml` — new `security-gate` job (osv-scanner, Cargo.lock → OSV);
  `verify` now `needs: security-gate`, so the whole
  `verify → build → release → {publish, npm-publish, homebrew-update}` chain is
  gated.
- `docker.yml` — new `security-gate` job (osv-scanner) that `build` `needs:`;
  `build` restructured to **build → load locally → trivy scan → build+push**.
  Trivy: `severity: HIGH,CRITICAL`, `ignore-unfixed: true`,
  `trivyignores: .trivyignore`, `exit-code: 1`. The push step reuses the gha
  build cache, so it is a cache hit, not a second full build.

### DAG wiring

```
release.yml: security-gate → verify → build → release → {publish, npm-publish, homebrew-update}
docker.yml:  security-gate → build (osv + trivy + push) → publish-mcp-registry
```

## Local verification

**V:** osv-scanner v2.3.8 (matches the pinned action SHA), run from the repo
root:

```
$ osv-scanner --config=.github/osv-scanner.toml --recursive ./
Scanned Cargo.lock file and found 426 packages
No issues found
EXIT_CODE=0
```

426 packages scanned, **0 known vulnerabilities**, exit 0 — the gate passes on
the current tree, nothing is suppressed. Both allowlist files ship empty.

YAML of both touched workflows and the TOML config validate clean.

## Scope notes / follow-ups (not in this PR, to keep it conservative)

- The PR-time `cargo audit` gate in `ci.yml` is intentionally left unchanged.
  osv-scanner here gates the **publish** paths it does not cover; for Rust both
  source RustSec data, so this is gap-filling, not a second redundant PR scanner.
- `ci.yml` also has a tag-time `docker` job that pushes the same image; it is
  already `cargo audit`-gated but has no trivy image scan, and it overlaps
  `docker.yml`'s tag-time push. Consolidating those two image-push paths (and
  adding trivy to the survivor) is a sensible follow-up but is out of scope for
  this gate-only PR.

## Action pins

All actions SHA-pinned with version comments, consistent with the repo
convention:

- `google/osv-scanner-action/osv-scanner-action@9a49870…` # v2.3.8
- `aquasecurity/trivy-action@a9c7b0f…` # v0.36.0
- `docker/setup-buildx-action@d7f5e7f…` # v4.1.0 (already in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
