### PR TITLE
feat(projection): experiment telemetry (MIK-5877 PROJ-ROLLOUT.3)

### DIFF
--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -161,6 +161,56 @@ fn apply_capability_projection(
     apply_validated_output(&response, projected)
 }
 
+/// Emit one A/B telemetry record for an eligible (experimental-mode,
+/// projection-capable) invocation (MIK-5877, PROJ-ROLLOUT.3).
+///
+/// Emits both metrics (a labelled counter + a response-size histogram, for
+/// dashboards) and a structured `target: "projection_ab"` tracing event keyed by
+/// `session_id` (so an offline analysis can join arm → task outcome). Called
+/// only when [`crate::projection::ab_classification`] returns `Some`, so it is
+/// zero-cost outside the experiment.
+fn emit_projection_ab_event(
+    session_id: Option<&str>,
+    server: &str,
+    tool: &str,
+    rec: crate::projection::AbRecord,
+    result: &Value,
+) {
+    let response_bytes = serde_json::to_string(result).map_or(0, |s| s.len());
+    let is_error = result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let projected = if rec.projected { "true" } else { "false" };
+
+    telemetry_metrics::counter!(
+        "projection_ab_invocations_total",
+        "arm" => rec.arm,
+        "projected" => projected
+    )
+    .increment(1);
+    telemetry_metrics::histogram!(
+        "projection_ab_response_bytes",
+        "arm" => rec.arm
+    )
+    // u32->f64 is lossless; clamp the (absurd) >4 GiB case rather than risk a
+    // precision-losing usize->f64 cast.
+    .record(f64::from(u32::try_from(response_bytes).unwrap_or(u32::MAX)));
+    tracing::info!(
+        target: "projection_ab",
+        // Un-sessioned calls log "none" and are always control (see
+        // projection_decision); exclude them when joining arm -> task outcome.
+        session_id = session_id.unwrap_or("none"),
+        server = server,
+        tool = tool,
+        arm = rec.arm,
+        projected = rec.projected,
+        response_bytes = response_bytes,
+        is_error = is_error,
+        "projection A/B invocation"
+    );
+}
+
 /// Whether a JSON value is non-empty at the top level: `null`, `{}`, and `[]`
 /// are considered empty; any scalar (including `0`, `false`, `""`) and any
 /// non-empty object/array are non-empty. This is a deliberately shallow check
@@ -999,13 +1049,28 @@ impl MetaMcp {
             // contract; `on` always projects; `experimental` projects only the
             // treatment arm of a sticky per-session A/B split.
             let decision = crate::projection::projection_decision(self.projection_mode, session_id);
-            if decision.project
+            let spec_present = cap_def.as_ref().is_some_and(|c| c.projection.is_some());
+            let final_result = if decision.project
                 && let Some(cap_def) = cap_def.as_ref()
                 && let Some(spec) = cap_def.projection.as_ref()
             {
-                return Ok(apply_capability_projection(validated, spec, want_full));
+                apply_capability_projection(validated, spec, want_full)
+            } else {
+                validated
+            };
+
+            // A/B telemetry (MIK-5877, PROJ-ROLLOUT.3): one structured event per
+            // eligible invocation so the experiment is measurable. No-op outside
+            // `experimental` mode / spec-less tools.
+            if let Some(rec) = crate::projection::ab_classification(
+                self.projection_mode,
+                session_id,
+                want_full,
+                spec_present,
+            ) {
+                emit_projection_ab_event(session_id, server, tool, rec, &final_result);
             }
-            return Ok(validated);
+            return Ok(final_result);
         }
 
         let backend = self

--- a/src/projection/mod.rs
+++ b/src/projection/mod.rs
@@ -21,7 +21,10 @@ pub mod role;
 pub mod schema;
 
 pub use engine::project;
-pub use mode::{ProjectionDecision, ProjectionMode, projection_decision, projection_key_suffix};
+pub use mode::{
+    AbRecord, ProjectionDecision, ProjectionMode, ab_classification, projection_decision,
+    projection_key_suffix,
+};
 pub use role::Role;
 pub use schema::{
     Actor, ActorSpec, Body, BodySpec, EnvTime, EnvTimeSpec, Projected, ProjectionSpec, Subject,

--- a/src/projection/mode.rs
+++ b/src/projection/mode.rs
@@ -118,6 +118,48 @@ pub fn projection_key_suffix(mode: ProjectionMode, session_id: Option<&str>) -> 
     }
 }
 
