### PR TITLE
fix: HTTP transport re-initializes expired backend sessions; revive_server resets the circuit breaker

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -781,6 +781,16 @@ impl Backend {
         *self.transport.write() = Some(transport);
     }
 
+    /// Test-only: trip this backend's circuit breaker open by recording
+    /// `failure_threshold` consecutive failures.
+    #[cfg(test)]
+    pub(crate) fn trip_circuit_breaker_for_test(&self) {
+        let threshold = self.failsafe.circuit_breaker.stats().failure_threshold;
+        for _ in 0..threshold {
+            self.failsafe.circuit_breaker.record_failure();
+        }
+    }
+
     /// Return `true` if this backend is configured for pass-through mode.
     ///
     /// When `true`, the direct `/mcp/{name}` endpoint skips tool policy
@@ -823,6 +833,14 @@ impl Backend {
     /// Get circuit breaker stats for this backend.
     pub fn circuit_breaker_stats(&self) -> crate::failsafe::CircuitBreakerStats {
         self.failsafe.circuit_breaker.stats()
+    }
+
+    /// Force this backend's circuit breaker back to `Closed` (MIK-5983).
+    ///
+    /// Called by `gateway_revive_server` so the documented manual recovery
+    /// path also clears a tripped breaker, not just the kill switch.
+    pub fn reset_circuit_breaker(&self) {
+        self.failsafe.circuit_breaker.reset();
     }
 
     /// Get health metrics for this backend.

--- a/src/failsafe/circuit_breaker.rs
+++ b/src/failsafe/circuit_breaker.rs
@@ -196,6 +196,30 @@ impl CircuitBreaker {
         }
     }
 
