### PR TITLE
ci(security): least-privilege permissions on docker security-gate job (CodeQL #62)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,8 @@ jobs:
   security-gate:
     name: Security gate (block image on known vulns)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Resolves CodeQL code-scanning alert #62 (`actions/missing-workflow-permissions`, medium).

The `security-gate` job in `.github/workflows/docker.yml` had no explicit `permissions` block, running with the default broad GITHUB_TOKEN scope. It only checks out + runs osv-scanner, so `contents: read` is sufficient. The `build` and `publish-mcp-registry` jobs already declare their own narrower permissions; this brings the last job in line.

No code/crate change — CI config only.