### PR TITLE
fix(capability): output schema can opt into extra fields via additionalProperties (#250)

### DIFF
--- a/src/capability/schema_validator/mod.rs
+++ b/src/capability/schema_validator/mod.rs
@@ -112,6 +112,23 @@ impl SchemaValidationResult {
 /// to work unchanged.
 #[must_use]
 pub fn validate_arguments(arguments: &Value, input_schema: &Value) -> SchemaValidationResult {
+    // Inputs are strict: an unrecognised parameter is almost always a caller
+    // typo or a hallucinated field, so it is reported as a violation.
+    validate_object(arguments, input_schema, true)
+}
+
+/// Core object validator shared by [`validate_arguments`] and [`validate_output`].
+///
+/// `reject_extra_keys` controls how keys absent from the schema's `properties`
+/// are treated: strict (`true`) for inputs, lenient (`false`) for outputs, where
+/// upstream APIs legitimately return extra fields the declared schema does not
+/// enumerate (e.g. Brave's `mixed`/`type`, Exa's `costDollars`/`searchTime`).
+#[must_use]
+fn validate_object(
+    arguments: &Value,
+    input_schema: &Value,
+    reject_extra_keys: bool,
+) -> SchemaValidationResult {
     // No schema → nothing to validate.
     if input_schema.is_null() || input_schema == &Value::Object(serde_json::Map::new()) {
         return SchemaValidationResult {
@@ -170,8 +187,9 @@ pub fn validate_arguments(arguments: &Value, input_schema: &Value) -> SchemaVali
     }
 
     // Step 2 – unknown parameters.
+    // Step 2 – extra keys not declared in the schema (strict for inputs only).
     for key in arg_map.keys() {
-        if !properties.contains_key(key.as_str()) {
+        if reject_extra_keys && !properties.contains_key(key.as_str()) {
             let known: Vec<&str> = properties.keys().map(String::as_str).collect();
             violations.push(ValidationViolation::new(
                 key,
@@ -230,7 +248,10 @@ pub fn validate_arguments(arguments: &Value, input_schema: &Value) -> SchemaVali
 /// and simple numeric/string constraints.
 #[must_use]
 pub fn validate_output(result: &Value, output_schema: &Value) -> SchemaValidationResult {
-    validate_arguments(result, output_schema)
+    // Outputs are lenient on extra keys: upstream APIs legitimately return
+    // fields the declared schema does not enumerate. Required-field and type
+    // checks still apply.
+    validate_object(result, output_schema, false)
 }
 
 // ── Per-property validation ───────────────────────────────────────────────────

--- a/src/capability/schema_validator/mod.rs
+++ b/src/capability/schema_validator/mod.rs
@@ -186,7 +186,6 @@ fn validate_object(
         }
     }
 
-    // Step 2 – unknown parameters.
     // Step 2 – extra keys not declared in the schema (strict for inputs only).
     for key in arg_map.keys() {
         if reject_extra_keys && !properties.contains_key(key.as_str()) {
@@ -248,10 +247,15 @@ fn validate_object(
 /// and simple numeric/string constraints.
 #[must_use]
 pub fn validate_output(result: &Value, output_schema: &Value) -> SchemaValidationResult {
-    // Outputs are lenient on extra keys: upstream APIs legitimately return
-    // fields the declared schema does not enumerate. Required-field and type
-    // checks still apply.
-    validate_object(result, output_schema, false)
+    // Outputs fail closed by default: extra keys not declared in the schema are
+    // rejected, so a backend cannot smuggle undeclared fields past the contract
+    // (anti-exfiltration control). A schema may opt into leniency with
+    // `additionalProperties: true` — used for backends like search whose
+    // upstream responses carry well-known extra fields the schema does not
+    // enumerate (e.g. Brave's `mixed`/`type`, Exa's `costDollars`). Required and
+    // type checks always apply.
+    let allows_extra = output_schema.get("additionalProperties") == Some(&Value::Bool(true));
+    validate_object(result, output_schema, !allows_extra)
 }
 
 // ── Per-property validation ───────────────────────────────────────────────────

--- a/src/capability/schema_validator/tests.rs
+++ b/src/capability/schema_validator/tests.rs
@@ -58,32 +58,38 @@ fn validate_output_reuses_object_schema_rules() {
 }
 
 // Regression for #250: upstream search APIs (Brave, Exa) return extra
-// top-level fields the gateway's declared output schema does not enumerate
-// (e.g. Brave's `mixed`/`type`, Exa's `costDollars`/`searchTime`). Output
-// validation must tolerate these extra keys instead of rejecting an
-// otherwise-valid response. Required-field and type checks still apply.
+// top-level fields the declared output schema does not enumerate (e.g. Brave's
+// `mixed`/`type`, Exa's `costDollars`/`searchTime`). A schema can opt into
+// tolerating these via `additionalProperties: true`, while the default stays
+// fail-closed (anti-exfiltration). Required and type checks always apply.
 #[test]
-fn validate_output_tolerates_extra_upstream_fields() {
-    let schema = schema_with_props(json!({ "web": { "type": "object" } }), &[]);
+fn validate_output_tolerates_extra_fields_when_schema_opts_in() {
+    let mut schema = schema_with_props(json!({ "web": { "type": "object" } }), &[]);
+    schema["additionalProperties"] = json!(true);
     let result = validate_output(
         &json!({ "web": { "results": [] }, "mixed": {}, "type": "search" }),
         &schema,
     );
     assert!(
         result.is_valid(),
-        "extra upstream fields must not fail output validation: {:?}",
+        "additionalProperties:true output must tolerate extra fields: {:?}",
         result.violations
     );
+}
 
-    // The same extra keys ARE rejected on the input path (strict).
-    let input = validate_arguments(
-        &json!({ "web": {}, "mixed": {}, "type": "search" }),
-        &schema,
-    );
+#[test]
+fn validate_output_rejects_extra_fields_by_default() {
+    // No additionalProperties → fail closed (anti-exfiltration default).
+    let schema = schema_with_props(json!({ "web": { "type": "object" } }), &[]);
+    let result = validate_output(&json!({ "web": {}, "exfil": "secret" }), &schema);
     assert!(
-        !input.is_valid(),
-        "input validation must still reject extra keys"
+        !result.is_valid(),
+        "default output validation must reject undeclared fields"
     );
+
+    // Inputs are always strict regardless.
+    let input = validate_arguments(&json!({ "web": {}, "exfil": "x" }), &schema);
+    assert!(!input.is_valid(), "input validation must reject extra keys");
 }
 
 #[test]

--- a/src/capability/schema_validator/tests.rs
+++ b/src/capability/schema_validator/tests.rs
@@ -57,6 +57,35 @@ fn validate_output_reuses_object_schema_rules() {
     assert_eq!(result.coerced["count"], json!(2));
 }
 
+// Regression for #250: upstream search APIs (Brave, Exa) return extra
+// top-level fields the gateway's declared output schema does not enumerate
+// (e.g. Brave's `mixed`/`type`, Exa's `costDollars`/`searchTime`). Output
+// validation must tolerate these extra keys instead of rejecting an
+// otherwise-valid response. Required-field and type checks still apply.
+#[test]
+fn validate_output_tolerates_extra_upstream_fields() {
+    let schema = schema_with_props(json!({ "web": { "type": "object" } }), &[]);
+    let result = validate_output(
+        &json!({ "web": { "results": [] }, "mixed": {}, "type": "search" }),
+        &schema,
+    );
+    assert!(
+        result.is_valid(),
+        "extra upstream fields must not fail output validation: {:?}",
+        result.violations
+    );
+
+    // The same extra keys ARE rejected on the input path (strict).
+    let input = validate_arguments(
+        &json!({ "web": {}, "mixed": {}, "type": "search" }),
+        &schema,
+    );
+    assert!(
+        !input.is_valid(),
+        "input validation must still reject extra keys"
+    );
+}
+
 #[test]
 fn output_error_heading_matches_result_validation() {
     let schema = schema_with_props(json!({ "status": { "type": "string" } }), &["status"]);


### PR DESCRIPTION
Refs #250.

## Problem
`validate_output` failed closed on any key absent from the declared schema's `properties` — a **deliberate anti-exfiltration control** (a backend must not smuggle undeclared fields past its contract; see the `enforce_output_schema_rejects_unexpected_fields` test with its `exfil` field). But that also rejected *valid* responses from backends whose declared schema is incomplete: the fulcrum search backends return well-known extra fields the schema does not enumerate, so a successful API call failed validation and the tool was unusable.

- `brave_search` → rejected on `mixed`, `type`
- `exa_search` → rejected on `costDollars`, `requestId`, `resolvedSearchType`, `searchTime`

## Fix — preserve security, resolve the tension
Honor JSON Schema `additionalProperties`:
- **Default (absent / false)** stays **fail-closed** — anti-exfiltration posture and the existing test preserved.
- A schema may set **`additionalProperties: true`** to opt into tolerating extra top-level fields.
- Inputs remain strict regardless. Required + type checks always apply.

Implemented by splitting the core into `validate_object(value, schema, reject_extra_keys)`; `validate_output` computes `reject_extra_keys` from the schema's `additionalProperties`.

## Scope
**Mechanism only.** The brave/exa output schemas live in the **private capabilities repo** (`mcp-gateway-private/capabilities`), and need `additionalProperties: true` set there for the user-visible symptom to fully clear. This PR makes that opt-in possible without weakening the secure default.

## Verification
- New tests: opt-in tolerates extra fields; default rejects them; inputs reject them.
- The anti-exfiltration `enforce_output_schema_rejects_unexpected_fields` test still passes.
- 2841 lib tests green; `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` clean; pre-push hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)