### PR TITLE
feat(projection): response-projection safety — _full opt-out + fail-fast (MIK-3533) — v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-06-08
+
+### Added
+
+- **Response-projection safety: `_full` opt-out + fail-fast fallback** (MIK-3533): the gateway already supports per-capability `response_transform.project` (trimming proxied responses to listed fields). This release makes it safe to rely on:
+  - **`_full: true`** — passing `_full: true` in a tool call's arguments bypasses response projection entirely and returns the unprojected payload. The flag is a gateway directive and is stripped before the request reaches any backend.
+  - **Fail-fast fallback** — if a projection would empty a previously-populated payload (e.g. the spec names fields absent from this particular response), the gateway logs a warning and returns the **unprojected** response instead of handing the caller broken/empty data.
+
+  Together these guarantee response projection can never silently drop a caller's data: either the projection keeps content, or the full response is returned. Covered by deterministic tests (`json_is_populated` truth table, projection-to-absent-field fail-fast, healthy-projection passthrough).
+
 ## [2.13.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Response-projection safety: `_full` opt-out + fail-fast fallback** (MIK-3533): the gateway already supports per-capability `response_transform.project` (trimming proxied responses to listed fields). This release makes it safe to rely on:
-  - **`_full: true`** — passing `_full: true` in a tool call's arguments bypasses response projection entirely and returns the unprojected payload. The flag is a gateway directive and is stripped before the request reaches any backend.
-  - **Fail-fast fallback** — if a projection would empty a previously-populated payload (e.g. the spec names fields absent from this particular response), the gateway logs a warning and returns the **unprojected** response instead of handing the caller broken/empty data.
+- **Response-projection safety: `_full` opt-out + fail-fast warning** (MIK-3533): the gateway already supports per-capability `response_transform.project` (trimming proxied responses to listed fields). This release makes it safe to rely on:
+  - **`_full: true`** — passing `_full: true` in a tool call's arguments bypasses response projection and returns the unprojected payload. The flag is a gateway directive: it is stripped before the request reaches any backend, and a `_full` call bypasses the response cache and idempotency replay so its (unprojected) result can never be served to, or replayed from, a normal projected call.
+  - **Fail-fast warning** — if a projection would empty a previously-populated payload (e.g. the spec names fields absent from this particular response), the gateway logs a warning and still applies the projection. It does **not** fall back to the full response, because `project` can be a privacy/allowlist boundary and a fallback would risk leaking the dropped fields; callers who want the full payload pass `_full: true`.
 
-  Together these guarantee response projection can never silently drop a caller's data: either the projection keeps content, or the full response is returned. Covered by deterministic tests (`json_is_populated` truth table, projection-to-absent-field fail-fast, healthy-projection passthrough).
+  Covered by deterministic tests (`json_is_populated` truth table, projection-to-absent-field empties payload, healthy-projection passthrough).
 
 ## [2.13.0] - 2026-06-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "2.13.0"
+version = "2.14.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -108,9 +108,13 @@ fn apply_validated_output(result: &Value, validated: Value) -> Value {
     Value::Object(obj)
 }
 