+/// A/B telemetry classification of a single invocation (MIK-5877, PROJ-ROLLOUT.3).
+///
+/// Captures which arm the call landed in and whether projection was *attempted*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbRecord {
+    /// Arm label: `"treatment"` or `"control"`.
+    pub arm: &'static str,
+    /// Whether projection was **attempted** — treatment arm AND not a `_full`
+    /// bypass. NOTE: this does not guarantee the shape actually changed:
+    /// `apply_capability_projection` still returns the payload raw for an
+    /// `isError` envelope or when the spec resolves no fields (fail-fast). For a
+    /// clean treatment-vs-control shape comparison, filter the emitted events to
+    /// `is_error = false` (and treat zero-size-delta treatment rows as no-op
+    /// specs).
+    pub projected: bool,
+}
+
+/// Classify an invocation for A/B telemetry, or `None` when it is not part of
+/// the experiment.
+///
+/// Only `experimental` mode with a projection-capable tool (`spec_present`) is
+/// in the experiment — `off`/`on` and spec-less tools return `None` so no event
+/// is emitted for them. `projected` is true only for the treatment arm of a
+/// non-`_full` call (a `_full` call bypasses projection even in treatment, so it
+/// records `projected = false` while keeping its arm label).
+#[must_use]
+pub fn ab_classification(
+    mode: ProjectionMode,
+    session_id: Option<&str>,
+    want_full: bool,
+    spec_present: bool,
+) -> Option<AbRecord> {
+    if mode != ProjectionMode::Experimental || !spec_present {
+        return None;
+    }
+    let decision = projection_decision(mode, session_id);
+    Some(AbRecord {
+        arm: decision.arm,
+        projected: decision.project && !want_full,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,5 +302,49 @@ mod tests {
             treatment.expect("a treatment session"),
             control.expect("a control session")
         );
+    }
+
+    #[test]
+    fn ab_classification_none_outside_experiment() {
+        // off/on are not the experiment; spec-less tools are not eligible.
+        assert!(ab_classification(ProjectionMode::Off, Some("s"), false, true).is_none());
+        assert!(ab_classification(ProjectionMode::On, Some("s"), false, true).is_none());
+        assert!(ab_classification(ProjectionMode::Experimental, Some("s"), false, false).is_none());
+    }
+
+    #[test]
+    fn ab_classification_treatment_projects_unless_full() {
+        // Find a treatment-arm session id.
+        let sid = (0..1000)
+            .map(|i| format!("t{i}"))
+            .find(|s| projection_decision(ProjectionMode::Experimental, Some(s)).arm == "treatment")
+            .expect("a treatment session exists");
+
+        let rec = ab_classification(ProjectionMode::Experimental, Some(&sid), false, true).unwrap();
+        assert_eq!(rec.arm, "treatment");
+        assert!(
+            rec.projected,
+            "treatment + non-full must record projected=true"
+        );
+
+        // `_full` bypasses projection even in treatment; arm label is retained.
+        let rec_full =
+            ab_classification(ProjectionMode::Experimental, Some(&sid), true, true).unwrap();
+        assert_eq!(rec_full.arm, "treatment");
+        assert!(
+            !rec_full.projected,
+            "a _full call must record projected=false"
+        );
+    }
+
+    #[test]
+    fn ab_classification_control_never_projects() {
+        let sid = (0..1000)
+            .map(|i| format!("c{i}"))
+            .find(|s| projection_decision(ProjectionMode::Experimental, Some(s)).arm == "control")
+            .expect("a control session exists");
+        let rec = ab_classification(ProjectionMode::Experimental, Some(&sid), false, true).unwrap();
+        assert_eq!(rec.arm, "control");
+        assert!(!rec.projected, "control arm must record projected=false");
     }
 }


### PR DESCRIPTION
## Summary

Phase 0 Unit B of the projection rollout (MIK-5877). Adds the telemetry that makes the projection experiment measurable. Without it, `experimental` mode would split traffic blind. Still dormant and unreleased; data collection begins only when an operator sets `projection_mode: experimental`.

## What

- **ab_classification(mode, session_id, want_full, spec_present)** in `src/projection/mode.rs`: a pure, testable classifier returning `Some(AbRecord{ arm, projected })` only in `experimental` mode for a projection-capable tool, else `None` (no event). `projected` means projection was **attempted** (treatment arm, non-full call); the doc notes it can still be raw for an isError response or a fail-fast no-op spec, so analysis should filter `is_error = false`.
- **emit_projection_ab_event(...)** in dispatch: a labelled counter `projection_ab_invocations_total`, a response-size histogram `projection_ab_response_bytes`, and a structured `projection_ab` tracing event keyed by session_id (arm, projected, response_bytes, is_error). Metric-label cardinality is bounded (arm, projected); session_id is a log field only. The offline analysis joins arm to task outcome; the primary signal is follow-up-calls-per-task.
- The dispatch capability branch is refactored to capture the final result, emit, then return. Reviewed to confirm the returned value is byte-for-byte identical to before across all cases (treatment, control, off, on, full bypass, isError, fail-fast) — telemetry only, no behavioral change.

## Testing

- 3 new classifier tests (none-outside-experiment, treatment-projects-unless-full, control-never-projects).
- Full suite 3243 pass, 0 fail. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- Reviewed adversarially (refactor no-op, emission count, cardinality, the projected-attempted-versus-applied semantic, cast soundness); merge-ready with two follow-up notes (isError exclusion and a byte-count cost optimization) tracked for before the experiment readout.

Generated with Claude Code
