### PR TITLE
fix(failsafe): auto-recover a tripped circuit breaker when a backend respawns

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -843,6 +843,98 @@ impl Backend {
         self.failsafe.circuit_breaker.reset();
     }
 
+    /// Whether this backend's circuit breaker is currently tripped
+    /// (`Open` or `HalfOpen` — i.e. not `Closed`).
+    #[must_use]
+    pub fn is_circuit_tripped(&self) -> bool {
+        self.failsafe.circuit_breaker.state() != crate::failsafe::CircuitState::Closed
+    }
+
+    /// Tear down the current transport (killing any child process) and start a
+    /// fresh one.
+    ///
+    /// Unlike [`ensure_started`](Self::ensure_started), this does **not** trust
+    /// `is_connected()` — it always rebuilds. A wedged-but-not-exited child
+    /// (responds to `try_wait` as alive yet never answers requests) cannot be
+    /// recovered by `ensure_started` alone; this is the escape hatch the health
+    /// loop uses when a probe fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the fresh transport fails to start or initialize.
+    pub async fn force_restart(&self) -> Result<()> {
+        let _guard = self.start_lock.lock().await;
+        // Take the transport out and drop the RwLock write guard *before*
+        // awaiting close() — a parking_lot guard is not Send across an await.
+        let old = self.transport.write().take();
+        if let Some(old) = old {
+            let _ = old.close().await;
+        }
+        self.start().await
+    }
+
+    /// Active health/recovery probe driven by the background health loop.
+    ///
+    /// This is the gateway's automatic equivalent of `gateway_revive_server`.
+    /// Two properties make it actually recover a wedged backend, which the old
+    /// `backend.request("ping")` health check could not:
+    ///
+    /// 1. **It bypasses the circuit breaker.** A probe routed through
+    ///    [`request`](Self::request) short-circuits on `can_proceed()` and
+    ///    returns `CircuitOpen` *without touching the backend* — so it could
+    ///    never discover that an `Open` backend had recovered. This probe talks
+    ///    to the transport directly.
+    /// 2. **On success it resets a tripped breaker**; on failure it forces a
+    ///    transport rebuild so the next probe targets a fresh child.
+    ///
+    /// `timeout` bounds the probe so a hung backend cannot stall the loop.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot be started, the probe times out,
+    /// or the `ping` call fails. The breaker is left for organic traffic to
+    /// trip — this probe never records failures, only recoveries.
+    pub async fn health_probe(&self, timeout: Duration) -> Result<()> {
+        // `ensure_started` now respawns reliably because `is_connected()` does a
+        // real liveness check (Fix C).
+        if let Err(e) = self.ensure_started().await {
+            let _ = self.force_restart().await;
+            return Err(e);
+        }
+
+        let transport = { self.transport.read().clone() };
+        let Some(transport) = transport else {
+            return Err(Error::BackendUnavailable(self.name.clone()));
+        };
+
+        match tokio::time::timeout(timeout, transport.request("ping", None)).await {
+            Ok(Ok(_)) => {
+                if self.is_circuit_tripped() {
+                    info!(
+                        backend = %self.name,
+                        "Health probe succeeded; resetting tripped circuit breaker"
+                    );
+                    self.failsafe.circuit_breaker.reset();
+                }
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                warn!(backend = %self.name, error = %e, "Health probe failed; rebuilding transport");
+                let _ = self.force_restart().await;
+                Err(e)
+            }
+            Err(_elapsed) => {
+                warn!(
+                    backend = %self.name,
+                    timeout_ms = timeout.as_millis(),
+                    "Health probe timed out; rebuilding transport"
+                );
+                let _ = self.force_restart().await;
+                Err(Error::BackendTimeout(self.name.clone()))
+            }
+        }
+    }
+
     /// Get health metrics for this backend.
     pub fn health_metrics(&self) -> crate::failsafe::HealthMetrics {
         self.failsafe.health_metrics()
@@ -1099,6 +1191,119 @@ mod tests {
             self.connected.store(false, Ordering::Relaxed);
             Ok(())
         }
+    }
+
+    // Method-agnostic transport for health-probe / recovery tests: answers any
+    // request with success unless `fail` is set, with a settable `connected`
+    // flag. Distinct from MockTransport, which hard-asserts "tools/list".
+    struct RecoveryMock {
+        connected: AtomicBool,
+        fail: AtomicBool,
+        pings: AtomicUsize,
+    }
+
+    impl RecoveryMock {
+        fn connected() -> Self {
+            Self {
+                connected: AtomicBool::new(true),
+                fail: AtomicBool::new(false),
+                pings: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Transport for RecoveryMock {
+        async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+            self.pings.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::Relaxed) {
+                return Err(Error::BackendUnavailable("probe failed".to_string()));
+            }
+            Ok(JsonRpcResponse::success_serialized(
+                RequestId::Number(1),
+                json!({}),
+            ))
+        }
+
+        async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected.load(Ordering::Relaxed)
+        }
+
+        async fn close(&self) -> Result<()> {
+            self.connected.store(false, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn is_circuit_tripped_reflects_breaker_state() {
+        let backend = Backend::new(
+            "test",
+            BackendConfig::default(),
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        );
+        assert!(!backend.is_circuit_tripped());
+        backend.trip_circuit_breaker_for_test();
+        assert!(backend.is_circuit_tripped());
+        backend.reset_circuit_breaker();
+        assert!(!backend.is_circuit_tripped());
+    }
+
+    // Headline regression: a successful health probe must auto-reset a tripped
+    // breaker. This is the recovery the old health check could never perform,
+    // because it pinged through the breaker (which short-circuits when Open).
+    #[tokio::test]
+    async fn health_probe_resets_tripped_breaker_on_success() {
+        let backend = Arc::new(Backend::new(
+            "test",
+            BackendConfig::default(),
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        ));
+        let mock = Arc::new(RecoveryMock::connected());
+        *backend.transport.write() = Some(mock.clone() as Arc<dyn Transport>);
+
+        backend.trip_circuit_breaker_for_test();
+        assert!(backend.is_circuit_tripped(), "precondition: breaker open");
+
+        backend
+            .health_probe(Duration::from_secs(5))
+            .await
+            .expect("probe should succeed");
+
+        assert!(
+            !backend.is_circuit_tripped(),
+            "a successful probe must reset the tripped breaker"
+        );
+        assert_eq!(mock.pings.load(Ordering::SeqCst), 1);
+    }
+
+    // A failing probe must NOT reset the breaker — recovery is success-gated.
+    #[tokio::test]
+    async fn health_probe_failure_leaves_breaker_tripped() {
+        let backend = Arc::new(Backend::new(
+            "test",
+            BackendConfig::default(),
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        ));
+        let mock = Arc::new(RecoveryMock::connected());
+        mock.fail.store(true, Ordering::Relaxed);
+        *backend.transport.write() = Some(mock.clone() as Arc<dyn Transport>);
+
+        backend.trip_circuit_breaker_for_test();
+        let result = backend.health_probe(Duration::from_secs(5)).await;
+
+        assert!(result.is_err(), "failed probe returns Err");
+        assert!(
+            backend.is_circuit_tripped(),
+            "a failed probe must leave the breaker tripped"
+        );
     }
 
     fn sample_tool(name: &str) -> Tool {

--- a/src/config/features/failsafe.rs
+++ b/src/config/features/failsafe.rs
@@ -18,7 +18,12 @@ const DEFAULT_RETRY_MULTIPLIER: f64 = 2.0;
 const DEFAULT_RATE_LIMIT_RPS: u32 = 100;
 const DEFAULT_RATE_LIMIT_BURST: u32 = 50;
 
-const DEFAULT_HEALTH_CHECK_INTERVAL_SECS: u64 = 30;
+// Deliberately NOT equal to `DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_SECS` (30s).
+// When the health interval and the breaker's half-open timer are phase-locked,
+// a probe can re-trip the breaker on the same beat it would have half-opened,
+// wedging recovery. A 10s interval also means an auto-recovering backend is
+// detected and its breaker reset within ~one interval (see Backend::health_probe).
+const DEFAULT_HEALTH_CHECK_INTERVAL_SECS: u64 = 10;
 const DEFAULT_HEALTH_CHECK_TIMEOUT_SECS: u64 = 5;
 
 // ── Failsafe ───────────────────────────────────────────────────────────────────
@@ -136,5 +141,36 @@ impl Default for HealthCheckConfig {
             interval: Duration::from_secs(DEFAULT_HEALTH_CHECK_INTERVAL_SECS),
             timeout: Duration::from_secs(DEFAULT_HEALTH_CHECK_TIMEOUT_SECS),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The health-check interval must NOT equal the breaker reset timeout.
+    // When phase-locked, a probe can re-trip the breaker on the same beat it
+    // would have half-opened, wedging recovery (the bug this guards against).
+    #[test]
+    fn health_interval_is_decoupled_from_breaker_reset_timeout() {
+        let health = HealthCheckConfig::default();
+        let breaker = CircuitBreakerConfig::default();
+        assert_ne!(
+            health.interval, breaker.reset_timeout,
+            "health interval and breaker reset_timeout must differ to avoid phase-lock"
+        );
+    }
+
+    // Probe timeout must be shorter than the interval so a hung probe cannot
+    // overlap the next tick.
+    #[test]
+    fn health_timeout_is_shorter_than_interval() {
+        let health = HealthCheckConfig::default();
+        assert!(
+            health.timeout < health.interval,
+            "probe timeout ({:?}) must be < interval ({:?})",
+            health.timeout,
+            health.interval
+        );
     }
 }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -711,9 +711,18 @@ impl Gateway {
                 tokio::select! {
                     _ = interval.tick() => {
                         for backend in backends_clone.all() {
-                            if backend.is_running() {
-                                // Send ping
-                                if let Err(e) = backend.request("ping", None).await {
+                            // Probe running backends (liveness) AND backends whose
+                            // breaker is tripped (recovery). The old guard only
+                            // probed running backends — but a backend that died
+                            // and tripped its breaker reports `is_running()==false`,
+                            // so it was skipped exactly when it needed recovery.
+                            // Cleanly-idle backends (closed breaker, not running)
+                            // are left alone so the idle reaper can shut them down.
+                            if backend.is_running() || backend.is_circuit_tripped() {
+                                // `health_probe` bypasses the breaker, resets it on
+                                // success, and rebuilds the transport on failure —
+                                // the automatic equivalent of gateway_revive_server.
+                                if let Err(e) = backend.health_probe(health_config.timeout).await {
                                     warn!(backend = %backend.name, error = %e, "Health check failed");
                                 }
                             }

--- a/src/gateway/ui/backends.rs
+++ b/src/gateway/ui/backends.rs
@@ -126,6 +126,7 @@ pub fn backends_router() -> Router<Arc<AppState>> {
         .route("/ui/api/backends", post(add_backend))
         .route("/ui/api/backends/{name}", delete(remove_backend))
         .route("/ui/api/backends/{name}", patch(update_backend))
+        .route("/ui/api/backends/{name}/revive", post(revive_backend))
         .route("/ui/api/registry", get(list_registry))
         .route("/ui/api/registry/search", get(search_registry))
 }
@@ -239,6 +240,37 @@ async fn remove_backend(
 ///
 /// Merges the provided fields into the existing backend config.
 /// Returns 200 on success, 404 when not found.
+async fn revive_backend(
+    State(state): State<Arc<AppState>>,
+    client: Option<Extension<AuthenticatedClient>>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    let client = client.map(|Extension(c)| c);
+    if !is_admin(client.as_ref()) {
+        return admin_auth_required().into_response();
+    }
+
+    let Some(backend) = state.backends.get(&name) else {
+        return flat_error(StatusCode::NOT_FOUND, format!("Backend '{name}' not found"))
+            .into_response();
+    };
+
+    let breaker_was_open = backend.is_circuit_tripped();
+    backend.reset_circuit_breaker();
+    let rebuilt = backend.force_restart().await.is_ok();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "backend": name,
+            "status": "revived",
+            "breaker_was_open": breaker_was_open,
+            "transport_rebuilt": rebuilt,
+        })),
+    )
+        .into_response()
+}
+
 async fn update_backend(
     State(state): State<Arc<AppState>>,
     client: Option<Extension<AuthenticatedClient>>,

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -430,7 +430,26 @@ impl Transport for StdioTransport {
     }
 
     fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed)
+        if !self.connected.load(Ordering::Relaxed) {
+            return false;
+        }
+        // Defense in depth (Fix C): the reader task flips `connected=false` on
+        // stdout EOF, but a zombie child or a not-yet-scheduled reader task can
+        // leave the cached flag stale-true. A stale-true flag makes
+        // `Backend::ensure_started` a no-op and dispatches requests into a dead
+        // pipe — the core reason a tripped breaker never recovered. Confirm real
+        // liveness with a non-blocking waitpid. `try_lock` keeps this sync
+        // method from blocking; on lock contention we trust the flag.
+        if let Ok(mut guard) = self.child.try_lock()
+            && let Some(child) = guard.as_mut()
+            && let Ok(Some(_status)) = child.try_wait()
+        {
+            // Child has exited; reconcile the cached flag so callers and future
+            // checks see the truth.
+            self.connected.store(false, Ordering::Relaxed);
+            return false;
+        }
+        true
     }
 
     async fn close(&self) -> Result<()> {


### PR DESCRIPTION
## Problem

A backend whose stdio child process dies and respawns leaves its circuit breaker wedged `Open` indefinitely. Observed live on the `trvl` backend: the breaker stayed open for >7 minutes while the child process itself was healthy and answering `ping` directly.

Root cause — the gateway has no working closed-loop recovery. The background health check could not heal a broken backend for three compounding reasons:

1. **Skipped down backends** — `is_running()` guard meant a dead backend (which reports `is_running()==false`) was never probed, exactly when it needed recovery.
2. **Pinged through the breaker** — `backend.request("ping")` short-circuits on `can_proceed()` and returns `CircuitOpen` without touching the backend, so the check could never discover the backend had recovered.
3. **Failure only logged** — no transport rebuild, no breaker reset.

Recovery was therefore left to organic traffic threading `success_threshold` (3) consecutive clean probes through 30s half-open windows, against an `is_connected()` that only read a cached `AtomicBool` (could report a zombie child as alive). With `reset_timeout` (30s) phase-locked to the health interval (30s), any single probe failure reset the counter, so it rarely converged.

## Changes

| # | Change | File |
|---|---|---|
| A | `Backend::health_probe()` — active recovery probe that **bypasses the breaker**, resets it on success, rebuilds the transport on failure. `force_restart()` rebuilds unconditionally (kill child + respawn + re-init). | `backend/mod.rs` |
| B | Health loop probes **running and breaker-tripped** backends; cleanly-idle backends left to the idle reaper. | `gateway/server/mod.rs` |
| C | `StdioTransport::is_connected()` confirms liveness via non-blocking `try_wait()` so a stale flag can't make `ensure_started()` a no-op. | `transport/stdio.rs` |
| D | Default health interval 30s → 10s, decoupled from the 30s breaker reset timeout (removes phase-lock; faster recovery). | `config/features/failsafe.rs` |
| E | `POST /ui/api/backends/{name}/revive` admin route — out-of-band operator lever (reset breaker + force rebuild) usable via curl, independent of the MCP tool surface. | `gateway/ui/backends.rs` |

A + B + C deliver automatic recovery within ~one health interval; D removes the phase-lock; E is the manual safety valve.

## Tests

- `health_probe_resets_tripped_breaker_on_success` (headline regression)
- `health_probe_failure_leaves_breaker_tripped`
- `is_circuit_tripped_reflects_breaker_state`
- `health_interval_is_decoupled_from_breaker_reset_timeout`
- `health_timeout_is_shorter_than_interval`

Full lib suite: 2847 pass. `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Scope / blast radius

5 files, +306/-5. New public API is additive (`is_circuit_tripped`, `force_restart`, `health_probe`, one HTTP route). No change to the Meta-MCP tool surface (E is an HTTP admin route, not a meta-tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)