+    /// Force the breaker back to `Closed` and clear all failure/success counters.
+    ///
+    /// This is the manual recovery lever behind the `gateway_revive_server`
+    /// meta-tool (MIK-5983): the `CIRCUIT_OPEN` error message directs operators
+    /// to that tool, so reviving a backend must also close a tripped breaker.
+    /// Without this, the documented recovery path was a no-op for breaker trips
+    /// (observed live 2026-06-11: hebb breaker wedged open 6.5h).
+    #[tracing::instrument(skip(self), fields(backend = %self.name))]
+    pub fn reset(&self) {
+        if !self.enabled {
+            return;
+        }
+        let state = *self.state.read();
+        if state == CircuitState::Closed {
+            // transition_to() early-returns on same-state transitions; still
+            // clear the failure window so a half-accumulated count does not
+            // survive the revive.
+            self.failures.store(0, Ordering::Relaxed);
+            self.successes.store(0, Ordering::Relaxed);
+        } else {
+            self.transition_to(CircuitState::Closed);
+        }
+    }
+
     /// Record a failed request
     #[tracing::instrument(skip(self), fields(backend = %self.name))]
     pub fn record_failure(&self) {
@@ -431,6 +455,50 @@ mod tests {
     }
 
     // ── stats snapshot ────────────────────────────────────────────────────
+
+    #[test]
+    fn reset_closes_an_open_breaker_and_allows_requests() {
+        // GIVEN: a breaker tripped open by hitting the failure threshold
+        let cb = CircuitBreaker::new("test", &make_config(true, 3));
+        for _ in 0..3 {
+            cb.record_failure();
+        }
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(!cb.can_proceed());
+
+        // WHEN: the operator resets it (gateway_revive_server path, MIK-5983)
+        cb.reset();
+
+        // THEN: closed, counters cleared, requests flow again
+        let s = cb.stats();
+        assert_eq!(s.state, CircuitState::Closed);
+        assert_eq!(s.current_failures, 0);
+        assert!(cb.can_proceed());
+    }
+
+    #[test]
+    fn reset_in_closed_state_clears_accumulated_failures() {
+        // GIVEN: a closed breaker with a half-accumulated failure window
+        let cb = CircuitBreaker::new("test", &make_config(true, 5));
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.stats().current_failures, 2);
+
+        // WHEN
+        cb.reset();
+
+        // THEN: window cleared, still closed
+        assert_eq!(cb.stats().current_failures, 0);
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn reset_on_disabled_breaker_is_a_noop() {
+        let cb = CircuitBreaker::new("test", &make_config(false, 3));
+        cb.reset();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.can_proceed());
+    }
 
     #[test]
     fn stats_initial_state_is_closed_with_zero_trips() {

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1259,16 +1259,28 @@ impl MetaMcp {
 
     /// `gateway_revive_server` — re-enable a previously killed backend.
     ///
-    /// Also resets the error-budget window so the backend starts with a clean slate.
+    /// Resets the error-budget window AND closes a tripped circuit breaker so
+    /// the backend starts with a clean slate. The breaker reset is load-bearing
+    /// (MIK-5983): the `CIRCUIT_OPEN` error message directs operators to this
+    /// tool, so it must actually recover a breaker-tripped backend.
     #[allow(clippy::unnecessary_wraps)]
     pub(super) fn revive_server(&self, args: &Value) -> Result<Value> {
         let server = extract_required_str(args, "server")?;
         let was_killed = self.kill_switch.is_killed(server);
         self.kill_switch.revive(server);
+
+        let mut breaker_was_open = false;
+        if let Some(backend) = self.backends.get(server) {
+            breaker_was_open =
+                backend.circuit_breaker_stats().state != crate::failsafe::CircuitState::Closed;
+            backend.reset_circuit_breaker();
+        }
+
         Ok(json!({
             "server": server,
             "status": "active",
             "was_killed": was_killed,
+            "breaker_was_open": breaker_was_open,
             "message": format!("Server '{server}' has been re-enabled")
         }))
     }

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -1188,3 +1188,57 @@ fn resolve_surfaced_tool_excluded_by_deny_all_profile() {
         "Denied backend's surfaced tool should be absent; names: {names:?}"
     );
 }
+
+// =========================================================================
+// gateway_revive_server — circuit-breaker reset (MIK-5983)
+// =========================================================================
+
+/// Reviving a backend with a tripped circuit breaker must close the breaker,
+/// not just the kill switch. Regression test for the 2026-06-11 incident where
+/// the documented recovery path was a no-op for breaker trips.
+#[test]
+fn revive_server_resets_a_tripped_circuit_breaker() {
+    use crate::backend::Backend;
+    use crate::config::{BackendConfig, FailsafeConfig};
+    use crate::failsafe::CircuitState;
+    use std::time::Duration;
+
+    // GIVEN: a registered backend whose breaker has tripped open
+    let registry = Arc::new(BackendRegistry::new());
+    let backend = Arc::new(Backend::new(
+        "wedged_backend",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::ZERO,
+    ));
+    backend.trip_circuit_breaker_for_test();
+    assert_eq!(
+        backend.circuit_breaker_stats().state,
+        CircuitState::Open,
+        "precondition: breaker must be open"
+    );
+    registry.register(Arc::clone(&backend));
+    let mm = MetaMcp::new(registry);
+
+    // WHEN: the operator runs gateway_revive_server
+    let result = mm
+        .revive_server(&serde_json::json!({"server": "wedged_backend"}))
+        .unwrap();
+
+    // THEN: breaker is closed and the response reports the prior open state
+    assert_eq!(backend.circuit_breaker_stats().state, CircuitState::Closed);
+    assert_eq!(result["breaker_was_open"], true);
+    assert_eq!(result["status"], "active");
+}
+
+/// Reviving a backend that is not registered still succeeds
+/// (kill-switch-only semantics) and reports `breaker_was_open: false`.
+#[test]
+fn revive_server_unregistered_backend_reports_breaker_not_open() {
+    let mm = MetaMcp::new(Arc::new(BackendRegistry::new()));
+    let result = mm
+        .revive_server(&serde_json::json!({"server": "ghost"}))
+        .unwrap();
+    assert_eq!(result["breaker_was_open"], false);
+    assert_eq!(result["status"], "active");
+}

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -31,6 +31,22 @@ use crate::protocol::{
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
+/// Detect the session-expiry signature in a transport error (MIK-5982).
+///
+/// Matches three observed shapes:
+/// - JSON-RPC `-32015` session errors (rust-mcp-sdk servers, e.g. hebb-serve:
+///   `HTTP 400 Bad Request: {"code":-32015,...,"message":"Bad Request: Session not found"}`)
+/// - any body containing "session not found" (case-insensitive)
+/// - bare `HTTP 404` responses, which the MCP Streamable HTTP spec defines as
+///   "session terminated or expired" (callers gate this on having had a session)
+fn is_session_expired_error(err: &Error) -> bool {
+    let Error::Transport(msg) = err else {
+        return false;
+    };
+    let lower = msg.to_lowercase();
+    lower.contains("session not found") || msg.contains("-32015") || lower.starts_with("http 404")
+}
+
 /// HTTP transport for MCP servers using SSE or Streamable HTTP protocol
 pub struct HttpTransport {
     /// HTTP client
@@ -606,7 +622,31 @@ impl Transport for HttpTransport {
             params,
         };
 
-        self.send_request(&request).await
+        let result = self.send_request(&request).await;
+
+        // MIK-5982: when the backend daemon restarts, our stored session ID is
+        // dead and every request — including circuit-breaker half-open probes —
+        // fails with `Session not found` forever (observed live 2026-06-11:
+        // hebb unreachable 6.5h while healthy). On the session-expiry
+        // signature, drop the session, re-run the initialize handshake, and
+        // retry the original request exactly once. `initialize()` calls
+        // `send_request` directly (not `request`), so this cannot recurse.
+        let had_session = self.session_id.read().is_some();
+        if let Err(ref err) = result
+            && had_session
+            && is_session_expired_error(err)
+        {
+            warn!(
+                url = %self.base_url,
+                method = %method,
+                "Backend session expired; re-initializing and retrying once"
+            );
+            *self.session_id.write() = None;
+            self.initialize().await?;
+            return self.send_request(&request).await;
+        }
+
+        result
     }
 
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<()> {

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -478,3 +478,169 @@ async fn build_headers_trace_flag_gates_trace_header() {
         "trace:true must emit x-trace-id"
     );
 }
+
+// =========================================================================
+// Session expiry → re-initialize → retry (MIK-5982)
+// =========================================================================
+
+/// When the backend daemon restarts, the stored session ID is dead and the
+/// backend answers `-32015 Session not found`. The transport must drop the
+/// session, re-run the initialize handshake, and retry the original request
+/// once. Regression test for the 2026-06-11 incident (hebb unreachable 6.5h
+/// behind a permanently re-opening circuit breaker).
+#[tokio::test]
+async fn request_reinitializes_session_and_retries_on_session_not_found() {
+    use axum::{
+        Json, Router,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        response::IntoResponse,
+        routing::post,
+    };
+    use serde_json::json;
+
+    const FRESH_SESSION: &str = "fresh-session-after-restart";
+
+    async fn mcp_handler(
+        State(hits): State<Arc<std::sync::atomic::AtomicU32>>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> axum::response::Response {
+        hits.fetch_add(1, Ordering::Relaxed);
+        let session = headers
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let method = body["method"].as_str().unwrap_or("");
+
+        // Notifications (no id) are acknowledged unconditionally.
+        if body.get("id").is_none() {
+            return StatusCode::ACCEPTED.into_response();
+        }
+
+        if method == "initialize" {
+            // Restarted daemon: hands out a fresh session on initialize.
+            let mut resp_headers = HeaderMap::new();
+            resp_headers.insert("mcp-session-id", FRESH_SESSION.parse().unwrap());
+            return (
+                StatusCode::OK,
+                resp_headers,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "0"}
+                    }
+                })),
+            )
+                .into_response();
+        }
+
+        if session == FRESH_SESSION {
+            // Post-restart session: requests succeed.
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {"ok": true}
+                })),
+            )
+                .into_response()
+        } else {
+            // Stale (pre-restart) session: the rust-mcp-sdk signature.
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "code": -32015,
+                    "data": null,
+                    "message": "Bad Request: Session not found"
+                })),
+            )
+                .into_response()
+        }
+    }
+
+    // GIVEN: a mock backend that rejects the stale session
+    let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/mcp", post(mcp_handler))
+        .with_state(Arc::clone(&hits));
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let transport = make_transport(&format!("http://{addr}/mcp"));
+    *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
+    *transport.session_id.write() = Some("stale-session-from-before-restart".to_string());
+
+    // WHEN: a request rides the dead session
+    let response = transport.request("tools/list", None).await.unwrap();
+
+    // THEN: the transport re-initialized and the retry succeeded
+    assert!(response.error.is_none(), "retried request must succeed");
+    assert_eq!(
+        transport.session_id.read().as_deref(),
+        Some(FRESH_SESSION),
+        "fresh session ID must replace the stale one"
+    );
+
+    server.abort();
+}
+
+/// A request without any session that fails with a non-session error must NOT
+/// trigger the re-initialize path (no retry storm on genuinely broken backends).
+#[tokio::test]
+async fn request_does_not_reinitialize_without_a_session() {
+    use axum::{Json, Router, http::StatusCode, routing::post};
+    use serde_json::json;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new().route(
+        "/mcp",
+        post(|| async {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"message": "Bad Request: Session not found"})),
+            )
+        }),
+    );
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let transport = make_transport(&format!("http://{addr}/mcp"));
+    *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
+    // No session_id set: the expiry signature without a prior session must
+    // surface as a plain error (nothing to re-initialize).
+
+    let err = transport.request("tools/list", None).await.unwrap_err();
+    assert!(err.to_string().contains("Session not found"));
+
+    server.abort();
+}
+
+#[test]
+fn session_expired_detection_matches_known_signatures() {
+    // rust-mcp-sdk shape (hebb-serve, observed live 2026-06-11)
+    assert!(is_session_expired_error(&Error::Transport(
+        "HTTP 400 Bad Request: {\"code\":-32015,\"data\":null,\"message\":\"Bad Request: Session not found\"}".to_string()
+    )));
+    // MCP spec: 404 = session terminated/expired
+    assert!(is_session_expired_error(&Error::Transport(
+        "HTTP 404 Not Found: ".to_string()
+    )));
+    // Plain transport failure must not match
+    assert!(!is_session_expired_error(&Error::Transport(
+        "Request failed: connection refused".to_string()
+    )));
+    // Non-transport errors must not match
+    assert!(!is_session_expired_error(&Error::Protocol(
+        "Session not found".to_string()
+    )));
+}


