### PR TITLE
feat(descriptor): role + projection on the Tool descriptor (MIK-3531) — v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-06-08
+
+### Added
+
+- **Tool descriptor carries `role` + `projection`** (MIK-3531, completes the foundation): the MCP `Tool` descriptor now has two optional fields — `role` (`selector`/`extractor`/`enricher`/`action`) and `projection` (a `ProjectionSpec`). Both default to `None` and are omitted from the wire for untagged tools, so existing payloads serialize and deserialize byte-for-byte as before. This is the descriptor surface the projection epic consumes: `list_tools` role filtering (MIK-3532) and response projection (MIK-3533/3534) build on it. No behavior change. Serialization-contract tests assert untagged tools omit the fields and pre-existing JSON still parses, and that tagged tools round-trip role + projection.
+
 ## [2.15.1] - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "2.15.1"
+version = "2.16.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "2.15.1"
+version = "2.16.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/benches/gateway_benchmarks.rs
+++ b/benches/gateway_benchmarks.rs
@@ -33,6 +33,8 @@ fn make_tool(name: &str) -> Tool {
         input_schema: json!({"type": "object", "properties": {"arg": {"type": "string"}}}),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 

--- a/examples/validator_demo.rs
+++ b/examples/validator_demo.rs
@@ -24,8 +24,8 @@ fn main() {
         title: Some("GitHub Issue Search".to_string()),
         description: Some(
             "Search and analyze GitHub issues using semantic search with filters. \
-             Use this when you need to find relevant issues, bugs, or feature requests. \
-             Returns a curated list of issues with relevance scores and key metadata."
+         Use this when you need to find relevant issues, bugs, or feature requests. \
+         Returns a curated list of issues with relevance scores and key metadata."
                 .to_string(),
         ),
         input_schema: json!({
@@ -69,6 +69,8 @@ fn main() {
             }
         })),
         annotations: None,
+        role: None,
+        projection: None,
     };
 
     // Example 2: Bad tool design (CRUD operation)
@@ -89,6 +91,8 @@ fn main() {
         }),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     };
 
     // Example 3: Short description
@@ -104,6 +108,8 @@ fn main() {
         }),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     };
 
     // Validate all tools

