### PR TITLE
fix: stdio logs to stderr (#224) + graceful tool list (#225) — v2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.2] - 2026-06-08
+
+### Fixed
+
+- **stdio logs corrupted the JSON-RPC stream** (#224): `serve --stdio` wrote tracing output to stdout, interleaving log lines (with ANSI escapes) among the newline-delimited JSON-RPC frames and breaking MCP clients such as Claude Desktop. `setup_tracing` now writes all log output to stderr regardless of mode, so stdout carries protocol only. Added a regression test that spawns `serve --stdio` and asserts every stdout line is valid JSON. Thanks to @robn for the report and the `strace` diagnosis.
+- **`tool list` hard-failed on a missing capability directory** (#225): the command errored with "Capabilities directory does not exist" when its local capability-YAML directory was absent, and its naming implied it reflected the running gateway's config (it does not — it ignores `-c gateway.yaml` and `capabilities.enabled`). `tool list` now degrades gracefully (empty catalogue, exit 0) with a one-line note clarifying it scans a local catalogue independent of server config; the `--help` text and command description were corrected to match. Thanks to @robn for the report.
+
 ## [2.12.1] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "2.12.1"
+version = "2.12.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -547,11 +547,15 @@ pub enum ToolCommand {
         format: OutputFormat,
     },
 
-    /// List all available tools with descriptions
+    /// List tools from a local capability catalogue
     ///
-    /// Scans the capabilities directory and prints each tool with its
-    /// description and authentication requirement.
-    #[command(about = "List all available tools")]
+    /// Scans a local directory of capability YAML files (default
+    /// `./capabilities`, or `MCP_GATEWAY_CAPABILITIES`) and prints each tool
+    /// with its description and authentication requirement. This is a local
+    /// catalogue scan and is independent of your server config: it does not
+    /// reflect `-c gateway.yaml` or `capabilities.enabled`. A configured
+    /// gateway exposes its tools over MCP at runtime, not via this command.
+    #[command(about = "List tools from a local capability catalogue")]
     List {
         /// Directory containing capability YAML definitions
         #[arg(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -360,6 +360,22 @@ pub async fn run_tool_command(cmd: ToolCommand) -> ExitCode {
 
 async fn tool_list(capabilities: std::path::PathBuf, format: OutputFormat) -> ExitCode {
     let dir = capabilities.to_string_lossy();
+    // `tool list` scans a *local* capability-YAML directory. It is independent
+    // of the running gateway's `-c gateway.yaml` config (including
+    // `capabilities.enabled`), which controls the server, not this CLI scan.
+    // When the directory is absent, report an empty catalogue with a one-line
+    // explanation rather than hard-failing (see issue #225); the `discover`
+    // path already degrades this way for the same condition.
+    if !capabilities.exists() {
+        eprintln!(
+            "No capability catalogue at '{dir}'. `tool list` scans a local directory of \
+             capability YAML files (set -C/--capabilities or MCP_GATEWAY_CAPABILITIES) and is \
+             independent of your server config. A configured gateway exposes its tools over MCP \
+             at runtime, not via this command."
+        );
+        print_tool_list(&[], format);
+        return ExitCode::SUCCESS;
+    }
     match ToolCatalogue::load(&dir).await {
         Ok(cat) => {
             print_tool_list(&cat.list_entries(), format);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,12 @@ pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 
 /// Setup tracing/logging
 ///
+/// All log output is written to **stderr**. In stdio transport mode
+/// (`serve --stdio`) stdout is reserved exclusively for newline-delimited
+/// JSON-RPC frames; emitting logs there corrupts the stream and breaks MCP
+/// clients (see issue #224). Writing to stderr is also correct for the HTTP
+/// server mode, where supervisors (systemd, Docker) capture stderr normally.
+///
 /// # Errors
 ///
 /// This function currently always succeeds but returns `Result` for
@@ -97,10 +103,14 @@ pub fn setup_tracing(level: &str, format: Option<&str>) -> Result<()> {
 
     match format {
         Some("json") => {
-            subscriber.with(fmt::layer().json()).init();
+            subscriber
+                .with(fmt::layer().json().with_writer(std::io::stderr))
+                .init();
         }
         _ => {
-            subscriber.with(fmt::layer()).init();
+            subscriber
+                .with(fmt::layer().with_writer(std::io::stderr))
+                .init();
         }
     }
 

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -444,3 +444,125 @@ async fn test_stdio_notification_cancelled_has_no_id_and_would_be_skipped() {
         "Method must match the notification prefix"
     );
 }
+
+// ============================================================================
+// Regression test for issue #224
+//
+// In `serve --stdio` mode, stdout is reserved exclusively for newline-delimited
+// JSON-RPC frames. Log output must go to stderr. Before the fix, `setup_tracing`
+// used `fmt::layer()` whose default writer is stdout, so startup log lines
+// (e.g. "Starting MCP Gateway (stdio mode)", with ANSI escapes) were
+// interleaved with protocol frames and broke MCP clients.
+//
+// This test spawns the real binary, sends one `initialize` request, and asserts
+// that every non-empty line on stdout parses as JSON. A leaked log line would
+// fail that parse.
+// ============================================================================
+
+#[test]
+fn test_stdio_stdout_carries_only_jsonrpc() {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    // Minimal, hermetic config: no backends, so the spawn does not touch the
+    // network or any well-known fallback config location.
+    let mut cfg = tempfile::Builder::new()
+        .suffix(".yaml")
+        .tempfile()
+        .expect("create temp config");
+    std::io::Write::write_all(&mut cfg, b"backends: {}\n").expect("write temp config");
+    let cfg_path = cfg.path().to_path_buf();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
+        .args(["serve", "--stdio", "-c"])
+        .arg(&cfg_path)
+        .env("RUST_LOG", "info") // guarantee startup logs are emitted
+        .env("NO_COLOR", "1") // determinism; logs must still land on stderr
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // Discard stderr: the gateway emits hundreds of startup log lines there.
+        // If we piped stderr without draining it, the OS pipe buffer would fill
+        // and the child would block on the log write before replying on stdout.
+        // Discarding it is also exactly what we want to assert: logs go to
+        // stderr (here, /dev/null), and stdout carries only JSON-RPC.
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mcp-gateway serve --stdio");
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "regression-224", "version": "1.0"}
+        }
+    });
+
+    {
+        let mut stdin = child.stdin.take().expect("stdin handle");
+        writeln!(stdin, "{request}").expect("write initialize request");
+        stdin.flush().ok();
+        // Keep `stdin` open until the response is read: dropping it here would
+        // send EOF and can race the server's read loop shut before it flushes
+        // the (large) initialize response. We hold it, then drop after reading.
+
+        // Read stdout on a worker thread so the main thread can enforce a timeout.
+        let stdout = child.stdout.take().expect("stdout handle");
+        let (tx, rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                match line {
+                    Ok(l) => {
+                        if tx.send(l).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let mut lines: Vec<String> = Vec::new();
+        let deadline = Duration::from_secs(15);
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            match rx.recv_timeout(Duration::from_millis(500)) {
+                Ok(l) => lines.push(l),
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if !lines.is_empty() {
+                        break; // got the response; no need to keep waiting
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = reader.join();
+        drop(stdin);
+
+        let mut saw_response = false;
+        for line in &lines {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let parsed: std::result::Result<serde_json::Value, _> = serde_json::from_str(trimmed);
+            assert!(
+                parsed.is_ok(),
+                "stdout in stdio mode must contain only JSON-RPC frames; found a non-JSON line \
+                 (issue #224 regression): {trimmed:?}"
+            );
+            saw_response = true;
+        }
+        assert!(
+            saw_response,
+            "expected at least one JSON-RPC response line on stdout"
+        );
+    }
+}

--- a/tests/tool_list_tests.rs
+++ b/tests/tool_list_tests.rs
@@ -1,0 +1,41 @@
+//! Integration tests for `mcp-gateway tool list`.
+//!
+//! Regression coverage for issue #225: `tool list` scans a *local* capability
+//! YAML directory and is independent of the running gateway's config. When the
+//! directory is absent it must degrade gracefully (empty catalogue, exit 0)
+//! with a one-line explanation on stderr, rather than hard-failing.
+
+use std::process::Command;
+
+#[test]
+fn test_tool_list_missing_dir_degrades_gracefully() {
+    // A path guaranteed not to exist.
+    let missing = {
+        let mut p = std::env::temp_dir();
+        p.push("mcp-gateway-nonexistent-caps-225");
+        p.push("definitely-not-here");
+        p
+    };
+    assert!(!missing.exists(), "test precondition: path must not exist");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
+        .args(["tool", "list", "-C"])
+        .arg(&missing)
+        .output()
+        .expect("run `mcp-gateway tool list`");
+
+    // Must NOT hard-fail (issue #225 was a non-zero exit on a missing dir).
+    assert!(
+        output.status.success(),
+        "tool list on a missing capability dir should exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The explanation must clarify this is a local scan independent of config.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("independent of your server config"),
+        "expected an orienting message on stderr, got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
Ships **v2.12.2**. Two externally-reported bugs from Rob Norris (@robn), both confirmed at the source.

## #224 — `serve --stdio` corrupts the JSON-RPC stream
`setup_tracing` built the log layer with `fmt::layer()`, whose default writer is **stdout**, and it ran for every subcommand including `serve --stdio`. Log lines (with ANSI escapes) interleaved with the newline-delimited JSON-RPC frames, breaking MCP clients such as Claude Desktop.

**Fix:** route all tracing to **stderr** regardless of mode (`src/lib.rs`). Correct for stdio (stdout = protocol only) and for HTTP/server mode (supervisors capture stderr). Regression test spawns the binary in `serve --stdio`, sends `initialize`, and asserts every stdout line parses as JSON.

## #225 — `tool list` hard-fails on a missing capability dir
`tool list` scans a local capability-YAML directory and is independent of the running gateway's config, but it errored hard when the dir was absent and its naming implied it reflected `-c gateway.yaml` / `capabilities.enabled`.

**Fix:** degrade gracefully (empty catalogue, exit 0) with a one-line orientation note (`src/commands/mod.rs`); corrected `--help` and command description (`src/cli/mod.rs`). Regression test asserts exit 0 + the note on a missing dir.

## Gates
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- new regression tests pass (`tests/stdio_tests.rs`, `tests/tool_list_tests.rs`)

Fixes #224
Fixes #225