### PR DESCRIPTION
## What

Fixes the two failure modes behind the 2026-06-11 incident where a healthy backend (hebb-serve) was unreachable through the gateway for 6.5 hours after a routine daemon restart.

| Ticket | Bug | Fix |
|---|---|---|
| MIK-5982 | When a backend daemon restarts, the stored MCP session ID is dead. Every request, including circuit-breaker half-open probes, failed with `-32015 Session not found`, re-opening the breaker on each probe, forever. | The HTTP transport detects the session-expiry signature (`-32015`, "session not found", or HTTP 404 per the MCP Streamable HTTP spec), drops the session, re-runs the initialize handshake, and retries the original request exactly once. `initialize()` calls `send_request` directly, so there is no recursion path, and the single-shot retry cannot storm a genuinely dead backend. |
| MIK-5983 | The `CIRCUIT_OPEN` error message tells operators to run `gateway_revive_server`, but that tool only reset the kill switch. The documented recovery path was a no-op for breaker trips. | `revive_server` now also closes the backend's circuit breaker and reports `breaker_was_open` in its response. New `CircuitBreaker::reset()` clears the failure window even when the breaker is already closed. |

## Timeline that motivated this

- 05:21:37Z ping to hebb green
- 05:22:36Z hebb-serve restarts; first failure `HTTP 400 ... Session not found` (29s latency = restart window)
- 05:22 to 12:06Z breaker re-opens on every half-open probe; backend reported down while demonstrably healthy
- 12:06Z recovered only by forcing a config diff so hot-reload rebuilt the transport

## Tests

- Circuit breaker: reset from Open, failure-window clear while Closed, disabled no-op
- Meta tool: revive resets a tripped breaker (registered backend), unregistered-backend path keeps kill-switch-only semantics
- Transport: mock restarted daemon (axum) proves re-init-and-retry end to end including fresh session adoption; no-session guard prevents retry storms; signature detection table covers the rust-mcp-sdk and MCP-spec shapes

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite pass locally (pre-push gate enforced the same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)