--- a/src/a2a/translator.rs
+++ b/src/a2a/translator.rs
@@ -81,6 +81,8 @@ pub fn skill_to_tool(skill: &Skill, namespace: &str) -> Tool {
         input_schema: a2a_input_schema(),
         output_schema: None,
         annotations: Some(annotations),
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1091,6 +1091,8 @@ mod tests {
             input_schema: json!({"type": "object"}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/capability/definition/mod.rs
+++ b/src/capability/definition/mod.rs
@@ -922,6 +922,8 @@ impl CapabilityDefinition {
                 Some(self.schema.output.clone())
             },
             annotations: Some(self.tool_annotations()),
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/context_compression.rs
+++ b/src/context_compression.rs
@@ -395,6 +395,8 @@ mod tests {
             input_schema: json!({"type": "object", "properties": {}}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 
@@ -406,6 +408,8 @@ mod tests {
             input_schema: schema,
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/gateway/meta_mcp/spec_preview.rs
+++ b/src/gateway/meta_mcp/spec_preview.rs
@@ -278,6 +278,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         };
         // WHEN: query is a substring of the name
         // THEN: match
@@ -294,6 +296,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         };
         // WHEN: query matches description word
         // THEN: match
@@ -310,6 +314,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         };
         // WHEN: query doesn't match anything
         // THEN: no match
@@ -326,6 +332,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         };
         // WHEN: query is lowercase
         // THEN: case-insensitive match

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -398,6 +398,8 @@ fn search_test_tool(name: &str) -> crate::protocol::Tool {
         input_schema: json!({"type": "object"}),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/gateway/meta_mcp_helpers_chain_tests.rs
+++ b/src/gateway/meta_mcp_helpers_chain_tests.rs
@@ -9,6 +9,8 @@ fn make_tool(name: &str, description: Option<&str>) -> Tool {
         input_schema: json!({"type": "object"}),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/gateway/meta_mcp_helpers_tests.rs
+++ b/src/gateway/meta_mcp_helpers_tests.rs
@@ -11,6 +11,8 @@ fn make_tool(name: &str, description: Option<&str>) -> Tool {
         input_schema: json!({"type": "object"}),
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/gateway/meta_mcp_tool_defs.rs
+++ b/src/gateway/meta_mcp_tool_defs.rs
@@ -30,11 +30,13 @@ fn build_list_servers_tool(server_count: usize) -> Tool {
         title: Some("List Servers".to_string()),
         description: Some(format!(
             "List all {server_count} connected MCP backend servers with their status, \
-             tool count, and circuit-breaker state."
+         tool count, and circuit-breaker state."
         )),
         input_schema: json!({ "type": "object", "properties": {}, "required": [] }),
         output_schema: None,
         annotations: Some(read_only_annotations("List Servers")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -45,8 +47,8 @@ fn build_list_tools_tool(tool_count: usize, server_count: usize) -> Tool {
         title: Some("List Tools".to_string()),
         description: Some(format!(
             "List tools from a specific backend, or omit server to list all {tool_count} tools \
-             across {server_count} backends. Returns names and descriptions — use \
-             gateway_search_tools for ranked results with full schemas."
+         across {server_count} backends. Returns names and descriptions — use \
+         gateway_search_tools for ranked results with full schemas."
         )),
         input_schema: json!({
             "type": "object",
@@ -60,6 +62,8 @@ fn build_list_tools_tool(tool_count: usize, server_count: usize) -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("List Tools")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -94,8 +98,8 @@ fn build_search_tools_tool(tool_count: usize, server_count: usize) -> Tool {
         title: Some("Search Tools".to_string()),
         description: Some(format!(
             "Search {tool_count} tools across {server_count} servers by keyword. Returns ranked \
-             matches with full schemas while avoiding the prompt bloat of loading every tool \
-             definition upfront. Supports multi-word queries and synonym expansion."
+         matches with full schemas while avoiding the prompt bloat of loading every tool \
+         definition upfront. Supports multi-word queries and synonym expansion."
         )),
         input_schema: json!({
             "type": "object",
@@ -107,6 +111,8 @@ fn build_search_tools_tool(tool_count: usize, server_count: usize) -> Tool {
         }),
         output_schema: Some(search_tools_output_schema()),
         annotations: Some(read_only_annotations("Search Tools")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -117,8 +123,8 @@ fn build_invoke_tool() -> Tool {
         title: Some("Invoke Tool".to_string()),
         description: Some(
             "Invoke any tool on any backend server. Routes through the gateway's auth, \
-             rate-limit, caching, and failsafe middleware. Use gateway_search_tools first \
-             to discover the right tool and server."
+         rate-limit, caching, and failsafe middleware. Use gateway_search_tools first \
+         to discover the right tool and server."
                 .to_string(),
         ),
         input_schema: json!({
@@ -138,6 +144,8 @@ fn build_invoke_tool() -> Tool {
             idempotent_hint: Some(false),
             open_world_hint: Some(true),
         }),
+        role: None,
+        projection: None,
     }
 }
 
@@ -163,7 +171,7 @@ pub(crate) fn build_stats_tool() -> Tool {
         title: Some("Get Gateway Statistics".to_string()),
         description: Some(
             "Get usage statistics including invocations, cache hits, \
-             token savings, and top tools"
+         token savings, and top tools"
                 .to_string(),
         ),
         input_schema: json!({
@@ -179,6 +187,8 @@ pub(crate) fn build_stats_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("Get Gateway Statistics")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -208,6 +218,8 @@ pub(crate) fn build_playbook_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_non_idempotent_open_world_annotations("Run Playbook")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -218,7 +230,7 @@ pub(crate) fn build_webhook_status_tool() -> Tool {
         title: Some("Webhook Status".to_string()),
         description: Some(
             "List registered webhook endpoints and their delivery statistics \
-             (received, delivered, failures, last event)"
+         (received, delivered, failures, last event)"
                 .to_string(),
         ),
         input_schema: json!({
@@ -228,6 +240,8 @@ pub(crate) fn build_webhook_status_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("Webhook Status")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -272,7 +286,7 @@ pub(crate) fn build_kill_server_tool() -> Tool {
         title: Some("Kill Server".to_string()),
         description: Some(
             "Immediately disable routing to a backend server (operator kill switch). \
-             The server's tools remain visible in search/list but are marked as disabled."
+         The server's tools remain visible in search/list but are marked as disabled."
                 .to_string(),
         ),
         input_schema: json!({
@@ -287,6 +301,8 @@ pub(crate) fn build_kill_server_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(destructive_idempotent_annotations("Kill Server")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -297,7 +313,7 @@ pub(crate) fn build_revive_server_tool() -> Tool {
         title: Some("Revive Server".to_string()),
         description: Some(
             "Re-enable routing to a previously disabled backend server. \
-             Also resets the error budget so the server gets a clean slate."
+         Also resets the error budget so the server gets a clean slate."
                 .to_string(),
         ),
         input_schema: json!({
@@ -312,6 +328,8 @@ pub(crate) fn build_revive_server_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_idempotent_annotations("Revive Server")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -322,7 +340,7 @@ pub(crate) fn build_set_profile_tool() -> Tool {
         title: Some("Set Routing Profile".to_string()),
         description: Some(
             "Switch the active routing profile for this session. \
-             A routing profile restricts which tools and backends are available."
+         A routing profile restricts which tools and backends are available."
                 .to_string(),
         ),
         input_schema: json!({
@@ -337,6 +355,8 @@ pub(crate) fn build_set_profile_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_idempotent_annotations("Set Routing Profile")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -356,6 +376,8 @@ pub(crate) fn build_get_profile_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("Get Routing Profile")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -370,9 +392,9 @@ pub(crate) fn build_list_disabled_capabilities_tool() -> Tool {
         title: Some("List Disabled Capabilities".to_string()),
         description: Some(
             "List capabilities that have been automatically disabled due to a high error rate. \
-             Each entry shows the backend, capability name, and how long it has been suspended. \
-             Disabled capabilities auto-recover after the configured cooldown period (default 5 min). \
-             Use gateway_revive_server to manually re-enable an entire backend immediately."
+         Each entry shows the backend, capability name, and how long it has been suspended. \
+         Disabled capabilities auto-recover after the configured cooldown period (default 5 min). \
+         Use gateway_revive_server to manually re-enable an entire backend immediately."
                 .to_string(),
         ),
         input_schema: json!({
@@ -382,6 +404,8 @@ pub(crate) fn build_list_disabled_capabilities_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("List Disabled Capabilities")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -392,8 +416,8 @@ pub(crate) fn build_list_profiles_tool() -> Tool {
         title: Some("List Tool Profiles".to_string()),
         description: Some(
             "List all available routing profiles with their descriptions. \
-             Use gateway_set_profile to switch to a profile that narrows \
-             the visible toolset to the current task (e.g. \"coding\", \"research\")."
+         Use gateway_set_profile to switch to a profile that narrows \
+         the visible toolset to the current task (e.g. \"coding\", \"research\")."
                 .to_string(),
         ),
         input_schema: json!({
@@ -403,6 +427,8 @@ pub(crate) fn build_list_profiles_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("List Tool Profiles")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -418,10 +444,10 @@ pub(crate) fn build_set_state_tool() -> Tool {
         title: Some("Set Workflow State".to_string()),
         description: Some(
             "Transition the session to a new workflow state. \
-             Capabilities with a non-empty `visible_in_states` list will only appear in \
-             tools/list when the session is in a matching state. \
-             Tools without `visible_in_states` are always visible. \
-             Returns the previous state, new state, and visible tool count."
+         Capabilities with a non-empty `visible_in_states` list will only appear in \
+         tools/list when the session is in a matching state. \
+         Tools without `visible_in_states` are always visible. \
+         Returns the previous state, new state, and visible tool count."
                 .to_string(),
         ),
         input_schema: json!({
@@ -436,6 +462,8 @@ pub(crate) fn build_set_state_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_idempotent_annotations("Set Workflow State")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -446,8 +474,8 @@ pub(crate) fn build_reload_config_tool() -> Tool {
         title: Some("Reload Config".to_string()),
         description: Some(
             "Trigger an immediate reload of config.yaml from disk without restarting the gateway. \
-             Returns a summary plus explicit restart-required fields when some changes stay pending. \
-             Server host/port changes require a restart and are reported but not applied."
+         Returns a summary plus explicit restart-required fields when some changes stay pending. \
+         Server host/port changes require a restart and are reported but not applied."
                 .to_string(),
         ),
         input_schema: json!({
@@ -457,6 +485,8 @@ pub(crate) fn build_reload_config_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_idempotent_annotations("Reload Config")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -467,8 +497,8 @@ pub(crate) fn build_cost_report_tool() -> Tool {
         title: Some("Cost Report".to_string()),
         description: Some(
             "Return current session and API-key spend. Includes total cost, call count, \
-             and breakdown by backend and tool. \
-             Per-key totals are shown for 24 h / 7 d / 30 d rolling windows."
+         and breakdown by backend and tool. \
+         Per-key totals are shown for 24 h / 7 d / 30 d rolling windows."
                 .to_string(),
         ),
         input_schema: serde_json::json!({
@@ -493,6 +523,8 @@ pub(crate) fn build_cost_report_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("Cost Report")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -548,10 +580,10 @@ pub(crate) fn build_reload_capabilities_tool() -> Tool {
         title: Some("Reload Capabilities".to_string()),
         description: Some(
             "Re-read all YAML capability files from disk and rebuild the capability \
-             backend's tool surface. Returns the new total. Useful when an agent has \
-             just written a new capability YAML and wants it usable without restarting \
-             the gateway. Clients should re-list capability tools to see additions; \
-             `tools/list_changed` notification is a follow-up."
+         backend's tool surface. Returns the new total. Useful when an agent has \
+         just written a new capability YAML and wants it usable without restarting \
+         the gateway. Clients should re-list capability tools to see additions; \
+         `tools/list_changed` notification is a follow-up."
                 .to_string(),
         ),
         input_schema: json!({
@@ -561,6 +593,8 @@ pub(crate) fn build_reload_capabilities_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_idempotent_annotations("Reload Capabilities")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -578,9 +612,9 @@ pub(crate) fn build_code_mode_search_tool() -> Tool {
         title: Some("Search Tools".to_string()),
         description: Some(
             "Search the gateway tool registry by name, description, or tag. \
-             Returns matching tools with their full schemas. \
-             Supports keyword queries, multi-word queries (any word matches), \
-             and glob-style patterns (e.g. \"file_*\", \"*search*\")."
+         Returns matching tools with their full schemas. \
+         Supports keyword queries, multi-word queries (any word matches), \
+         and glob-style patterns (e.g. \"file_*\", \"*search*\")."
                 .to_string(),
         ),
         input_schema: json!({
@@ -605,6 +639,8 @@ pub(crate) fn build_code_mode_search_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(read_only_annotations("Search Tools")),
+        role: None,
+        projection: None,
     }
 }
 
@@ -617,9 +653,9 @@ pub(crate) fn build_code_mode_execute_tool() -> Tool {
         title: Some("Execute Tool".to_string()),
         description: Some(
             "Execute a gateway tool by name with arguments. \
-             Use `tool` + `arguments` for a single call. \
-             Use `chain` for sequential execution where each step can \
-             reference the previous result."
+         Use `tool` + `arguments` for a single call. \
+         Use `chain` for sequential execution where each step can \
+         reference the previous result."
                 .to_string(),
         ),
         input_schema: json!({
@@ -650,6 +686,8 @@ pub(crate) fn build_code_mode_execute_tool() -> Tool {
         }),
         output_schema: None,
         annotations: Some(write_non_idempotent_open_world_annotations("Execute Tool")),
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -25,6 +25,15 @@ pub struct Tool {
     /// Tool annotations (hints about behavior)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ToolAnnotations>,
+    /// Tool role for discovery filtering (projection layer, MIK-3531/3532).
+    /// `None` (the default) is treated as [`crate::projection::Role::Action`],
+    /// preserving backward compatibility for untagged tools.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<crate::projection::Role>,
+    /// Canonical projection spec for this tool's responses, if declared.
+    /// `None` means the response is not projected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection: Option<crate::projection::ProjectionSpec>,
 }
 
 /// Tool annotations (hints about tool behavior)
@@ -535,6 +544,69 @@ pub enum ToolChoice {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ── Tool descriptor: role + projection (MIK-3531) ─────────────────
+
+    fn bare_tool() -> Tool {
+        Tool {
+            name: "t".to_string(),
+            title: None,
+            description: None,
+            input_schema: json!({"type": "object"}),
+            output_schema: None,
+            annotations: None,
+            role: None,
+            projection: None,
+        }
+    }
+
+    #[test]
+    fn untagged_tool_omits_role_and_projection_on_the_wire() {
+        // Backward compatibility: an untagged tool must serialize exactly as
+        // before — no `role` / `projection` keys (skip_serializing_if).
+        let v = serde_json::to_value(bare_tool()).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("role"), "untagged tool must omit role");
+        assert!(
+            !obj.contains_key("projection"),
+            "untagged tool must omit projection"
+        );
+    }
+
+    #[test]
+    fn untagged_tool_deserializes_from_pre_existing_json() {
+        // Old payloads with no role/projection keys must still parse, defaulting
+        // both to None.
+        let t: Tool = serde_json::from_value(json!({
+            "name": "legacy", "inputSchema": {"type": "object"}
+        }))
+        .unwrap();
+        assert!(t.role.is_none());
+        assert!(t.projection.is_none());
+    }
+
+    #[test]
+    fn tagged_tool_round_trips_role_and_projection() {
+        use crate::projection::{ActorSpec, ProjectionSpec, Role};
+        let mut t = bare_tool();
+        t.role = Some(Role::Selector);
+        t.projection = Some(ProjectionSpec {
+            actor: Some(ActorSpec {
+                email: Some("assignee.email".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let v = serde_json::to_value(&t).unwrap();
+        assert_eq!(v["role"], json!("selector"));
+        assert_eq!(v["projection"]["actor"]["email"], json!("assignee.email"));
+        let back: Tool = serde_json::from_value(v).unwrap();
+        assert_eq!(back.role, Some(Role::Selector));
+        assert_eq!(
+            back.projection.unwrap().actor.unwrap().email.as_deref(),
+            Some("assignee.email")
+        );
+    }
 
     // ── ResourceTemplate ──────────────────────────────────────────────
 

--- a/src/provider/composite_provider.rs
+++ b/src/provider/composite_provider.rs
@@ -160,6 +160,8 @@ mod tests {
                         input_schema: json!({}),
                         output_schema: None,
                         annotations: None,
+                        role: None,
+                        projection: None,
                     })
                     .collect(),
             })

--- a/src/provider/transforms/chain.rs
+++ b/src/provider/transforms/chain.rs
@@ -241,6 +241,8 @@ mod tests {
                     input_schema: json!({}),
                     output_schema: None,
                     annotations: None,
+                    role: None,
+                    projection: None,
                 })
                 .collect())
         }

--- a/src/provider/transforms/filter.rs
+++ b/src/provider/transforms/filter.rs
@@ -123,6 +123,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/provider/transforms/namespace.rs
+++ b/src/provider/transforms/namespace.rs
@@ -99,6 +99,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/provider/transforms/rename.rs
+++ b/src/provider/transforms/rename.rs
@@ -98,6 +98,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/provider/transforms/response.rs
+++ b/src/provider/transforms/response.rs
@@ -116,6 +116,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }];
 
         // WHEN: transforming tools

--- a/src/security/scope_collision.rs
+++ b/src/security/scope_collision.rs
@@ -60,6 +60,8 @@ pub struct ScopeCollision {
 ///     input_schema: json!({}),
 ///     output_schema: None,
 ///     annotations: None,
+///     role: None,
+///     projection: None,
 /// }];
 /// let tools_b = vec![Tool {
 ///     name: "search".to_string(),
@@ -68,6 +70,8 @@ pub struct ScopeCollision {
 ///     input_schema: json!({}),
 ///     output_schema: None,
 ///     annotations: None,
+///     role: None,
+///     projection: None,
 /// }];
 ///
 /// let backends = vec![
@@ -186,6 +190,8 @@ mod tests {
             input_schema: json!({}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/security/tool_integrity.rs
+++ b/src/security/tool_integrity.rs
@@ -191,6 +191,8 @@ mod tests {
             input_schema: schema,
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/tool_registry.rs
+++ b/src/tool_registry.rs
@@ -398,6 +398,8 @@ mod tests {
             input_schema: json!({"type": "object", "properties": {}}),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -151,6 +151,8 @@ mod tests {
             }),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/validator/rules/tests.rs
+++ b/src/validator/rules/tests.rs
@@ -9,6 +9,8 @@ fn create_tool(name: &str, description: &str, input_schema: serde_json::Value) -
         input_schema,
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 

--- a/src/validator/rules/tool_poisoning.rs
+++ b/src/validator/rules/tool_poisoning.rs
@@ -371,6 +371,8 @@ mod tests {
             }),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 
@@ -390,6 +392,8 @@ mod tests {
             }),
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/src/validator/rules_schema.rs
+++ b/src/validator/rules_schema.rs
@@ -349,6 +349,8 @@ mod tests {
             input_schema,
             output_schema: None,
             annotations: None,
+            role: None,
+            projection: None,
         }
     }
 

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -36,6 +36,8 @@ fn make_tool(name: &str, desc: &str, schema: serde_json::Value) -> Tool {
         input_schema: schema,
         output_schema: None,
         annotations: None,
+        role: None,
+        projection: None,
     }
 }
 
@@ -174,6 +176,8 @@ fn rug_pull_output_schema_change_detected() {
         input_schema: json!({}),
         output_schema: Some(json!({"type": "object", "properties": {"data": {"type": "string"}}})),
         annotations: None,
+        role: None,
+        projection: None,
     }];
     checker.check_tools("backend", &v1);
 
@@ -186,6 +190,8 @@ fn rug_pull_output_schema_change_detected() {
             json!({"type": "object", "properties": {"data": {"type": "string"}, "exfil": {"type": "string"}}}),
         ),
         annotations: None,
+        role: None,
+        projection: None,
     }];
     let mutations = checker.check_tools("backend", &v2);
     assert_eq!(mutations.len(), 1);


### PR DESCRIPTION
Ships **v2.16.0**. Completes the MIK-3531 foundation: the MCP `Tool` descriptor now carries the projection layer's two optional fields.

## What's new
- `Tool.role: Option<Role>` (`selector` / `extractor` / `enricher` / `action`)
- `Tool.projection: Option<ProjectionSpec>` (per-field canonical→source mapping)

Both default to `None` and are `skip_serializing_if` omitted, so **untagged tools serialize/deserialize byte-for-byte as before** — fully backward-compatible. **No behavior change** — this is the descriptor surface the rest of the epic consumes (MIK-3532 role filter, MIK-3533/3534 projection logic).

## Mechanics
Swept all **48** `Tool { ... }` construction sites across `src/`, `tests/`, `benches/`, `examples/`, and a doc-test — ast-grep for the bulk, manual for path-qualified (`crate::protocol::Tool`) and `vec!`-wrapped literals. Every site sets the new fields to `None`.

## Tests (TDD serialization contract)
- untagged tool omits `role`/`projection` on the wire (backward compat)
- pre-existing JSON without those keys still parses to `None`/`None`
- tagged tool round-trips `role` + a per-field `ProjectionSpec`

## Peer review (codex)
No blocker, no major. One minor (a layering note — `protocol::Tool` now names the projection DTOs; no dependency cycle, projection is pure serde DTOs) accepted as a documented tradeoff since the ticket specifies extending the descriptor.

## Gates (DoD)
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` full suite: **3211 passed, 0 failed**
- No `unsafe`; CHANGELOG updated; semver minor (additive optional fields)

Relates to MIK-3530, MIK-3531. Next: MIK-3532 (`list_tools` role filter, the first consumer) and role-tagging the meta-tools.
