### PR TITLE
feat(projection): canonical specs for linear_get_issue and github_get_repo (MIK-5877)

### DIFF
--- a/capabilities/knowledge/github_get_repo.yaml
+++ b/capabilities/knowledge/github_get_repo.yaml
@@ -46,6 +46,29 @@ cache:
   strategy: exact
   ttl: 1800  # 30 min — stars/issues update frequently
 
+# Canonical projection (MIK-5877). Maps the GitHub repo payload onto the
+# gateway's canonical schema (actor = owner, subject = repo, url, env_time,
+# body = description). Paths are relative to the raw REST response (no transform
+# block, so fields are top-level). DORMANT unless the gateway runs with
+# meta_mcp.projection_mode = on | experimental; at the default `off` this block
+# changes no response. The untouched payload is always preserved under _raw.
+projection:
+  subject:
+    id: id
+    title: full_name
+  actor:
+    id: owner.id
+    display_name: owner.login
+    handle: owner.login
+  url:
+    href: html_url
+    label: full_name
+  env_time:
+    created: created_at
+    updated: updated_at
+  body:
+    text: description
+
 auth:
   required: false
   type: none

--- a/capabilities/linear/linear_get_issue.yaml
+++ b/capabilities/linear/linear_get_issue.yaml
@@ -25,6 +25,29 @@ transform:
   rename:
     nodes[0]: issue
 
+# Canonical projection (MIK-5877). Maps the issue payload onto the gateway's
+# canonical schema (actor/subject/env_time/url). Paths are relative to the
+# transformed payload above ({issue: {...}}). DORMANT unless the gateway runs
+# with meta_mcp.projection_mode = on | experimental; at the default `off` this
+# block changes no response. The untouched payload is always preserved under
+# _raw. NOTE: enabling experimental projects this tool for ~50% of sessions —
+# any consumer that reads issue.* directly (e.g. a claim-verify protocol) must
+# pass _full:true or run outside the experiment window.
+projection:
+  subject:
+    id: issue.identifier
+    title: issue.title
+  actor:
+    id: issue.assignee.id
+    display_name: issue.assignee.displayName
+    email: issue.assignee.email
+    handle: issue.assignee.name
+  env_time:
+    created: issue.createdAt
+    updated: issue.updatedAt
+  url:
+    href: issue.url
+
 auth:
   required: true
   type: api_key

--- a/src/capability/definition/tests.rs
+++ b/src/capability/definition/tests.rs
@@ -1337,3 +1337,121 @@ fn linear_capability_payload_shapes_match_declared_output_schemas() {
         }),
     );
 }