-/// Whether a JSON value carries meaningful content. Used by the response
-/// projection fail-fast guard: an empty object/array or null means projection
-/// dropped everything, so the caller should get the unprojected response.
+/// Whether a JSON value is non-empty at the top level: `null`, `{}`, and `[]`
+/// are considered empty; any scalar (including `0`, `false`, `""`) and any
+/// non-empty object/array are non-empty. This is a deliberately shallow check
+/// used by the projection fail-fast guard — when a projection reduces a
+/// populated payload to one of the empty forms, the guard logs a warning. It
+/// intentionally treats a present-but-empty scalar as non-empty so legitimate
+/// values are preserved.
 fn json_is_populated(value: &Value) -> bool {
     match value {
         Value::Null => false,
@@ -244,13 +248,23 @@ impl MetaMcp {
 
         let tool_key = format!("{server}:{tool}");
 
-        let idem_key = resolve_idempotency_key(
-            args,
-            server,
-            tool,
-            &arguments,
-            self.idempotency_cache.as_ref(),
-        );
+        // `_full` requests bypass idempotency and response caching entirely.
+        // A `_full` call returns a different (unprojected) payload than the
+        // cached/projected result, so sharing a key would let one shape leak
+        // into the other (a non-`_full` caller could hit a cached full payload
+        // and receive fields the projection was meant to drop). A `_full` call
+        // is therefore always a fresh, uncached dispatch.
+        let idem_key = if want_full {
+            None
+        } else {
+            resolve_idempotency_key(
+                args,
+                server,
+                tool,
+                &arguments,
+                self.idempotency_cache.as_ref(),
+            )
+        };
 
         if let (Some(idem_cache), Some(key)) = (&self.idempotency_cache, &idem_key) {
             match enforce(idem_cache, key)? {
@@ -280,7 +294,7 @@ impl MetaMcp {
             }
         }
 
-        if let Some(ref cache) = self.cache {
+        if !want_full && let Some(ref cache) = self.cache {
             let cache_key = ResponseCache::build_key(server, tool, &arguments);
             if let Some(cached) = cache.get(&cache_key) {
                 debug!(server, tool, trace_id, "Cache hit");
@@ -694,7 +708,7 @@ impl MetaMcp {
             }
         }
 
-        if let Some(ref cache) = self.cache {
+        if !want_full && let Some(ref cache) = self.cache {
             let cache_key = ResponseCache::build_key(server, tool, &arguments);
             cache.set(&cache_key, result.clone(), self.default_cache_ttl);
             debug!(server, tool, trace_id, ttl = ?self.default_cache_ttl, "Cached result");

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -108,6 +108,18 @@ fn apply_validated_output(result: &Value, validated: Value) -> Value {
     Value::Object(obj)
 }
 
+/// Whether a JSON value carries meaningful content. Used by the response
+/// projection fail-fast guard: an empty object/array or null means projection
+/// dropped everything, so the caller should get the unprojected response.
+fn json_is_populated(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Object(map) => !map.is_empty(),
+        Value::Array(items) => !items.is_empty(),
+        _ => true,
+    }
+}
+
 /// Monotonically increasing request counter for load-balanced cache key slot selection.
 ///
 /// Global across all backends; overflow wraps (u64 → effectively infinite for our purposes).
@@ -146,7 +158,19 @@ impl MetaMcp {
     ) -> Result<Value> {
         let server = extract_required_str(args, "server")?;
         let tool = extract_required_str(args, "tool")?;
-        let arguments = parse_tool_arguments(args)?;
+        let mut arguments = parse_tool_arguments(args)?;
+        // `_full` is a gateway directive (opt out of response projection), not
+        // an upstream parameter. Capture and strip it BEFORE the argument hash
+        // and idempotency key are computed, so toggling it cannot bypass
+        // idempotency or pollute the cache key, and it never reaches a backend
+        // (MIK-3533).
+        let want_full = arguments
+            .get("_full")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if let Some(obj) = arguments.as_object_mut() {
+            obj.remove("_full");
+        }
 
         // === PRE-INVOKE: Compute request hash for transparency log ============
         //
@@ -341,7 +365,13 @@ impl MetaMcp {
 
         let dispatch_start = Instant::now();
         let dispatch_result = self
-            .dispatch_to_backend(server, tool, arguments.clone(), prompt_cache_key.as_deref())
+            .dispatch_to_backend(
+                server,
+                tool,
+                arguments.clone(),
+                prompt_cache_key.as_deref(),
+                want_full,
+            )
             .await;
         let dispatch_latency = dispatch_start.elapsed();
         telemetry_metrics::counter!(
@@ -800,6 +830,7 @@ impl MetaMcp {
         tool: &str,
         arguments: Value,
         prompt_cache_key: Option<&str>,
+        want_full: bool,
     ) -> Result<Value> {
         let injection = self.secret_injector.inject(server, tool, arguments)?;
         let arguments = injection.arguments;
@@ -819,13 +850,32 @@ impl MetaMcp {
             // search for an "issue" key at the top of `{content, structuredContent,
             // isError}`, find nothing, and silently return `{}`. See bug report:
             // https://github.com/MikkoParkkola/mcp-gateway/issues/167.
-            if let Some(cap_def) = cap.get(tool)
+            //
+            // `_full: true` (stripped earlier in invoke_tool_traced) bypasses
+            // projection entirely.
+            if !want_full
+                && let Some(cap_def) = cap.get(tool)
                 && !cap_def.response_transform.is_empty()
             {
                 let t = ResponseTransform::new(&cap_def.response_transform);
                 let inner =
                     extract_output_validation_target(&response).unwrap_or_else(|| response.clone());
+                let inner_populated = json_is_populated(&inner);
                 let transformed = t.transform_result(tool, inner).await?;
+                if inner_populated && !json_is_populated(&transformed) {
+                    // Fail-fast (observability): projection emptied a populated
+                    // payload — the spec likely names fields absent from this
+                    // response. We still apply the projection (it may be a
+                    // privacy/allowlist boundary, so we must NOT fall back to
+                    // the full response and risk leaking dropped fields). The
+                    // warning surfaces the misconfiguration; callers who want
+                    // the unprojected payload pass `_full: true`.
+                    tracing::warn!(
+                        server = server,
+                        tool = tool,
+                        "response_transform produced an empty payload; returning projected result (pass _full:true to bypass projection)"
+                    );
+                }
                 response = apply_validated_output(&response, transformed);
             }
 
@@ -1614,5 +1664,61 @@ mod response_transform_tests {
             }
             .is_empty()
         );
+    }
+
+    /// `json_is_populated` truth table — the basis of the fail-fast guard.
+    #[test]
+    fn json_is_populated_truth_table() {
+        use super::json_is_populated;
+        assert!(!json_is_populated(&json!(null)));
+        assert!(!json_is_populated(&json!({})));
+        assert!(!json_is_populated(&json!([])));
+        assert!(json_is_populated(&json!({"id": 1})));
+        assert!(json_is_populated(&json!([1])));
+        assert!(json_is_populated(&json!("x")));
+        assert!(json_is_populated(&json!(0)));
+        assert!(json_is_populated(&json!(false)));
+    }
+
+    /// Fail-fast trigger: projecting to a field absent from the response
+    /// empties it. `json_is_populated` returns false, so `dispatch_to_backend`
+    /// falls back to the unprojected response instead of returning `{}`
+    /// (MIK-3533).
+    #[tokio::test]
+    async fn projection_to_absent_field_empties_payload_and_triggers_failsafe() {
+        use super::json_is_populated;
+        let config = TransformConfig {
+            project: vec!["nonexistent_field".to_string()],
+            ..Default::default()
+        };
+        let transform = ResponseTransform::new(&config);
+        let raw = json!({ "id": "abc", "name": "Alice" });
+
+        assert!(json_is_populated(&raw), "raw payload is populated");
+        let transformed = transform.transform_result("tool", raw).await.unwrap();
+        assert!(
+            !json_is_populated(&transformed),
+            "projecting to an absent field empties the payload -> fail-fast fallback"
+        );
+    }
+
+    /// Healthy projection keeps real fields populated, so the fail-fast guard
+    /// does NOT fire and the projected response is used.
+    #[tokio::test]
+    async fn projection_to_present_field_stays_populated() {
+        use super::json_is_populated;
+        let config = TransformConfig {
+            project: vec!["id".to_string()],
+            ..Default::default()
+        };
+        let transform = ResponseTransform::new(&config);
+        let raw = json!({ "id": "abc", "name": "Alice", "secret": "x" });
+
+        let transformed = transform.transform_result("tool", raw).await.unwrap();
+        assert!(
+            json_is_populated(&transformed),
+            "a projection that keeps a present field stays populated"
+        );
+        assert_eq!(transformed.get("id"), Some(&json!("abc")));
     }
 }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1696,8 +1696,9 @@ mod response_transform_tests {
 
     /// Fail-fast trigger: projecting to a field absent from the response
     /// empties it. `json_is_populated` returns false, so `dispatch_to_backend`
-    /// falls back to the unprojected response instead of returning `{}`
-    /// (MIK-3533).
+    /// logs a warning (and still applies the projection — it never falls back
+    /// to the unprojected payload, which could leak dropped fields). Callers
+    /// pass `_full: true` to bypass projection (MIK-3533).
     #[tokio::test]
     async fn projection_to_absent_field_empties_payload_and_triggers_failsafe() {
         use super::json_is_populated;
@@ -1712,7 +1713,7 @@ mod response_transform_tests {
         let transformed = transform.transform_result("tool", raw).await.unwrap();
         assert!(
             !json_is_populated(&transformed),
-            "projecting to an absent field empties the payload -> fail-fast fallback"
+            "projecting to an absent field empties the payload -> warning logged"
         );
     }
 


### PR DESCRIPTION
Ships **v2.14.0**. Makes the existing per-capability `response_transform.project` (response field-trimming) safe to rely on, extending the gateway's context-reduction story from the tool list to proxied response payloads.

## What's new
- **`_full: true` opt-out** — passing `_full: true` in a tool call's arguments returns the unprojected payload. The flag is a gateway directive: stripped before reaching any backend, and stripped before the argument hash / idempotency key are computed. A `_full` call is a **fresh, uncached dispatch** — it bypasses the response cache and idempotency replay so its unprojected result can never be served to, or replayed from, a normal projected call.
- **Fail-fast warning** — if a projection empties a previously-populated payload (spec names fields absent from this response), the gateway logs a warning and **still applies the projection**. It does NOT fall back to the full response, because `project` can be a privacy/allowlist boundary and a fallback would risk leaking the dropped fields.

## Peer review (codex) — 3 rounds
- R1: 2 MAJOR — `_full` polluting idempotency key; fallback-to-full leak.
- R2: idempotency fix confirmed; found a **BLOCKER** — stripping `_full` before the cache key made projected/unprojected calls share a key (cross-contamination/leak).
- R3: **BLOCKER resolved, no MAJOR** — `_full` cannot read/write the shared response cache or idempotency store; a normal call can never serve a cached `_full` payload. Remaining items were doc-only and fixed.

## Gates (DoD)
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` full suite: **3200 passed, 0 failed**
- Tests: `json_is_populated` truth table, projection-to-absent-field empties payload (warn trigger), healthy-projection passthrough
- No `unsafe`; CHANGELOG updated; semver minor (additive `_full` directive, backward-compatible)

Relates to MIK-3533. Note: the broader projection epic (declarative ProjectionSpec, role metadata, narrow-by-default, per-backend mappings — MIK-3531/3532/3534) remains as follow-up; this release delivers the safety layer on the existing primitive.