### PR TITLE
fix(warmstart): prefetch backend tools in stdio mode too (MIK-4649) — v2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.1] - 2026-06-08
+
+### Fixed
+
+- **Stdio-mode warm-start never prefetched backend tools** (MIK-4649): in `serve --stdio` mode (how Claude Code / Codex connect), warm-start started each backend but **skipped tool prefetch** — that step was gated on HTTP mode only. Subprocess MCP backends (e.g. `codex`) were therefore left with an empty tool cache, and since discovery skips empty-cache backends, their tools never appeared in `gateway_search` / `tools/list`. Tool prefetch now runs in both transport modes. Root-caused empirically against the live gateway: `codex mcp-server` serves `tools/list` fine, but the gateway logged only pings for it and never a tool fetch. Regression test asserts prefetch occurs in both modes.
+
 ## [2.15.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "2.15.0"
+version = "2.15.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/src/gateway/server/warmstart.rs
+++ b/src/gateway/server/warmstart.rs
@@ -28,6 +28,22 @@ pub(super) fn build_warm_start_list(
     )
 }
 
+/// Whether a successful warm-start should immediately prefetch (and cache) the
+/// backend's tool list.
+///
+/// Tool discovery (`gateway_search` / `tools/list`) only surfaces backends with
+/// a populated tool cache; an empty cache is skipped. Subprocess backends
+/// (codex, other stdio command servers) therefore stay invisible unless their
+/// tools are prefetched here. This must happen in **both** transport modes —
+/// the gateway is commonly run via `serve --stdio` (how Claude Code / Codex
+/// connect), and gating prefetch on HTTP-only left every stdio-mode subprocess
+/// backend with zero discoverable tools (MIK-4649).
+const fn warm_start_prefetches_tools(mode: WarmStartMode) -> bool {
+    // Both modes prefetch: stdio-mode subprocess backends were previously left
+    // with empty tool caches and zero discoverable tools (MIK-4649).
+    matches!(mode, WarmStartMode::Http | WarmStartMode::Stdio)
+}
+
 pub(super) fn spawn_warm_start_task(
     backends: &Arc<BackendRegistry>,
     warm_start_list: Vec<String>,
@@ -44,21 +60,22 @@ pub(super) fn spawn_warm_start_task(
             };
 
             match backend.start().await {
-                Ok(()) if matches!(mode, WarmStartMode::Http) => {
-                    match backend.get_tools_shared().await {
-                        Ok(tools) => info!(
-                            backend = %name,
-                            tools = tools.len(),
-                            "Warm-started + tools cached"
-                        ),
-                        Err(e) => warn!(
-                            backend = %name,
-                            error = %e,
-                            "Warm-started but tool prefetch failed"
-                        ),
+                Ok(()) => {
+                    if warm_start_prefetches_tools(mode) {
+                        match backend.get_tools_shared().await {
+                            Ok(tools) => info!(
+                                backend = %name,
+                                tools = tools.len(),
+                                "Warm-started + tools cached"
+                            ),
+                            Err(e) => warn!(
+                                backend = %name,
+                                error = %e,
+                                "Warm-started but tool prefetch failed"
+                            ),
+                        }
                     }
                 }
-                Ok(()) => {}
                 Err(e) if matches!(mode, WarmStartMode::Stdio) => {
                     warn!(backend = %name, error = %e, "Warm-start failed (stdio)");
                 }
@@ -91,7 +108,23 @@ fn resolve_warm_start_names(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_warm_start_names;
+    use super::{WarmStartMode, resolve_warm_start_names, warm_start_prefetches_tools};
+
+    #[test]
+    fn warm_start_prefetches_tools_in_both_modes() {
+        // Tool prefetch must happen regardless of transport mode. Gating it on
+        // HTTP-only left every stdio-mode subprocess backend (e.g. codex) with
+        // an empty tool cache, so its tools never appeared in discovery
+        // (MIK-4649).
+        assert!(
+            warm_start_prefetches_tools(WarmStartMode::Http),
+            "HTTP mode must prefetch tools"
+        );
+        assert!(
+            warm_start_prefetches_tools(WarmStartMode::Stdio),
+            "Stdio mode must prefetch tools (MIK-4649: codex tools were invisible)"
+        );
+    }
 
     #[test]
     fn resolve_warm_start_names_uses_all_backends_when_config_is_empty() {


### PR DESCRIPTION
Ships **v2.15.1**. Fixes MIK-4649 — subprocess MCP backends (e.g. `codex`) exposed **zero** tools despite pinging green.

## Root cause (found empirically against the live gateway)
`spawn_warm_start_task` prefetched a backend's tools **only in HTTP mode** (`Ok(()) if matches!(mode, Http)`); the stdio arm was `Ok(()) => {}` — no prefetch. The gateway runs via `serve --stdio` for Claude Code / Codex, so every subprocess backend was started but left with an **empty tool cache**, and discovery skips empty-cache backends → tools never appear in `gateway_search` / `tools/list`. The in-process `fulcrum` capabilities backend appeared only because its tools load from YAML, not `tools/list` — which is why the bug looked codex-specific.

## Investigation (TDD / fail-fast against the running gateway — two theories falsified)
- `gateway_search "codex"` returned 0 codex tools (RED, live).
- `codex mcp-server` serves initialize + tools/list instantly (`codex`, `codex-reply`).
- Gateway log: codex Registered + Started, then only pinged — never a tool fetch.
- Falsified: subagent "empty-cache fetch logic" (near, but tools are never fetched); "allow_tools codex_* glob" (moot — default profile is `full`).

## Fix
Extracted `warm_start_prefetches_tools(mode)`; prefetch runs in **both** transport modes. Per-backend warm-start is already a background `tokio::spawn`, so it does not block stdio startup (confirmed in review).

## Tests / verification
- TDD unit (RED to GREEN): `warm_start_prefetches_tools_in_both_modes` — written failing against the HTTP-only predicate, then fixed.
- Live behavioral A/B: the fixed binary in stdio mode returns codex tools via `gateway_list_tools(codex)` (status active, `codex` + `codex-reply`); the old binary returned 0.
- Gates: fmt, clippy --all-targets -D warnings, warmstart suite (3) green.

## Peer review (codex)
No blocker, no major. One minor (unit test guards the policy predicate, not full start-to-cache) addressed by the live behavioral A/B.

Fixes MIK-4649. Operators pick this up on the next gateway restart.
