### PR TITLE
feat(projection): projection layer foundation types (MIK-3531) — v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-06-08
+
+### Added
+
+- **Projection layer foundation** (MIK-3531, part of the MIK-3530 epic): new `src/projection/` module with the canonical projection vocabulary — `Actor`, `Subject`, `EnvTime`, `Url`, `Body`, a `Projected<T>` wrapper that always preserves the untouched backend payload under `_raw`, a `ProjectionSpec` (declarative canonical-field → source-path mapping), and a `Role` enum (`selector` / `extractor` / `enricher` / `action`, defaulting to `action`). Types and serialization contract only — no behavior change. Subsequent PRs wire `role`/`projection` onto the tool descriptor and add the projection logic that consumes a `ProjectionSpec` (MIK-3532 / MIK-3533 / MIK-3534). Covered by round-trip serialization tests.
+
 ## [2.14.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "2.14.0"
+version = "2.15.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod metrics;
 pub mod mtls;
 pub mod oauth;
 pub mod playbook;
+pub mod projection;
 pub mod protocol;
 pub mod provider;
 pub mod ranking;

--- a/src/projection/mod.rs
+++ b/src/projection/mod.rs
@@ -1,0 +1,25 @@
+//! Projection layer for the gateway proxy surface (MIK-3530).
+//!
+//! The gateway exposes the union of many heterogeneous backend tool surfaces.
+//! The projection layer absorbs that churn by:
+//!
+//! 1. Defining a small **canonical schema** ([`Actor`], [`Subject`],
+//!    [`EnvTime`], [`Url`], [`Body`]) that backend responses can be projected
+//!    onto, always preserving the original payload under `_raw`
+//!    ([`Projected`]).
+//! 2. Tagging tools with a [`Role`] (selector / extractor / enricher / action)
+//!    so discovery can be filtered by intent.
+//!
+//! This module (MIK-3531) provides the foundation types and their
+//! serialization contract. The descriptor wiring (role/projection on the tool
+//! descriptor) and the projection logic that consumes a [`ProjectionSpec`] land
+//! in subsequent PRs (MIK-3532 / MIK-3533 / MIK-3534).
+
+pub mod role;
+pub mod schema;
+
+pub use role::Role;
+pub use schema::{
+    Actor, ActorSpec, Body, BodySpec, EnvTime, EnvTimeSpec, Projected, ProjectionSpec, Subject,
+    SubjectSpec, Url, UrlSpec,
+};

--- a/src/projection/role.rs
+++ b/src/projection/role.rs
@@ -1,0 +1,70 @@
+//! Tool role taxonomy for the projection layer (MIK-3530 / MIK-3531).
+//!
+//! Every gateway-advertised tool can be tagged with the role it plays in an
+//! agent workflow. `list_tools` discovery filtering (MIK-3532) uses this so a
+//! caller can request, for example, only `selector` tools instead of the full
+//! union of backend surfaces.
+
+use serde::{Deserialize, Serialize};
+
+/// The role a tool plays in an agent workflow.
+///
+/// Untagged tools default to [`Role::Action`], which preserves full backward
+/// compatibility: a tool with no declared role behaves exactly as before.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// Finds or lists candidate subjects (e.g. `search`, `list`).
+    Selector,
+    /// Pulls detail for a known subject (e.g. `get`, `read`).
+    Extractor,
+    /// Adds derived or contextual data to a subject (e.g. `enrich`, `annotate`).
+    Enricher,
+    /// Mutates external state (e.g. `create`, `update`, `delete`).
+    ///
+    /// This is the default for untagged tools — the safe assumption is that a
+    /// tool may have side effects.
+    #[default]
+    Action,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Role;
+
+    #[test]
+    fn default_role_is_action() {
+        assert_eq!(Role::default(), Role::Action);
+    }
+
+    #[test]
+    fn role_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&Role::Selector).unwrap(),
+            "\"selector\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Role::Extractor).unwrap(),
+            "\"extractor\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Role::Enricher).unwrap(),
+            "\"enricher\""
+        );
+        assert_eq!(serde_json::to_string(&Role::Action).unwrap(), "\"action\"");
+    }
+
+    #[test]
+    fn role_round_trips() {
+        for role in [
+            Role::Selector,
+            Role::Extractor,
+            Role::Enricher,
+            Role::Action,
+        ] {
+            let json = serde_json::to_string(&role).unwrap();
+            let back: Role = serde_json::from_str(&json).unwrap();
+            assert_eq!(role, back);
+        }
+    }
+}