+
+// ── MIK-5877: capability projection specs validate against realistic payloads ──
+
+#[test]
+fn linear_get_issue_projection_spec_maps_canonical_fields() {
+    let cap = load_repo_capability("capabilities/linear/linear_get_issue.yaml");
+    let spec = cap
+        .projection
+        .as_ref()
+        .expect("linear_get_issue must declare a projection spec");
+
+    // Realistic payload AFTER the capability's transform (project nodes[0] ->
+    // rename to `issue`) — that is what the projection engine sees at dispatch.
+    let payload = serde_json::json!({
+        "issue": {
+            "id": "uuid-1",
+            "identifier": "ENG-123",
+            "title": "Fix the bug",
+            "assignee": {
+                "id": "user-1",
+                "name": "alice",
+                "displayName": "Alice Example",
+                "email": "alice@iki.fi"
+            },
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+            "url": "https://linear.app/x/issue/ENG-123"
+        }
+    });
+
+    let out = crate::projection::project(&payload, spec);
+
+    assert_eq!(out["subject"]["id"], serde_json::json!("ENG-123"));
+    assert_eq!(out["subject"]["title"], serde_json::json!("Fix the bug"));
+    assert_eq!(out["actor"]["id"], serde_json::json!("user-1"));
+    assert_eq!(out["actor"]["handle"], serde_json::json!("alice"));
+    assert_eq!(
+        out["actor"]["display_name"],
+        serde_json::json!("Alice Example")
+    );
+    assert_eq!(out["actor"]["email"], serde_json::json!("alice@iki.fi"));
+    assert_eq!(
+        out["env_time"]["created"],
+        serde_json::json!("2026-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        out["env_time"]["updated"],
+        serde_json::json!("2026-01-02T00:00:00Z")
+    );
+    assert_eq!(
+        out["url"]["href"],
+        serde_json::json!("https://linear.app/x/issue/ENG-123")
+    );
+    // _raw always preserves the original payload verbatim.
+    assert_eq!(out["_raw"], payload);
+}
+
+#[test]
+fn github_get_repo_projection_spec_maps_canonical_fields() {
+    let cap = load_repo_capability("capabilities/knowledge/github_get_repo.yaml");
+    let spec = cap
+        .projection
+        .as_ref()
+        .expect("github_get_repo must declare a projection spec");
+
+    // Realistic GitHub REST /repos/{owner}/{repo} response (no transform block,
+    // so fields are top-level).
+    let payload = serde_json::json!({
+        "id": 123_456,
+        "name": "mcp-gateway",
+        "full_name": "MikkoParkkola/mcp-gateway",
+        "owner": {
+            "login": "MikkoParkkola",
+            "id": 999,
+            "html_url": "https://github.com/MikkoParkkola"
+        },
+        "description": "Universal MCP Gateway",
+        "html_url": "https://github.com/MikkoParkkola/mcp-gateway",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "stargazers_count": 42
+    });
+
+    let out = crate::projection::project(&payload, spec);
+
+    assert_eq!(out["subject"]["id"], serde_json::json!("123456"));
+    assert_eq!(
+        out["subject"]["title"],
+        serde_json::json!("MikkoParkkola/mcp-gateway")
+    );
+    assert_eq!(out["actor"]["id"], serde_json::json!("999"));
+    assert_eq!(out["actor"]["handle"], serde_json::json!("MikkoParkkola"));
+    assert_eq!(
+        out["actor"]["display_name"],
+        serde_json::json!("MikkoParkkola")
+    );
+    assert_eq!(
+        out["url"]["href"],
+        serde_json::json!("https://github.com/MikkoParkkola/mcp-gateway")
+    );
+    assert_eq!(
+        out["url"]["label"],
+        serde_json::json!("MikkoParkkola/mcp-gateway")
+    );
+    assert_eq!(
+        out["env_time"]["created"],
+        serde_json::json!("2025-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        out["env_time"]["updated"],
+        serde_json::json!("2026-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        out["body"]["text"],
+        serde_json::json!("Universal MCP Gateway")
+    );
+    assert_eq!(out["_raw"], payload);
+}


### PR DESCRIPTION
## Summary

Phase 0 Unit C of the projection rollout (MIK-5877). Adds a dormant `projection:` block to two high-traffic read tools so the experiment has something real to project. Inert at the default `projection_mode: off` — changes no response contract until an operator opts into `on` or `experimental`.

## What

- **linear_get_issue**: maps the issue payload (paths relative to the post-transform `{issue: ...}` object) onto the canonical schema — subject from the issue, actor from the assignee, plus url and timestamps. Uses `issue.identifier` (e.g. "ENG-123") as the subject id rather than the internal UUID.
- **github_get_repo**: maps the raw GitHub REST response — subject from the repo, actor from the owner, plus url, timestamps, and description as body.
- The untouched payload is always preserved under `_raw`.

## Validation

Two tests load the real capability YAML and run the engine against a realistic response fixture, asserting each canonical bucket is populated correctly and `_raw` matches the input — proving the field paths resolve, not merely that the YAML parses. Every path was independently verified against the live Linear GraphQL and GitHub REST schemas.

## Safety note

Enabling `experimental` projects linear_get_issue for roughly half of sessions. Any consumer that reads `issue.*` directly (for example a claim-verify protocol) must pass `_full: true` or run outside the experiment window. This is documented in the YAML. Arm isolation prevents cross-arm cache contamination but not the within-treatment shape change — that is the experiment's nature.

## Testing

- Full suite 3245 pass, 0 fail. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

Generated with Claude Code