--- a/src/projection/schema.rs
+++ b/src/projection/schema.rs
@@ -1,0 +1,290 @@
+//! Canonical projection schema (MIK-3530 / MIK-3531).
+//!
+//! The gateway proxies the union of many heterogeneous backend tool surfaces
+//! (linear, github, gws-*, slack, hebb, ...). The same concept wears different
+//! field names across them — an "actor" is `assignee.email` on one backend,
+//! `user.login` on another, `organizer.email` on a third. This module defines a
+//! small canonical vocabulary those shapes can be projected onto so agents see
+//! consistent fields.
+//!
+//! Projection is never lossy: [`Projected`] always pairs the canonical view with
+//! the untouched backend payload under `_raw`.
+//!
+//! This module is the foundation (MIK-3531). It defines the types and their
+//! serialization contract only; the projection *logic* that maps a backend
+//! response onto these shapes via a [`ProjectionSpec`] lands in subsequent PRs
+//! (MIK-3533 / MIK-3534).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A canonical actor: assignee / author / organizer / sender / user.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Actor {
+    /// Stable identifier, if the backend exposes one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Human-readable display name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Email address, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Handle / login / username, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+}
+
+/// A canonical subject: the primary entity a tool result is about (issue, PR,
+/// event, message, ...).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Subject {
+    /// Stable identifier of the subject.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Human-readable title / summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Backend-specific kind (e.g. `issue`, `pull_request`, `event`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+/// Canonical timestamps for an entity. Values are RFC-3339 strings as emitted
+/// by the backend; they are not re-parsed here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvTime {
+    /// Creation timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+    /// Last-updated timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated: Option<String>,
+}
+
+/// A canonical URL: a link plus an optional human-readable label.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Url {
+    /// The link target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
+    /// Optional display label for the link.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// A canonical body: free-text content plus its format hint.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Body {
+    /// The body text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Format hint (e.g. `markdown`, `plain`, `html`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+}
+
+/// A projected canonical view `T` paired with the untouched backend payload.
+///
+/// Projection must never drop data a caller might need, so the original
+/// response is always preserved under `_raw`. The canonical fields of `T` are
+/// flattened alongside `_raw` in the serialized form.
+///
+/// `T` must be a struct/map-like type whose serialized form is a JSON object
+/// (all the canonical views in this module qualify); flattening a scalar or
+/// array view is not supported by serde and is not a valid projection target.
+/// The top-level `_raw` key is reserved for the wrapper — a canonical view must
+/// not itself serialize a field named `_raw`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Projected<T> {
+    /// The canonical projected view.
+    #[serde(flatten)]
+    pub view: T,
+    /// The untouched backend payload.
+    #[serde(rename = "_raw")]
+    pub raw: Value,
+}
+
+impl<T> Projected<T> {
+    /// Wrap a canonical view together with the raw backend payload it was
+    /// derived from.
+    pub fn new(view: T, raw: Value) -> Self {
+        Self { view, raw }
+    }
+}
+
+/// Per-field source paths for projecting an [`Actor`]. Each field is the dotted
+/// JSON path into the backend payload that supplies the corresponding canonical
+/// field (e.g. `email: Some("assignee.email")`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActorSpec {
+    /// Source path for [`Actor::id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Source path for [`Actor::display_name`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Source path for [`Actor::email`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Source path for [`Actor::handle`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+}
+
+/// Per-field source paths for projecting a [`Subject`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectSpec {
+    /// Source path for [`Subject::id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Source path for [`Subject::title`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Source path for [`Subject::kind`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+/// Per-field source paths for projecting [`EnvTime`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvTimeSpec {
+    /// Source path for [`EnvTime::created`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+    /// Source path for [`EnvTime::updated`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated: Option<String>,
+}
+
+/// Per-field source paths for projecting a [`Url`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UrlSpec {
+    /// Source path for [`Url::href`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
+    /// Source path for [`Url::label`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Per-field source paths for projecting a [`Body`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BodySpec {
+    /// Source path for [`Body::text`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Source path for [`Body::format`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+}
+
+/// Declarative, **per-field** mapping from canonical fields to source paths in a
+/// backend response. A `None` bucket means "this backend does not expose that
+/// concept"; within a bucket, a `None` field means that specific canonical
+/// field has no source.
+///
+/// Per-field (rather than per-bucket) mapping is deliberate: the motivating
+/// cases are leaf mappings such as `assignee.email` → [`Actor::email`] and
+/// `user.login` → [`Actor::handle`], which a single path-per-bucket spec could
+/// not express. This is the *specification* consumed by the projection logic in
+/// later PRs; this foundation PR defines the shape and its serialization only.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectionSpec {
+    /// Field mapping for the [`Actor`] bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<ActorSpec>,
+    /// Field mapping for the [`Subject`] bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<SubjectSpec>,
+    /// Field mapping for the [`EnvTime`] bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_time: Option<EnvTimeSpec>,
+    /// Field mapping for the [`Url`] bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<UrlSpec>,
+    /// Field mapping for the [`Body`] bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<BodySpec>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Actor, ActorSpec, Body, EnvTime, Projected, ProjectionSpec, Subject, SubjectSpec, Url,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn empty_canonical_types_serialize_to_empty_objects() {
+        // skip_serializing_if = none means an all-default value is `{}`.
+        assert_eq!(serde_json::to_value(Actor::default()).unwrap(), json!({}));
+        assert_eq!(serde_json::to_value(Subject::default()).unwrap(), json!({}));
+        assert_eq!(serde_json::to_value(EnvTime::default()).unwrap(), json!({}));
+        assert_eq!(serde_json::to_value(Url::default()).unwrap(), json!({}));
+        assert_eq!(serde_json::to_value(Body::default()).unwrap(), json!({}));
+        assert_eq!(
+            serde_json::to_value(ProjectionSpec::default()).unwrap(),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn actor_round_trips() {
+        let actor = Actor {
+            id: Some("u1".into()),
+            display_name: Some("Alice".into()),
+            email: Some("alice@example.com".into()),
+            handle: Some("alice".into()),
+        };
+        let json = serde_json::to_value(&actor).unwrap();
+        let back: Actor = serde_json::from_value(json).unwrap();
+        assert_eq!(actor, back);
+    }
+
+    #[test]
+    fn projected_flattens_view_and_preserves_raw() {
+        let raw = json!({"assignee": {"email": "alice@example.com"}, "extra": 42});
+        let view = Actor {
+            email: Some("alice@example.com".into()),
+            ..Default::default()
+        };
+        let projected = Projected::new(view, raw.clone());
+
+        let serialized = serde_json::to_value(&projected).unwrap();
+        // Canonical field is flattened to the top level...
+        assert_eq!(serialized["email"], json!("alice@example.com"));
+        // ...and the untouched payload is preserved under `_raw`.
+        assert_eq!(serialized["_raw"], raw);
+
+        let back: Projected<Actor> = serde_json::from_value(serialized).unwrap();
+        assert_eq!(back, projected);
+    }
+
+    #[test]
+    fn projection_spec_round_trips() {
+        // Leaf mappings: assignee.email -> Actor.email, user.login -> Actor.handle.
+        let spec = ProjectionSpec {
+            actor: Some(ActorSpec {
+                email: Some("assignee.email".into()),
+                handle: Some("user.login".into()),
+                ..Default::default()
+            }),
+            subject: Some(SubjectSpec {
+                title: Some("issue.title".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "actor": {"email": "assignee.email", "handle": "user.login"},
+                "subject": {"title": "issue.title"}
+            })
+        );
+        let back: ProjectionSpec = serde_json::from_value(json).unwrap();
+        assert_eq!(spec, back);
+    }
+}


### PR DESCRIPTION
Ships **v2.15.0**. First PR of the MIK-3530 projection epic — the foundation types, no behavior change.

## What's new — `src/projection/`
- **Canonical schema**: `Actor`, `Subject`, `EnvTime`, `Url`, `Body` — the small vocabulary heterogeneous backend responses project onto.
- **`Projected<T>`** — wraps a canonical view with the untouched backend payload under `_raw`, so projection is never lossy. Documented contract (object-like `T`, `_raw` reserved).
- **`ProjectionSpec`** — declarative **per-field** canonical→source-path mapping (`ActorSpec`/`SubjectSpec`/…), so leaf mappings like `assignee.email → Actor.email` and `user.login → Actor.handle` are expressible.
- **`Role`** enum (`selector` / `extractor` / `enricher` / `action`, default `action`) for the upcoming `list_tools` role filter (MIK-3532).

## Scope / safety
- **Zero blast radius**: types + serialization contract only, wired into `lib.rs` as `pub mod projection`. Nothing constructs these yet.
- The tool-descriptor extension (`role`/`projection` on `Tool`) is **deliberately deferred** — `Tool` is constructed at ~88 sites, so that's its own focused sweep rather than bundled here.

## Peer review (codex)
No blocker. Codex flagged `ProjectionSpec` being too rigid (one path per bucket) for the leaf-mapping use case — **redesigned to per-field specs as recommended**, and added the `Projected` `_raw`-reserved doc guard.

## Gates (DoD)
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- projection suite: 7 tests (Role default/lowercase/round-trip; canonical round-trips; `Projected` flatten+`_raw`; per-field spec round-trip)
- No `unsafe`; CHANGELOG updated; semver minor (additive module)

Relates to MIK-3530, MIK-3531. Follow-ups: descriptor extension, MIK-3532 (role filter), MIK-3533/3534 (projection logic + per-backend mappings).