### PR TITLE
spike(evidence): evidence-typed verdict + non-bypassable render guard (MIK-5854)

### DIFF
--- a/src/evidence/adapter.rs
+++ b/src/evidence/adapter.rs
@@ -119,9 +119,7 @@ fn evidence_from_error(source: SourceId, error: &Error) -> EvidenceState {
         | Error::Config(_)
         | Error::ConfigValidation(_)
         | Error::ConfigWatcher(_)
-        | Error::CapabilityHashMismatch { .. } => {
-            EvidenceState::NotConfigured { source, detail }
-        }
+        | Error::CapabilityHashMismatch { .. } => EvidenceState::NotConfigured { source, detail },
 
         // Everything else is an unavailability / transport / protocol failure:
         // the source could not produce an authoritative answer.
@@ -166,7 +164,10 @@ mod tests {
     fn ok_with_tool_level_error_is_failed_not_no_hit() {
         let r = Ok(json!({"content": [], "isError": true}));
         assert!(
-            matches!(evidence_from_result(src(), &r), EvidenceState::Failed { .. }),
+            matches!(
+                evidence_from_result(src(), &r),
+                EvidenceState::Failed { .. }
+            ),
             "isError=true must be Failed, never CheckedNoHit"
         );
     }

--- a/src/evidence/adapter.rs
+++ b/src/evidence/adapter.rs
@@ -1,0 +1,232 @@
+//! Backend-result → [`EvidenceState`] adapter (spike MIK-5854, EVGUARD.1).
+//!
+//! This is the **additive** glue that maps a gateway backend invocation outcome
+//! onto the typed evidence model. It is pure and deterministic, depends only on
+//! the existing [`crate::error::Error`] enum and `serde_json::Value`, and is
+//! **not** wired into any production invoke / result-proxy path — wiring is a
+//! later phase (attach a `SourceId` at the invoke boundary and route the result
+//! here before the result is assembled).
+//!
+//! The mapping is the load-bearing decision of the whole apparatus: it is where a
+//! *failure to check* is kept categorically distinct from an *authoritative
+//! negative*. A transport error, a timeout, a missing backend, or an auth refusal
+//! all become "could-not-check" variants; only a genuine empty-but-successful
+//! response becomes [`EvidenceState::CheckedNoHit`].
+
+use serde_json::Value;
+
+use crate::error::Error;
+
+use super::state::{EvidenceState, SourceId};
+
+/// True when an MCP tool result carries a tool-level error (`isError: true`).
+///
+/// MCP backends can return a *successful transport response* whose body reports
+/// a tool error. That is a failure to obtain an authoritative answer, not a
+/// negative finding, so it must not be read as [`EvidenceState::CheckedNoHit`].
+#[must_use]
+pub fn mcp_is_error(value: &Value) -> bool {
+    value.get("isError").and_then(Value::as_bool) == Some(true)
+}
+
+/// True when a successful backend result carries no usable data.
+///
+/// Treats JSON null, an empty array, an empty object, an empty/whitespace string,
+/// and the MCP shape `{ "content": [] }` (or absent/null `content`) as empty. A
+/// non-empty `content` array, or any other non-empty value, is data.
+#[must_use]
+pub fn value_is_empty(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(s) => s.trim().is_empty(),
+        Value::Array(a) => a.is_empty(),
+        Value::Object(map) => {
+            if let Some(content) = map.get("content") {
+                // MCP envelope: emptiness is decided by the content payload.
+                return match content {
+                    Value::Null => true,
+                    Value::Array(a) => a.is_empty(),
+                    _ => false,
+                };
+            }
+            map.is_empty()
+        }
+        // Numbers and booleans are data.
+        _ => false,
+    }
+}
+
+/// Map a backend invocation outcome to an [`EvidenceState`] for `source`.
+///
+/// - `Ok` with a tool-level error (`isError: true`) → [`EvidenceState::Failed`].
+/// - `Ok` with no usable data → [`EvidenceState::CheckedNoHit`] (a trustworthy negative).
+/// - `Ok` with data → [`EvidenceState::CheckedHit`].
+/// - `Err` is mapped to the matching could-not-check variant (see the match).
+///
+/// # Examples
+///
+/// ```
+/// use mcp_gateway::evidence::{adapter::evidence_from_result, EvidenceState, SourceId};
+/// use serde_json::json;
+///
+/// let hit = evidence_from_result(SourceId::new("registry"), &Ok(json!({"content": [{"text": "x"}]})));
+/// assert!(matches!(hit, EvidenceState::CheckedHit { .. }));
+///
+/// let empty = evidence_from_result(SourceId::new("registry"), &Ok(json!({"content": []})));
+/// assert!(matches!(empty, EvidenceState::CheckedNoHit { .. }));
+/// ```
+#[must_use]
+pub fn evidence_from_result(source: SourceId, result: &Result<Value, Error>) -> EvidenceState {
+    match result {
+        Ok(value) => {
+            if mcp_is_error(value) {
+                EvidenceState::Failed {
+                    source,
+                    detail: Some("backend returned a tool-level error (isError=true)".to_string()),
+                }
+            } else if value_is_empty(value) {
+                EvidenceState::CheckedNoHit {
+                    source,
+                    detail: None,
+                }
+            } else {
+                EvidenceState::CheckedHit {
+                    source,
+                    detail: None,
+                }
+            }
+        }
+        Err(error) => evidence_from_error(source, error),
+    }
+}
+
+/// Map a gateway [`Error`] to its could-not-check [`EvidenceState`].
+///
+/// Kept separate so the error taxonomy is expressed once and is easy to extend
+/// as the gateway error enum grows.
+fn evidence_from_error(source: SourceId, error: &Error) -> EvidenceState {
+    let detail = Some(error.to_string());
+    match error {
+        // The backend was reached but did not answer in time.
+        Error::BackendTimeout(_) => EvidenceState::Timeout { source, detail },
+
+        // Authorization was refused.
+        Error::OAuth(_) => EvidenceState::NotAuthorized { source, detail },
+
+        // The source / tool is not present or not configured in this gateway.
+        Error::BackendNotFound(_)
+        | Error::ToolNotFound(_)
+        | Error::Config(_)
+        | Error::ConfigValidation(_)
+        | Error::ConfigWatcher(_)
+        | Error::CapabilityHashMismatch { .. } => {
+            EvidenceState::NotConfigured { source, detail }
+        }
+
+        // Everything else is an unavailability / transport / protocol failure:
+        // the source could not produce an authoritative answer.
+        _ => EvidenceState::Failed { source, detail },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn src() -> SourceId {
+        SourceId::new("test-source")
+    }
+
+    #[test]
+    fn ok_with_content_is_checked_hit() {
+        let r = Ok(json!({"content": [{"type": "text", "text": "found"}], "isError": false}));
+        assert!(matches!(
+            evidence_from_result(src(), &r),
+            EvidenceState::CheckedHit { .. }
+        ));
+    }
+
+    #[test]
+    fn ok_empty_content_is_checked_no_hit_not_failure() {
+        // The crown-jewel distinction: queried-and-empty is a trustworthy
+        // negative, NOT a failure to check.
+        for v in [json!({"content": []}), json!(null), json!([]), json!({})] {
+            assert!(
+                matches!(
+                    evidence_from_result(src(), &Ok(v.clone())),
+                    EvidenceState::CheckedNoHit { .. }
+                ),
+                "expected CheckedNoHit for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn ok_with_tool_level_error_is_failed_not_no_hit() {
+        let r = Ok(json!({"content": [], "isError": true}));
+        assert!(
+            matches!(evidence_from_result(src(), &r), EvidenceState::Failed { .. }),
+            "isError=true must be Failed, never CheckedNoHit"
+        );
+    }
+
+    #[test]
+    fn timeout_maps_to_timeout() {
+        let r: Result<Value, Error> = Err(Error::BackendTimeout("slow".into()));
+        assert!(matches!(
+            evidence_from_result(src(), &r),
+            EvidenceState::Timeout { .. }
+        ));
+    }
+
+    #[test]
+    fn oauth_maps_to_not_authorized() {
+        let r: Result<Value, Error> = Err(Error::OAuth("refused".into()));
+        assert!(matches!(
+            evidence_from_result(src(), &r),
+            EvidenceState::NotAuthorized { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_backend_maps_to_not_configured() {
+        for e in [
+            Error::BackendNotFound("x".into()),
+            Error::ToolNotFound("y".into()),
+            Error::Config("z".into()),
+        ] {
+            let r: Result<Value, Error> = Err(e);
+            assert!(matches!(
+                evidence_from_result(src(), &r),
+                EvidenceState::NotConfigured { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn transport_and_circuit_map_to_failed() {
+        for e in [
+            Error::CircuitOpen("open".into()),
+            Error::BackendUnavailable("down".into()),
+            Error::Transport("reset".into()),
+            Error::Internal("boom".into()),
+        ] {
+            let r: Result<Value, Error> = Err(e);
+            assert!(matches!(
+                evidence_from_result(src(), &r),
+                EvidenceState::Failed { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn source_id_is_preserved() {
+        let r = Ok(json!({"content": [{"text": "x"}]}));
+        let st = evidence_from_result(SourceId::new("alpha"), &r);
+        match st {
+            EvidenceState::CheckedHit { source, .. } => assert_eq!(source.as_str(), "alpha"),
+            other => panic!("expected CheckedHit, got {other:?}"),
+        }
+    }
+}

--- a/src/evidence/guard.rs
+++ b/src/evidence/guard.rs
@@ -41,7 +41,10 @@ pub struct RawClaim {
 impl RawClaim {
     /// Construct a raw candidate claim.
     pub fn new(text: impl Into<String>, evidence: Vec<EvidenceState>) -> Self {
-        Self { text: text.into(), evidence }
+        Self {
+            text: text.into(),
+            evidence,
+        }
     }
 }
 
@@ -134,7 +137,11 @@ pub fn render_guard(claims: Vec<RawClaim>) -> Vec<EmittableClaim> {
                 return None;
             }
 
-            Some(EmittableClaim { text: claim.text, verdict, citations })
+            Some(EmittableClaim {
+                text: claim.text,
+                verdict,
+                citations,
+            })
         })
         .collect()
 }

--- a/src/evidence/guard.rs
+++ b/src/evidence/guard.rs
@@ -1,0 +1,149 @@
+//! Non-bypassable render guard.
+//!
+//! The guard enforces a structural invariant: **a claim cannot be emitted
+//! without passing through [`render_guard`]**. This is achieved with the
+//! *sealed-constructor* pattern — [`EmittableClaim`] has only private fields and
+//! no public constructor, so the only way to obtain one is the [`render_guard`]
+//! function (the sole `pub` item that returns it). Downstream code can read an
+//! [`EmittableClaim`] via its accessors but can never fabricate one that skipped
+//! the guard.
+//!
+//! Each surviving claim is tagged with its [`Verdict`] and carries the
+//! [`SourceId`]s of the evidence-states that justify it, so every emitted claim
+//! is self-citing.
+//!
+//! # Drop vs downgrade policy
+//!
+//! - A claim with **no relevant backing** (empty, or only
+//!   [`EvidenceState::SkippedNotApplicable`]) is **dropped** — it never produces
+//!   an [`EmittableClaim`].
+//! - A claim with relevant backing is **emitted with its verdict tag**,
+//!   including [`Verdict::Disclaimer`] and [`Verdict::Adverse`]. Downgrading is
+//!   expressed through the verdict, not through suppression, so the experiment
+//!   can measure abstention ([`Verdict::Disclaimer`]) distinctly from an
+//!   authoritative negative ([`Verdict::Adverse`]).
+
+use crate::evidence::state::{EvidenceState, SourceId};
+use crate::evidence::verdict::{Verdict, classify};
+
+/// An unguarded, candidate claim plus the evidence-states backing it.
+///
+/// This is the *input* to the guard. It is freely constructible — it carries no
+/// authority. Only [`render_guard`] can turn it into an [`EmittableClaim`].
+#[derive(Debug, Clone)]
+pub struct RawClaim {
+    /// The proposition the agent wants to emit (free text).
+    pub text: String,
+    /// The evidence-states consulted in support of this claim.
+    pub evidence: Vec<EvidenceState>,
+}
+
+impl RawClaim {
+    /// Construct a raw candidate claim.
+    pub fn new(text: impl Into<String>, evidence: Vec<EvidenceState>) -> Self {
+        Self { text: text.into(), evidence }
+    }
+}
+
+/// A claim that has passed the render guard and is permitted to be emitted.
+///
+/// # Invariant
+///
+/// **The only constructor is [`render_guard`].** All fields are private and there
+/// is no public `new`/`From`/`Default`, so an [`EmittableClaim`] is *proof* that
+/// the claim was classified by the guard. This makes "emit a claim without
+/// guarding it" unrepresentable in the type system rather than merely
+/// discouraged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmittableClaim {
+    text: String,
+    verdict: Verdict,
+    citations: Vec<SourceId>,
+}
+
+impl EmittableClaim {
+    /// The claim text.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The verdict the guard assigned to this claim.
+    #[must_use]
+    pub fn verdict(&self) -> Verdict {
+        self.verdict
+    }
+
+    /// The evidence-source ids that justify this claim's verdict.
+    ///
+    /// Guaranteed non-empty: a claim with no relevant backing is dropped by the
+    /// guard rather than emitted.
+    #[must_use]
+    pub fn citations(&self) -> &[SourceId] {
+        &self.citations
+    }
+}
+
+/// The non-bypassable render guard.
+///
+/// Filters a batch of candidate [`RawClaim`]s into the [`EmittableClaim`]s that
+/// are permitted to surface. For each candidate:
+///
+/// 1. Compute its [`Verdict`] via [`classify`].
+/// 2. Collect the citing [`SourceId`]s — every relevant (non-not-applicable)
+///    evidence-state's source.
+/// 3. If there are **no** relevant evidence-states, **drop** the claim.
+/// 4. Otherwise emit an [`EmittableClaim`] tagged with the verdict and
+///    citations.
+///
+/// Because [`EmittableClaim`] is sealed, this function is the single chokepoint
+/// through which any claim must pass before it can be rendered.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_gateway::evidence::{EvidenceState, RawClaim, SourceId, Verdict, render_guard};
+///
+/// let backed = RawClaim::new(
+///     "entity X is on the list",
+///     vec![EvidenceState::CheckedHit { source: SourceId::new("list"), detail: None }],
+/// );
+/// let unbacked = RawClaim::new("entity Y is fine", vec![]);
+///
+/// let emitted = render_guard(vec![backed, unbacked]);
+/// assert_eq!(emitted.len(), 1); // the unbacked claim was dropped
+/// assert_eq!(emitted[0].verdict(), Verdict::Clean);
+/// assert_eq!(emitted[0].citations(), &[SourceId::new("list")]);
+/// ```
+#[must_use]
+pub fn render_guard(claims: Vec<RawClaim>) -> Vec<EmittableClaim> {
+    claims
+        .into_iter()
+        .filter_map(|claim| {
+            let verdict = classify(&claim.evidence);
+            let citations: Vec<SourceId> = claim
+                .evidence
+                .iter()
+                .filter(|state| !is_not_applicable(state))
+                .map(|state| state.source().clone())
+                .collect();
+
+            // Drop claims with no relevant backing — never emit an
+            // uncited claim.
+            if citations.is_empty() {
+                return None;
+            }
+
+            Some(EmittableClaim { text: claim.text, verdict, citations })
+        })
+        .collect()
+}
+
+/// Whether a state is a not-applicable (neutral) state, excluded from citations.
+fn is_not_applicable(state: &EvidenceState) -> bool {
+    matches!(state, EvidenceState::SkippedNotApplicable { .. })
+}
+
+#[cfg(test)]
+#[path = "guard_tests.rs"]
+mod tests;

--- a/src/evidence/guard_tests.rs
+++ b/src/evidence/guard_tests.rs
@@ -1,0 +1,127 @@
+//! Tests for the render guard: non-bypassability (structural), drop/downgrade
+//! behavior, and mandatory self-citation.
+
+use super::*;
+
+fn hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedHit { source: SourceId::new(id), detail: None }
+}
+fn no_hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedNoHit { source: SourceId::new(id), detail: None }
+}
+fn failed(id: &str) -> EvidenceState {
+    EvidenceState::Failed { source: SourceId::new(id), detail: None }
+}
+fn skipped(id: &str) -> EvidenceState {
+    EvidenceState::SkippedNotApplicable { source: SourceId::new(id), detail: None }
+}
+
+#[test]
+fn backed_claim_is_emitted_with_verdict_and_citations() {
+    let claims = vec![RawClaim::new("X is listed", vec![hit("registry")])];
+    let out = render_guard(claims);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].text(), "X is listed");
+    assert_eq!(out[0].verdict(), Verdict::Clean);
+    assert_eq!(out[0].citations(), &[SourceId::new("registry")]);
+}
+
+#[test]
+fn unbacked_claim_is_dropped() {
+    // GIVEN a claim with no evidence at all.
+    // THEN the guard drops it entirely (no EmittableClaim is produced).
+    let out = render_guard(vec![RawClaim::new("trust me", vec![])]);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn only_not_applicable_backing_is_dropped() {
+    // GIVEN a claim whose only backing is a not-applicable state.
+    // THEN it has no relevant citations and is dropped.
+    let out = render_guard(vec![RawClaim::new("n/a claim", vec![skipped("s")])]);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn adverse_claim_is_emitted_not_dropped() {
+    // An authoritative negative is a finding, not an absence — it is emitted
+    // (tagged Adverse), not suppressed.
+    let out = render_guard(vec![RawClaim::new("X not on list", vec![no_hit("registry")])]);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].verdict(), Verdict::Adverse);
+}
+
+#[test]
+fn disclaimer_claim_is_emitted_with_tag_not_dropped() {
+    // A could-not-check claim is downgraded via its verdict tag (Disclaimer),
+    // NOT dropped — so the experiment can observe abstention.
+    let out = render_guard(vec![RawClaim::new("X status unknown", vec![failed("registry")])]);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].verdict(), Verdict::Disclaimer);
+    // Still self-citing: the could-not-check source is named.
+    assert_eq!(out[0].citations(), &[SourceId::new("registry")]);
+}
+
+#[test]
+fn every_emitted_claim_carries_nonempty_citations() {
+    let claims = vec![
+        RawClaim::new("a", vec![hit("s1")]),
+        RawClaim::new("b", vec![no_hit("s2"), failed("s3")]),
+        RawClaim::new("c", vec![failed("s4")]),
+    ];
+    let out = render_guard(claims);
+    assert_eq!(out.len(), 3);
+    for claim in &out {
+        assert!(
+            !claim.citations().is_empty(),
+            "emitted claim {:?} must cite at least one source",
+            claim.text()
+        );
+    }
+}
+
+#[test]
+fn not_applicable_states_are_excluded_from_citations() {
+    // GIVEN a claim backed by a real hit plus a not-applicable state.
+    // THEN only the relevant source appears in citations.
+    let out = render_guard(vec![RawClaim::new("x", vec![hit("real"), skipped("noise")])]);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].citations(), &[SourceId::new("real")]);
+    assert_eq!(out[0].verdict(), Verdict::Clean);
+}
+
+#[test]
+fn guard_preserves_order_and_count_of_surviving_claims() {
+    let claims = vec![
+        RawClaim::new("first", vec![hit("s1")]),
+        RawClaim::new("dropped", vec![]),
+        RawClaim::new("second", vec![no_hit("s2")]),
+    ];
+    let out = render_guard(claims);
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].text(), "first");
+    assert_eq!(out[1].text(), "second");
+}
+
+// --- Non-bypassability (structural invariant) -------------------------------
+//
+// The strongest guarantee is enforced by the type system at COMPILE time:
+// `EmittableClaim` has only private fields and no public constructor, so the
+// following are impossible to write outside this module and would not compile:
+//
+//     EmittableClaim { text: ..., verdict: ..., citations: ... } // E0451 private fields
+//     EmittableClaim::new(...)                                   // no such fn
+//
+// We do not use a compile-fail harness (trybuild) for a spike; instead we assert
+// the runtime contract that proves the only path is the guard.
+
+#[test]
+fn emittable_claim_only_obtainable_via_guard() {
+    // The ONLY way to get an EmittableClaim is render_guard. This test documents
+    // and exercises that path; the absence of any other constructor is enforced
+    // by the private fields (see module-level note above).
+    let out = render_guard(vec![RawClaim::new("only path", vec![hit("s")])]);
+    let claim: &EmittableClaim = &out[0];
+    // Read-only accessors exist; no mutator or constructor is exposed.
+    assert_eq!(claim.text(), "only path");
+}

--- a/src/evidence/guard_tests.rs
+++ b/src/evidence/guard_tests.rs
@@ -4,16 +4,28 @@
 use super::*;
 
 fn hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedHit { source: SourceId::new(id), detail: None }
+    EvidenceState::CheckedHit {
+        source: SourceId::new(id),
+        detail: None,
+    }
 }
 fn no_hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedNoHit { source: SourceId::new(id), detail: None }
+    EvidenceState::CheckedNoHit {
+        source: SourceId::new(id),
+        detail: None,
+    }
 }
 fn failed(id: &str) -> EvidenceState {
-    EvidenceState::Failed { source: SourceId::new(id), detail: None }
+    EvidenceState::Failed {
+        source: SourceId::new(id),
+        detail: None,
+    }
 }
 fn skipped(id: &str) -> EvidenceState {
-    EvidenceState::SkippedNotApplicable { source: SourceId::new(id), detail: None }
+    EvidenceState::SkippedNotApplicable {
+        source: SourceId::new(id),
+        detail: None,
+    }
 }
 
 #[test]
@@ -46,7 +58,10 @@ fn only_not_applicable_backing_is_dropped() {
 fn adverse_claim_is_emitted_not_dropped() {
     // An authoritative negative is a finding, not an absence — it is emitted
     // (tagged Adverse), not suppressed.
-    let out = render_guard(vec![RawClaim::new("X not on list", vec![no_hit("registry")])]);
+    let out = render_guard(vec![RawClaim::new(
+        "X not on list",
+        vec![no_hit("registry")],
+    )]);
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].verdict(), Verdict::Adverse);
 }
@@ -55,7 +70,10 @@ fn adverse_claim_is_emitted_not_dropped() {
 fn disclaimer_claim_is_emitted_with_tag_not_dropped() {
     // A could-not-check claim is downgraded via its verdict tag (Disclaimer),
     // NOT dropped — so the experiment can observe abstention.
-    let out = render_guard(vec![RawClaim::new("X status unknown", vec![failed("registry")])]);
+    let out = render_guard(vec![RawClaim::new(
+        "X status unknown",
+        vec![failed("registry")],
+    )]);
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].verdict(), Verdict::Disclaimer);
     // Still self-citing: the could-not-check source is named.
@@ -84,7 +102,10 @@ fn every_emitted_claim_carries_nonempty_citations() {
 fn not_applicable_states_are_excluded_from_citations() {
     // GIVEN a claim backed by a real hit plus a not-applicable state.
     // THEN only the relevant source appears in citations.
-    let out = render_guard(vec![RawClaim::new("x", vec![hit("real"), skipped("noise")])]);
+    let out = render_guard(vec![RawClaim::new(
+        "x",
+        vec![hit("real"), skipped("noise")],
+    )]);
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].citations(), &[SourceId::new("real")]);
     assert_eq!(out[0].verdict(), Verdict::Clean);

--- a/src/evidence/harness.rs
+++ b/src/evidence/harness.rs
@@ -1,0 +1,280 @@
+//! Experiment harness (EVGUARD.3 / EVGUARD.4).
+//!
+//! This module scaffolds the measurement: it defines the discriminating ground
+//! truth cases, a trait-stubbed agent invocation boundary, and a strict
+//! no-partial-credit scorer that compares three strategies:
+//!
+//! - **raw passthrough** ([`RawPassthrough`]) — the baseline: emit whatever the
+//!   agent claimed, ungated.
+//! - **render guard** ([`RenderGuardStrategy`]) — route claims through
+//!   [`crate::evidence::render_guard`] and report the resulting verdict.
+//! - **reliability-weighted majority vote** ([`ReliabilityWeightedVote`]) — the
+//!   only weighting scheme permitted by the spike: each source carries a scalar
+//!   reliability weight and the winning expected-answer is the weighted
+//!   plurality. No probabilistic fusion, no calibration.
+//!
+//! The agent / LLM call itself is stubbed behind the [`Strategy`] trait so the
+//! pure scoring and strategy logic compile and are unit-tested with synthetic
+//! cases. Wiring a real agent is a later phase.
+
+use std::collections::HashMap;
+
+use crate::evidence::guard::{RawClaim, render_guard};
+use crate::evidence::state::{EvidenceState, SourceId};
+use crate::evidence::verdict::Verdict;
+
+/// The four discriminating ground-truth situations the experiment must separate.
+///
+/// These map one-to-one onto the verdicts a correct strategy should produce, and
+/// crucially keep *abstain* ([`Self::ShouldAbstain`]) distinct from
+/// *authoritative empty* ([`Self::SourceAuthoritativelyEmpty`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GroundTruth {
+    /// The correct behavior is to abstain — no source can settle the claim
+    /// (could-not-check). Correct verdict: [`Verdict::Disclaimer`].
+    ShouldAbstain,
+    /// A source was queried and authoritatively returned no match. Correct
+    /// verdict: [`Verdict::Adverse`].
+    SourceAuthoritativelyEmpty,
+    /// A source was unavailable / errored. Correct verdict:
+    /// [`Verdict::Disclaimer`] (we could not check).
+    SourceUnavailableFailed,
+    /// A source answered, but from stale data. Correct behavior is a caveated
+    /// answer. Correct verdict: [`Verdict::Qualified`].
+    SourceStale,
+}
+
+impl GroundTruth {
+    /// The verdict a fully-correct strategy must report for this case.
+    #[must_use]
+    pub fn expected_verdict(self) -> Verdict {
+        match self {
+            Self::ShouldAbstain | Self::SourceUnavailableFailed => Verdict::Disclaimer,
+            Self::SourceAuthoritativelyEmpty => Verdict::Adverse,
+            Self::SourceStale => Verdict::Qualified,
+        }
+    }
+}
+
+/// A single labelled experiment case.
+#[derive(Debug, Clone)]
+pub struct GroundTruthCase {
+    /// Human-readable case name (for reporting).
+    pub name: String,
+    /// The candidate claim and its backing evidence, as the agent produced it.
+    pub claim: RawClaim,
+    /// The correct situation this case represents.
+    pub truth: GroundTruth,
+}
+
+impl GroundTruthCase {
+    /// Construct a labelled case.
+    pub fn new(name: impl Into<String>, claim: RawClaim, truth: GroundTruth) -> Self {
+        Self { name: name.into(), claim, truth }
+    }
+}
+
+/// The verdict a strategy reports for a case (or that it emitted nothing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrategyOutput {
+    /// The strategy emitted a claim tagged with this verdict.
+    Emitted(Verdict),
+    /// The strategy emitted nothing for this case (the claim was dropped).
+    Suppressed,
+}
+
+/// The agent-invocation boundary, stubbed for the spike.
+///
+/// A real implementation would call an LLM / agent to decide what to emit for a
+/// case. Here it is a trait so the pure scoring logic compiles and is testable
+/// with deterministic synthetic strategies.
+pub trait Strategy {
+    /// A short, stable name for reporting.
+    fn name(&self) -> &'static str;
+
+    /// Decide what (if anything) to emit for one case.
+    fn decide(&self, case: &GroundTruthCase) -> StrategyOutput;
+}
+
+/// Baseline: emit the agent's claim verbatim with no evidence gating.
+///
+/// Models "raw tool output" — it always asserts a clean answer regardless of the
+/// backing evidence, which is exactly the unsupported-claim behavior the spike
+/// measures against.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RawPassthrough;
+
+impl Strategy for RawPassthrough {
+    fn name(&self) -> &'static str {
+        "raw-passthrough"
+    }
+
+    fn decide(&self, _case: &GroundTruthCase) -> StrategyOutput {
+        // Ungated: every claim is asserted as if clean.
+        StrategyOutput::Emitted(Verdict::Clean)
+    }
+}
+
+/// Route the claim through the non-bypassable [`render_guard`] and report the
+/// resulting verdict (or suppression when the claim is dropped).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RenderGuardStrategy;
+
+impl Strategy for RenderGuardStrategy {
+    fn name(&self) -> &'static str {
+        "render-guard"
+    }
+
+    fn decide(&self, case: &GroundTruthCase) -> StrategyOutput {
+        let emitted = render_guard(vec![case.claim.clone()]);
+        emitted
+            .first()
+            .map_or(StrategyOutput::Suppressed, |claim| StrategyOutput::Emitted(claim.verdict()))
+    }
+}
+
+/// Reliability-weighted majority vote over the per-source outcomes.
+///
+/// Each source id carries a scalar reliability weight. Every backing
+/// evidence-state casts a weighted vote for the verdict it would imply *on its
+/// own*; the verdict with the greatest total weight wins. This is the **only**
+/// weighting scheme permitted by the spike — deliberately a plain weighted
+/// plurality, with no probabilistic fusion or calibration.
+#[derive(Debug, Clone)]
+pub struct ReliabilityWeightedVote {
+    weights: HashMap<SourceId, f64>,
+    default_weight: f64,
+}
+
+impl ReliabilityWeightedVote {
+    /// Construct with per-source weights and a fallback weight for unknown
+    /// sources.
+    #[must_use]
+    pub fn new(weights: HashMap<SourceId, f64>, default_weight: f64) -> Self {
+        Self { weights, default_weight }
+    }
+
+    /// The reliability weight for a source, falling back to the default.
+    fn weight_for(&self, source: &SourceId) -> f64 {
+        self.weights.get(source).copied().unwrap_or(self.default_weight)
+    }
+
+    /// The verdict a single evidence-state would imply on its own.
+    ///
+    /// Not-applicable states are filtered out by [`Strategy::decide`] before this
+    /// is called, so they never reach the tally; they share the
+    /// [`Verdict::Disclaimer`] arm here only for totality.
+    fn per_state_verdict(state: &EvidenceState) -> Verdict {
+        match state {
+            EvidenceState::CheckedHit { .. } => Verdict::Clean,
+            EvidenceState::CheckedNoHit { .. } => Verdict::Adverse,
+            EvidenceState::Stale { .. } => Verdict::Qualified,
+            EvidenceState::Failed { .. }
+            | EvidenceState::Timeout { .. }
+            | EvidenceState::NotConfigured { .. }
+            | EvidenceState::NotAuthorized { .. }
+            | EvidenceState::SkippedNotApplicable { .. } => Verdict::Disclaimer,
+        }
+    }
+}
+
+impl Strategy for ReliabilityWeightedVote {
+    fn name(&self) -> &'static str {
+        "reliability-weighted-vote"
+    }
+
+    fn decide(&self, case: &GroundTruthCase) -> StrategyOutput {
+        let mut tally: HashMap<Verdict, f64> = HashMap::new();
+        for state in &case.claim.evidence {
+            if matches!(state, EvidenceState::SkippedNotApplicable { .. }) {
+                continue;
+            }
+            let verdict = Self::per_state_verdict(state);
+            *tally.entry(verdict).or_insert(0.0) += self.weight_for(state.source());
+        }
+
+        // No relevant votes → suppressed (nothing to emit).
+        // Deterministic tie-break: the most-supported verdict (Ord) wins, so
+        // equal weights resolve toward Clean < Qualified < Adverse < Disclaimer.
+        tally
+            .into_iter()
+            .max_by(|(va, wa), (vb, wb)| {
+                wa.partial_cmp(wb).unwrap_or(std::cmp::Ordering::Equal).then(vb.cmp(va))
+            })
+            .map_or(StrategyOutput::Suppressed, |(verdict, _)| StrategyOutput::Emitted(verdict))
+    }
+}
+
+/// Score a strategy over a case set with **no partial credit**.
+///
+/// A case is correct **iff** the strategy emits a claim whose verdict equals the
+/// case's [`GroundTruth::expected_verdict`]. Suppression, a wrong verdict, or any
+/// mismatch all score zero for that case — there is no graded reward for being
+/// "close" (e.g. emitting Qualified when Adverse was required).
+///
+/// Returns the number of fully-correct cases.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_gateway::evidence::harness::{
+///     GroundTruth, GroundTruthCase, RenderGuardStrategy, score_strategy,
+/// };
+/// use mcp_gateway::evidence::{EvidenceState, RawClaim, SourceId};
+///
+/// let case = GroundTruthCase::new(
+///     "empty",
+///     RawClaim::new(
+///         "X not listed",
+///         vec![EvidenceState::CheckedNoHit { source: SourceId::new("l"), detail: None }],
+///     ),
+///     GroundTruth::SourceAuthoritativelyEmpty,
+/// );
+/// assert_eq!(score_strategy(&RenderGuardStrategy, &[case]), 1);
+/// ```
+#[must_use]
+pub fn score_strategy<S: Strategy + ?Sized>(strategy: &S, cases: &[GroundTruthCase]) -> usize {
+    cases
+        .iter()
+        .filter(|case| {
+            matches!(
+                strategy.decide(case),
+                StrategyOutput::Emitted(v) if v == case.truth.expected_verdict()
+            )
+        })
+        .count()
+}
+
+/// One strategy's score line over a case set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScoreRow {
+    /// The strategy name.
+    pub strategy: String,
+    /// Number of fully-correct cases.
+    pub correct: usize,
+    /// Total number of cases scored.
+    pub total: usize,
+}
+
+/// Score every strategy in `strategies` over the same `cases`, returning one
+/// [`ScoreRow`] per strategy in input order.
+///
+/// This is the comparison table for EVGUARD.3 / EVGUARD.4.
+#[must_use]
+pub fn compare_strategies(
+    strategies: &[&dyn Strategy],
+    cases: &[GroundTruthCase],
+) -> Vec<ScoreRow> {
+    strategies
+        .iter()
+        .map(|s| ScoreRow {
+            strategy: s.name().to_string(),
+            correct: score_strategy(*s, cases),
+            total: cases.len(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "harness_tests.rs"]
+mod tests;

--- a/src/evidence/harness.rs
+++ b/src/evidence/harness.rs
@@ -70,7 +70,11 @@ pub struct GroundTruthCase {
 impl GroundTruthCase {
     /// Construct a labelled case.
     pub fn new(name: impl Into<String>, claim: RawClaim, truth: GroundTruth) -> Self {
-        Self { name: name.into(), claim, truth }
+        Self {
+            name: name.into(),
+            claim,
+            truth,
+        }
     }
 }
 
@@ -127,9 +131,9 @@ impl Strategy for RenderGuardStrategy {
 
     fn decide(&self, case: &GroundTruthCase) -> StrategyOutput {
         let emitted = render_guard(vec![case.claim.clone()]);
-        emitted
-            .first()
-            .map_or(StrategyOutput::Suppressed, |claim| StrategyOutput::Emitted(claim.verdict()))
+        emitted.first().map_or(StrategyOutput::Suppressed, |claim| {
+            StrategyOutput::Emitted(claim.verdict())
+        })
     }
 }
 
@@ -151,12 +155,18 @@ impl ReliabilityWeightedVote {
     /// sources.
     #[must_use]
     pub fn new(weights: HashMap<SourceId, f64>, default_weight: f64) -> Self {
-        Self { weights, default_weight }
+        Self {
+            weights,
+            default_weight,
+        }
     }
 
     /// The reliability weight for a source, falling back to the default.
     fn weight_for(&self, source: &SourceId) -> f64 {
-        self.weights.get(source).copied().unwrap_or(self.default_weight)
+        self.weights
+            .get(source)
+            .copied()
+            .unwrap_or(self.default_weight)
     }
 
     /// The verdict a single evidence-state would imply on its own.
@@ -199,9 +209,13 @@ impl Strategy for ReliabilityWeightedVote {
         tally
             .into_iter()
             .max_by(|(va, wa), (vb, wb)| {
-                wa.partial_cmp(wb).unwrap_or(std::cmp::Ordering::Equal).then(vb.cmp(va))
+                wa.partial_cmp(wb)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(vb.cmp(va))
             })
-            .map_or(StrategyOutput::Suppressed, |(verdict, _)| StrategyOutput::Emitted(verdict))
+            .map_or(StrategyOutput::Suppressed, |(verdict, _)| {
+                StrategyOutput::Emitted(verdict)
+            })
     }
 }
 

--- a/src/evidence/harness_tests.rs
+++ b/src/evidence/harness_tests.rs
@@ -8,16 +8,28 @@ fn sid(id: &str) -> SourceId {
     SourceId::new(id)
 }
 fn hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedHit { source: sid(id), detail: None }
+    EvidenceState::CheckedHit {
+        source: sid(id),
+        detail: None,
+    }
 }
 fn no_hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedNoHit { source: sid(id), detail: None }
+    EvidenceState::CheckedNoHit {
+        source: sid(id),
+        detail: None,
+    }
 }
 fn failed(id: &str) -> EvidenceState {
-    EvidenceState::Failed { source: sid(id), detail: None }
+    EvidenceState::Failed {
+        source: sid(id),
+        detail: None,
+    }
 }
 fn stale(id: &str) -> EvidenceState {
-    EvidenceState::Stale { source: sid(id), detail: None }
+    EvidenceState::Stale {
+        source: sid(id),
+        detail: None,
+    }
 }
 
 /// The canonical four discriminating cases.
@@ -25,7 +37,10 @@ fn discriminating_cases() -> Vec<GroundTruthCase> {
     vec![
         GroundTruthCase::new(
             "should-abstain",
-            RawClaim::new("status of X unknown", vec![failed("primary"), failed("secondary")]),
+            RawClaim::new(
+                "status of X unknown",
+                vec![failed("primary"), failed("secondary")],
+            ),
             GroundTruth::ShouldAbstain,
         ),
         GroundTruthCase::new(
@@ -48,13 +63,22 @@ fn discriminating_cases() -> Vec<GroundTruthCase> {
 
 #[test]
 fn ground_truth_maps_to_expected_verdicts() {
-    assert_eq!(GroundTruth::ShouldAbstain.expected_verdict(), Verdict::Disclaimer);
-    assert_eq!(GroundTruth::SourceUnavailableFailed.expected_verdict(), Verdict::Disclaimer);
+    assert_eq!(
+        GroundTruth::ShouldAbstain.expected_verdict(),
+        Verdict::Disclaimer
+    );
+    assert_eq!(
+        GroundTruth::SourceUnavailableFailed.expected_verdict(),
+        Verdict::Disclaimer
+    );
     assert_eq!(
         GroundTruth::SourceAuthoritativelyEmpty.expected_verdict(),
         Verdict::Adverse
     );
-    assert_eq!(GroundTruth::SourceStale.expected_verdict(), Verdict::Qualified);
+    assert_eq!(
+        GroundTruth::SourceStale.expected_verdict(),
+        Verdict::Qualified
+    );
 }
 
 // --- No-partial-credit scorer ----------------------------------------------
@@ -69,7 +93,10 @@ fn scorer_gives_no_credit_for_wrong_verdict() {
         RawClaim::new("x", vec![no_hit("l")]),
         GroundTruth::SourceAuthoritativelyEmpty,
     );
-    assert_eq!(score_strategy(&RawPassthrough, std::slice::from_ref(&case)), 0);
+    assert_eq!(
+        score_strategy(&RawPassthrough, std::slice::from_ref(&case)),
+        0
+    );
 }
 
 #[test]
@@ -106,7 +133,10 @@ fn scorer_gives_no_partial_credit_for_close_verdict() {
         RawClaim::new("x", vec![no_hit("l")]),
         GroundTruth::SourceAuthoritativelyEmpty,
     );
-    assert_eq!(score_strategy(&AlwaysQualified, std::slice::from_ref(&case)), 0);
+    assert_eq!(
+        score_strategy(&AlwaysQualified, std::slice::from_ref(&case)),
+        0
+    );
 }
 
 // --- Strategy behavior over the discriminating set --------------------------
@@ -143,8 +173,14 @@ fn reliability_weighted_vote_distinguishes_adverse_from_disclaimer() {
         GroundTruth::SourceUnavailableFailed,
     );
 
-    assert_eq!(voter.decide(&empty), StrategyOutput::Emitted(Verdict::Adverse));
-    assert_eq!(voter.decide(&failed_case), StrategyOutput::Emitted(Verdict::Disclaimer));
+    assert_eq!(
+        voter.decide(&empty),
+        StrategyOutput::Emitted(Verdict::Adverse)
+    );
+    assert_eq!(
+        voter.decide(&failed_case),
+        StrategyOutput::Emitted(Verdict::Disclaimer)
+    );
 }
 
 #[test]
@@ -158,7 +194,10 @@ fn reliability_weighting_lets_trusted_source_win() {
         RawClaim::new("x", vec![no_hit("trusted"), failed("flaky")]),
         GroundTruth::SourceAuthoritativelyEmpty,
     );
-    assert_eq!(voter.decide(&case), StrategyOutput::Emitted(Verdict::Adverse));
+    assert_eq!(
+        voter.decide(&case),
+        StrategyOutput::Emitted(Verdict::Adverse)
+    );
 }
 
 #[test]
@@ -177,10 +216,13 @@ fn reliability_vote_with_no_relevant_evidence_is_suppressed() {
 #[test]
 fn compare_strategies_produces_one_row_per_strategy_in_order() {
     let cases = discriminating_cases();
-    let weights = HashMap::from([(sid("list"), 1.0), (sid("primary"), 1.0), (sid("secondary"), 1.0)]);
+    let weights = HashMap::from([
+        (sid("list"), 1.0),
+        (sid("primary"), 1.0),
+        (sid("secondary"), 1.0),
+    ]);
     let voter = ReliabilityWeightedVote::new(weights, 1.0);
-    let strategies: Vec<&dyn Strategy> =
-        vec![&RawPassthrough, &RenderGuardStrategy, &voter];
+    let strategies: Vec<&dyn Strategy> = vec![&RawPassthrough, &RenderGuardStrategy, &voter];
 
     let rows = compare_strategies(&strategies, &cases);
 

--- a/src/evidence/harness_tests.rs
+++ b/src/evidence/harness_tests.rs
@@ -1,0 +1,196 @@
+//! Tests for the experiment harness: ground-truth/verdict alignment, the
+//! no-partial-credit scorer, and the three strategies over synthetic cases.
+
+use super::*;
+use crate::evidence::state::EvidenceState;
+
+fn sid(id: &str) -> SourceId {
+    SourceId::new(id)
+}
+fn hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedHit { source: sid(id), detail: None }
+}
+fn no_hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedNoHit { source: sid(id), detail: None }
+}
+fn failed(id: &str) -> EvidenceState {
+    EvidenceState::Failed { source: sid(id), detail: None }
+}
+fn stale(id: &str) -> EvidenceState {
+    EvidenceState::Stale { source: sid(id), detail: None }
+}
+
+/// The canonical four discriminating cases.
+fn discriminating_cases() -> Vec<GroundTruthCase> {
+    vec![
+        GroundTruthCase::new(
+            "should-abstain",
+            RawClaim::new("status of X unknown", vec![failed("primary"), failed("secondary")]),
+            GroundTruth::ShouldAbstain,
+        ),
+        GroundTruthCase::new(
+            "source-authoritatively-empty",
+            RawClaim::new("X not on list", vec![no_hit("list")]),
+            GroundTruth::SourceAuthoritativelyEmpty,
+        ),
+        GroundTruthCase::new(
+            "source-unavailable-failed",
+            RawClaim::new("could not verify X", vec![failed("list")]),
+            GroundTruth::SourceUnavailableFailed,
+        ),
+        GroundTruthCase::new(
+            "source-stale",
+            RawClaim::new("X was clear (stale)", vec![hit("list"), stale("list")]),
+            GroundTruth::SourceStale,
+        ),
+    ]
+}
+
+#[test]
+fn ground_truth_maps_to_expected_verdicts() {
+    assert_eq!(GroundTruth::ShouldAbstain.expected_verdict(), Verdict::Disclaimer);
+    assert_eq!(GroundTruth::SourceUnavailableFailed.expected_verdict(), Verdict::Disclaimer);
+    assert_eq!(
+        GroundTruth::SourceAuthoritativelyEmpty.expected_verdict(),
+        Verdict::Adverse
+    );
+    assert_eq!(GroundTruth::SourceStale.expected_verdict(), Verdict::Qualified);
+}
+
+// --- No-partial-credit scorer ----------------------------------------------
+
+#[test]
+fn scorer_gives_no_credit_for_wrong_verdict() {
+    // Raw passthrough always emits Clean. Against a case whose truth is Adverse,
+    // "Clean" is wrong and earns ZERO — no partial credit for emitting *a*
+    // verdict.
+    let case = GroundTruthCase::new(
+        "empty",
+        RawClaim::new("x", vec![no_hit("l")]),
+        GroundTruth::SourceAuthoritativelyEmpty,
+    );
+    assert_eq!(score_strategy(&RawPassthrough, std::slice::from_ref(&case)), 0);
+}
+
+#[test]
+fn scorer_gives_no_credit_for_suppression() {
+    // A strategy that suppresses everything scores zero even on a should-abstain
+    // case (the expected verdict is Disclaimer *emitted*, not silence).
+    struct AlwaysSuppress;
+    impl Strategy for AlwaysSuppress {
+        fn name(&self) -> &'static str {
+            "always-suppress"
+        }
+        fn decide(&self, _case: &GroundTruthCase) -> StrategyOutput {
+            StrategyOutput::Suppressed
+        }
+    }
+    let cases = discriminating_cases();
+    assert_eq!(score_strategy(&AlwaysSuppress, &cases), 0);
+}
+
+#[test]
+fn scorer_gives_no_partial_credit_for_close_verdict() {
+    // Emitting Qualified when Adverse is required is WRONG, not half-right.
+    struct AlwaysQualified;
+    impl Strategy for AlwaysQualified {
+        fn name(&self) -> &'static str {
+            "always-qualified"
+        }
+        fn decide(&self, _case: &GroundTruthCase) -> StrategyOutput {
+            StrategyOutput::Emitted(Verdict::Qualified)
+        }
+    }
+    let case = GroundTruthCase::new(
+        "empty",
+        RawClaim::new("x", vec![no_hit("l")]),
+        GroundTruth::SourceAuthoritativelyEmpty,
+    );
+    assert_eq!(score_strategy(&AlwaysQualified, std::slice::from_ref(&case)), 0);
+}
+
+// --- Strategy behavior over the discriminating set --------------------------
+
+#[test]
+fn render_guard_scores_perfectly_on_discriminating_cases() {
+    // The render guard's verdict mapping is built to match the ground truth on
+    // exactly these four cases.
+    let cases = discriminating_cases();
+    assert_eq!(score_strategy(&RenderGuardStrategy, &cases), cases.len());
+}
+
+#[test]
+fn raw_passthrough_only_scores_when_truth_happens_to_be_clean() {
+    // Baseline always says Clean — none of the four discriminating cases is
+    // Clean, so it scores zero. This is the headline contrast the spike wants.
+    let cases = discriminating_cases();
+    assert_eq!(score_strategy(&RawPassthrough, &cases), 0);
+}
+
+#[test]
+fn reliability_weighted_vote_distinguishes_adverse_from_disclaimer() {
+    let weights = HashMap::from([(sid("list"), 1.0)]);
+    let voter = ReliabilityWeightedVote::new(weights, 1.0);
+
+    let empty = GroundTruthCase::new(
+        "empty",
+        RawClaim::new("x", vec![no_hit("list")]),
+        GroundTruth::SourceAuthoritativelyEmpty,
+    );
+    let failed_case = GroundTruthCase::new(
+        "failed",
+        RawClaim::new("x", vec![failed("list")]),
+        GroundTruth::SourceUnavailableFailed,
+    );
+
+    assert_eq!(voter.decide(&empty), StrategyOutput::Emitted(Verdict::Adverse));
+    assert_eq!(voter.decide(&failed_case), StrategyOutput::Emitted(Verdict::Disclaimer));
+}
+
+#[test]
+fn reliability_weighting_lets_trusted_source_win() {
+    // A high-weight authoritative-negative source outvotes a low-weight
+    // could-not-check source.
+    let weights = HashMap::from([(sid("trusted"), 10.0), (sid("flaky"), 1.0)]);
+    let voter = ReliabilityWeightedVote::new(weights, 1.0);
+    let case = GroundTruthCase::new(
+        "mixed",
+        RawClaim::new("x", vec![no_hit("trusted"), failed("flaky")]),
+        GroundTruth::SourceAuthoritativelyEmpty,
+    );
+    assert_eq!(voter.decide(&case), StrategyOutput::Emitted(Verdict::Adverse));
+}
+
+#[test]
+fn reliability_vote_with_no_relevant_evidence_is_suppressed() {
+    let voter = ReliabilityWeightedVote::new(HashMap::new(), 1.0);
+    let case = GroundTruthCase::new(
+        "none",
+        RawClaim::new("x", vec![]),
+        GroundTruth::ShouldAbstain,
+    );
+    assert_eq!(voter.decide(&case), StrategyOutput::Suppressed);
+}
+
+// --- Comparison table -------------------------------------------------------
+
+#[test]
+fn compare_strategies_produces_one_row_per_strategy_in_order() {
+    let cases = discriminating_cases();
+    let weights = HashMap::from([(sid("list"), 1.0), (sid("primary"), 1.0), (sid("secondary"), 1.0)]);
+    let voter = ReliabilityWeightedVote::new(weights, 1.0);
+    let strategies: Vec<&dyn Strategy> =
+        vec![&RawPassthrough, &RenderGuardStrategy, &voter];
+
+    let rows = compare_strategies(&strategies, &cases);
+
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].strategy, "raw-passthrough");
+    assert_eq!(rows[1].strategy, "render-guard");
+    assert_eq!(rows[2].strategy, "reliability-weighted-vote");
+    for row in &rows {
+        assert_eq!(row.total, cases.len());
+    }
+    // Headline measurement: the guard beats the raw baseline.
+    assert!(rows[1].correct > rows[0].correct);
+}

--- a/src/evidence/mod.rs
+++ b/src/evidence/mod.rs
@@ -1,0 +1,50 @@
+//! Evidence-typed render guard apparatus (spike MIK-5854).
+//!
+//! This module is an **additive, standalone** measurement apparatus. It is wired
+//! into the crate (see [`crate`] module tree) but is **not** called from any
+//! production routing, invoke, or result-proxy path. Its purpose is to model and
+//! measure whether *typed evidence* plus a *non-bypassable render guard* reduces
+//! unsupported claims compared to raw tool output.
+//!
+//! # Design
+//!
+//! The apparatus is built from four composable pieces, each in its own submodule:
+//!
+//! 1. [`state`] — the [`EvidenceState`] enum: an exhaustive, eight-variant model
+//!    of what happened when a backing source was consulted. No `Option`
+//!    smuggling — every outcome (including "could not check" and "not
+//!    applicable") is a first-class variant.
+//! 2. [`verdict`] — the four-valued [`Verdict`] enum
+//!    ([`Verdict::Clean`], [`Verdict::Qualified`], [`Verdict::Adverse`],
+//!    [`Verdict::Disclaimer`]) and the pure, deterministic mapping from a set of
+//!    backing evidence-states to a verdict. The load-bearing behavior is the
+//!    distinction between [`Verdict::Adverse`] (an authoritative negative) and
+//!    [`Verdict::Disclaimer`] (we could not check).
+//! 3. [`guard`] — the [`render_guard`] function: the only constructor of an
+//!    [`EmittableClaim`]. A claim cannot be emitted without passing through the
+//!    guard, which tags each surviving claim with its verdict and the evidence
+//!    ids that justify it, and drops claims with no backing at all.
+//! 4. [`harness`] — the experiment scaffolding (EVGUARD.3 / EVGUARD.4): ground
+//!    truth cases, an agent invocation [`harness::Strategy`] trait stub, and a
+//!    no-partial-credit scorer comparing the raw-passthrough baseline, the
+//!    render guard, and reliability-weighted majority voting.
+//!
+//! # Scope boundary
+//!
+//! Pure deterministic logic: the state→verdict mapping ([`verdict`]), the render
+//! guard ([`guard`]), and the scorer ([`harness::score_strategy`]). Stubbed
+//! behind a trait: the agent / LLM invocation ([`harness::Strategy`]), so the
+//! pure logic compiles and is unit-tested with synthetic cases.
+//!
+//! No formal evidence calculus lives here (no Dempster-Shafer, no Bayesian
+//! fusion, no subjective logic, no isotonic calibration). Reliability-weighted
+//! majority voting is the only weighting scheme, and it is deliberately simple.
+
+pub mod guard;
+pub mod harness;
+pub mod state;
+pub mod verdict;
+
+pub use guard::{EmittableClaim, RawClaim, render_guard};
+pub use state::{EvidenceState, SourceId};
+pub use verdict::{Verdict, classify};

--- a/src/evidence/mod.rs
+++ b/src/evidence/mod.rs
@@ -40,11 +40,13 @@
 //! fusion, no subjective logic, no isotonic calibration). Reliability-weighted
 //! majority voting is the only weighting scheme, and it is deliberately simple.
 
+pub mod adapter;
 pub mod guard;
 pub mod harness;
 pub mod state;
 pub mod verdict;
 
+pub use adapter::evidence_from_result;
 pub use guard::{EmittableClaim, RawClaim, render_guard};
 pub use state::{EvidenceState, SourceId};
 pub use verdict::{Verdict, classify};

--- a/src/evidence/state.rs
+++ b/src/evidence/state.rs
@@ -1,0 +1,202 @@
+//! Evidence-state model: the eight outcomes of consulting a backing source.
+//!
+//! [`EvidenceState`] is exhaustive by construction. Every way a source check can
+//! resolve — including the "could not check" and "not applicable" cases — is a
+//! named variant carrying minimal metadata, rather than being smuggled through an
+//! `Option` or a sentinel value. This is what lets the verdict mapping
+//! ([`crate::evidence::verdict`]) distinguish an *authoritative negative*
+//! ([`EvidenceState::CheckedNoHit`]) from a *failure to check*
+//! ([`EvidenceState::Failed`] and friends).
+
+use std::fmt;
+
+/// Identifier of a backing source (e.g. a tool, dataset, or check name).
+///
+/// A newtype over `String` so that source ids are not interchangeable with
+/// arbitrary text and so the type reads clearly in signatures.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceId(pub String);
+
+impl SourceId {
+    /// Construct a [`SourceId`] from anything string-like.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_gateway::evidence::SourceId;
+    /// let id = SourceId::new("registry-v2");
+    /// assert_eq!(id.as_str(), "registry-v2");
+    /// ```
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Borrow the underlying id as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The outcome of consulting one backing source for a claim.
+///
+/// Each variant carries the [`SourceId`] that produced it plus an optional
+/// human-readable `detail` for diagnostics. The variants partition into three
+/// evidential classes, which the verdict mapping keys on:
+///
+/// | Class | Variants | Meaning |
+/// |-------|----------|---------|
+/// | **Conclusive** | [`CheckedHit`](Self::CheckedHit), [`CheckedNoHit`](Self::CheckedNoHit) | The source was queried and gave an authoritative answer. |
+/// | **Could-not-check** | [`Failed`](Self::Failed), [`Timeout`](Self::Timeout), [`NotConfigured`](Self::NotConfigured), [`NotAuthorized`](Self::NotAuthorized) | The source could not produce an authoritative answer. |
+/// | **Modifier / neutral** | [`Stale`](Self::Stale), [`SkippedNotApplicable`](Self::SkippedNotApplicable) | Degrades confidence, or is irrelevant to this claim. |
+///
+/// The class taxonomy is expressed once in code via [`EvidenceState::class`] so
+/// the mapping logic never re-derives it ad hoc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidenceState {
+    /// The source was queried and returned a positive, authoritative match.
+    CheckedHit {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source was queried and authoritatively returned *no* match.
+    ///
+    /// This is a **trustworthy negative**, not an absence of evidence: the
+    /// source was reachable, authorized, and current. It is the basis for an
+    /// [`crate::evidence::Verdict::Adverse`] verdict.
+    CheckedNoHit {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source returned an error and could not produce an answer.
+    Failed {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source did not respond within the deadline.
+    Timeout {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source is not configured in this deployment.
+    NotConfigured {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The caller is not authorized to query this source.
+    NotAuthorized {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source answered, but from data old enough to degrade confidence.
+    ///
+    /// Stale is a *modifier*: it pushes an otherwise-clean verdict toward
+    /// [`crate::evidence::Verdict::Qualified`]. On its own (with no conclusive
+    /// evidence to modify) it cannot support a claim.
+    Stale {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+    /// The source was deliberately skipped as not applicable to this claim.
+    ///
+    /// Neutral: it neither supports nor undermines the claim and is filtered out
+    /// before the verdict mapping runs.
+    SkippedNotApplicable {
+        /// The source that produced this outcome.
+        source: SourceId,
+        /// Optional diagnostic detail.
+        detail: Option<String>,
+    },
+}
+
+/// The evidential class of an [`EvidenceState`].
+///
+/// Computed once from the variant so the verdict mapping keys on a small, total
+/// taxonomy instead of re-matching the eight variants in multiple places.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceClass {
+    /// An authoritative positive answer ([`EvidenceState::CheckedHit`]).
+    ConclusivePositive,
+    /// An authoritative negative answer ([`EvidenceState::CheckedNoHit`]).
+    ConclusiveNegative,
+    /// The source could not produce an authoritative answer.
+    CouldNotCheck,
+    /// The source answered but from stale data (a confidence modifier).
+    Stale,
+    /// The source is not applicable to this claim (neutral).
+    NotApplicable,
+}
+
+impl EvidenceState {
+    /// The [`SourceId`] that produced this state.
+    #[must_use]
+    pub fn source(&self) -> &SourceId {
+        match self {
+            Self::CheckedHit { source, .. }
+            | Self::CheckedNoHit { source, .. }
+            | Self::Failed { source, .. }
+            | Self::Timeout { source, .. }
+            | Self::NotConfigured { source, .. }
+            | Self::NotAuthorized { source, .. }
+            | Self::Stale { source, .. }
+            | Self::SkippedNotApplicable { source, .. } => source,
+        }
+    }
+
+    /// The optional diagnostic detail attached to this state.
+    #[must_use]
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            Self::CheckedHit { detail, .. }
+            | Self::CheckedNoHit { detail, .. }
+            | Self::Failed { detail, .. }
+            | Self::Timeout { detail, .. }
+            | Self::NotConfigured { detail, .. }
+            | Self::NotAuthorized { detail, .. }
+            | Self::Stale { detail, .. }
+            | Self::SkippedNotApplicable { detail, .. } => detail.as_deref(),
+        }
+    }
+
+    /// The evidential [`EvidenceClass`] of this state.
+    ///
+    /// This is the single source of truth for the conclusive / could-not-check /
+    /// modifier taxonomy that the verdict mapping depends on.
+    #[must_use]
+    pub fn class(&self) -> EvidenceClass {
+        match self {
+            Self::CheckedHit { .. } => EvidenceClass::ConclusivePositive,
+            Self::CheckedNoHit { .. } => EvidenceClass::ConclusiveNegative,
+            Self::Failed { .. }
+            | Self::Timeout { .. }
+            | Self::NotConfigured { .. }
+            | Self::NotAuthorized { .. } => EvidenceClass::CouldNotCheck,
+            Self::Stale { .. } => EvidenceClass::Stale,
+            Self::SkippedNotApplicable { .. } => EvidenceClass::NotApplicable,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod tests;

--- a/src/evidence/state_tests.rs
+++ b/src/evidence/state_tests.rs
@@ -6,14 +6,38 @@ use super::*;
 fn source_accessor_returns_id_for_every_variant() {
     let s = SourceId::new("src");
     let variants = [
-        EvidenceState::CheckedHit { source: s.clone(), detail: None },
-        EvidenceState::CheckedNoHit { source: s.clone(), detail: None },
-        EvidenceState::Failed { source: s.clone(), detail: None },
-        EvidenceState::Timeout { source: s.clone(), detail: None },
-        EvidenceState::NotConfigured { source: s.clone(), detail: None },
-        EvidenceState::NotAuthorized { source: s.clone(), detail: None },
-        EvidenceState::Stale { source: s.clone(), detail: None },
-        EvidenceState::SkippedNotApplicable { source: s.clone(), detail: None },
+        EvidenceState::CheckedHit {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::CheckedNoHit {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::Failed {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::Timeout {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::NotConfigured {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::NotAuthorized {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::Stale {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::SkippedNotApplicable {
+            source: s.clone(),
+            detail: None,
+        },
     ];
     for v in &variants {
         assert_eq!(v.source(), &s);
@@ -28,7 +52,10 @@ fn detail_accessor_round_trips() {
     };
     assert_eq!(with.detail(), Some("matched row 7"));
 
-    let without = EvidenceState::CheckedHit { source: SourceId::new("s"), detail: None };
+    let without = EvidenceState::CheckedHit {
+        source: SourceId::new("s"),
+        detail: None,
+    };
     assert_eq!(without.detail(), None);
 }
 
@@ -36,27 +63,55 @@ fn detail_accessor_round_trips() {
 fn class_taxonomy_is_correct() {
     let s = SourceId::new("s");
     assert_eq!(
-        EvidenceState::CheckedHit { source: s.clone(), detail: None }.class(),
+        EvidenceState::CheckedHit {
+            source: s.clone(),
+            detail: None
+        }
+        .class(),
         EvidenceClass::ConclusivePositive
     );
     assert_eq!(
-        EvidenceState::CheckedNoHit { source: s.clone(), detail: None }.class(),
+        EvidenceState::CheckedNoHit {
+            source: s.clone(),
+            detail: None
+        }
+        .class(),
         EvidenceClass::ConclusiveNegative
     );
     for cnc in [
-        EvidenceState::Failed { source: s.clone(), detail: None },
-        EvidenceState::Timeout { source: s.clone(), detail: None },
-        EvidenceState::NotConfigured { source: s.clone(), detail: None },
-        EvidenceState::NotAuthorized { source: s.clone(), detail: None },
+        EvidenceState::Failed {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::Timeout {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::NotConfigured {
+            source: s.clone(),
+            detail: None,
+        },
+        EvidenceState::NotAuthorized {
+            source: s.clone(),
+            detail: None,
+        },
     ] {
         assert_eq!(cnc.class(), EvidenceClass::CouldNotCheck);
     }
     assert_eq!(
-        EvidenceState::Stale { source: s.clone(), detail: None }.class(),
+        EvidenceState::Stale {
+            source: s.clone(),
+            detail: None
+        }
+        .class(),
         EvidenceClass::Stale
     );
     assert_eq!(
-        EvidenceState::SkippedNotApplicable { source: s, detail: None }.class(),
+        EvidenceState::SkippedNotApplicable {
+            source: s,
+            detail: None
+        }
+        .class(),
         EvidenceClass::NotApplicable
     );
 }

--- a/src/evidence/state_tests.rs
+++ b/src/evidence/state_tests.rs
@@ -1,0 +1,69 @@
+//! Tests for [`EvidenceState`] accessors and the [`EvidenceClass`] taxonomy.
+
+use super::*;
+
+#[test]
+fn source_accessor_returns_id_for_every_variant() {
+    let s = SourceId::new("src");
+    let variants = [
+        EvidenceState::CheckedHit { source: s.clone(), detail: None },
+        EvidenceState::CheckedNoHit { source: s.clone(), detail: None },
+        EvidenceState::Failed { source: s.clone(), detail: None },
+        EvidenceState::Timeout { source: s.clone(), detail: None },
+        EvidenceState::NotConfigured { source: s.clone(), detail: None },
+        EvidenceState::NotAuthorized { source: s.clone(), detail: None },
+        EvidenceState::Stale { source: s.clone(), detail: None },
+        EvidenceState::SkippedNotApplicable { source: s.clone(), detail: None },
+    ];
+    for v in &variants {
+        assert_eq!(v.source(), &s);
+    }
+}
+
+#[test]
+fn detail_accessor_round_trips() {
+    let with = EvidenceState::CheckedHit {
+        source: SourceId::new("s"),
+        detail: Some("matched row 7".to_string()),
+    };
+    assert_eq!(with.detail(), Some("matched row 7"));
+
+    let without = EvidenceState::CheckedHit { source: SourceId::new("s"), detail: None };
+    assert_eq!(without.detail(), None);
+}
+
+#[test]
+fn class_taxonomy_is_correct() {
+    let s = SourceId::new("s");
+    assert_eq!(
+        EvidenceState::CheckedHit { source: s.clone(), detail: None }.class(),
+        EvidenceClass::ConclusivePositive
+    );
+    assert_eq!(
+        EvidenceState::CheckedNoHit { source: s.clone(), detail: None }.class(),
+        EvidenceClass::ConclusiveNegative
+    );
+    for cnc in [
+        EvidenceState::Failed { source: s.clone(), detail: None },
+        EvidenceState::Timeout { source: s.clone(), detail: None },
+        EvidenceState::NotConfigured { source: s.clone(), detail: None },
+        EvidenceState::NotAuthorized { source: s.clone(), detail: None },
+    ] {
+        assert_eq!(cnc.class(), EvidenceClass::CouldNotCheck);
+    }
+    assert_eq!(
+        EvidenceState::Stale { source: s.clone(), detail: None }.class(),
+        EvidenceClass::Stale
+    );
+    assert_eq!(
+        EvidenceState::SkippedNotApplicable { source: s, detail: None }.class(),
+        EvidenceClass::NotApplicable
+    );
+}
+
+#[test]
+fn source_id_display_and_as_str_agree() {
+    let id = SourceId::new("registry-v2");
+    assert_eq!(id.as_str(), "registry-v2");
+    assert_eq!(id.to_string(), "registry-v2");
+}

--- a/src/evidence/verdict.rs
+++ b/src/evidence/verdict.rs
@@ -1,0 +1,131 @@
+//! Four-valued verdict and the pure state→verdict mapping.
+//!
+//! [`classify`] is the deterministic core of the apparatus. Given the set of
+//! [`EvidenceState`]s backing a single claim, it returns exactly one
+//! [`Verdict`]. The mapping is total, side-effect-free, and order-independent.
+//!
+//! # The load-bearing distinction
+//!
+//! [`Verdict::Adverse`] and [`Verdict::Disclaimer`] are categorically different
+//! and must never be confused:
+//!
+//! - **[`Verdict::Adverse`]** — a source was queried and authoritatively
+//!   returned *no match* ([`EvidenceState::CheckedNoHit`]). This is a trustworthy
+//!   negative finding.
+//! - **[`Verdict::Disclaimer`]** — *no* conclusive evidence is available; the
+//!   source(s) could not be checked (failed / timed out / not configured / not
+//!   authorized) or only stale data exists. We are silent on the truth, not
+//!   asserting a negative.
+//!
+//! Collapsing these two would let "we couldn't check" masquerade as "we checked
+//! and it's clear", which is exactly the unsupported-claim failure this spike
+//! measures.
+
+use crate::evidence::state::{EvidenceClass, EvidenceState};
+
+/// The four possible verdicts for a claim, ordered from most to least supported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Verdict {
+    /// Fully supported: conclusive positive evidence, no contradiction, no
+    /// confidence-degrading factors.
+    Clean,
+    /// Supported but with caveats: a mix of sufficient and insufficient
+    /// evidence, an internal contradiction, or a stale-degraded positive.
+    Qualified,
+    /// An authoritative negative finding: a source was queried and returned no
+    /// match. Categorically distinct from [`Verdict::Disclaimer`].
+    Adverse,
+    /// We could not determine the truth: no conclusive evidence is available.
+    /// Categorically distinct from [`Verdict::Adverse`].
+    Disclaimer,
+}
+
+/// Map the set of evidence-states backing a claim to a single [`Verdict`].
+///
+/// The mapping is a decision tree keyed on [`EvidenceClass`]:
+///
+/// 1. [`EvidenceClass::NotApplicable`] states are **filtered out first** — they
+///    neither support nor undermine the claim.
+/// 2. If nothing remains → [`Verdict::Disclaimer`] (no backing at all).
+/// 3. If there is **no conclusive evidence** (only could-not-check and/or stale)
+///    → [`Verdict::Disclaimer`].
+/// 4. With conclusive evidence present:
+///    - both a positive *and* a negative (contradiction) → [`Verdict::Qualified`];
+///    - only negative(s) → [`Verdict::Adverse`];
+///    - only positive(s): if any could-not-check **or** any stale state is also
+///      present → [`Verdict::Qualified`]; otherwise → [`Verdict::Clean`].
+///
+/// This satisfies every rule in the spike spec:
+/// - ≥1 [`CheckedHit`](EvidenceState::CheckedHit) with no contradiction → toward Clean.
+/// - [`CheckedNoHit`](EvidenceState::CheckedNoHit) → [`Verdict::Adverse`], not Disclaimer.
+/// - only could-not-check states → [`Verdict::Disclaimer`].
+/// - mixed sufficient + insufficient → [`Verdict::Qualified`].
+/// - [`Stale`](EvidenceState::Stale) degrades Clean → [`Verdict::Qualified`].
+///
+/// # Examples
+///
+/// ```
+/// use mcp_gateway::evidence::{EvidenceState, SourceId, Verdict, classify};
+///
+/// let hit = EvidenceState::CheckedHit { source: SourceId::new("s"), detail: None };
+/// assert_eq!(classify(&[hit]), Verdict::Clean);
+///
+/// let empty = EvidenceState::CheckedNoHit { source: SourceId::new("s"), detail: None };
+/// assert_eq!(classify(&[empty]), Verdict::Adverse);
+///
+/// let failed = EvidenceState::Failed { source: SourceId::new("s"), detail: None };
+/// assert_eq!(classify(&[failed]), Verdict::Disclaimer);
+/// ```
+#[must_use]
+pub fn classify(states: &[EvidenceState]) -> Verdict {
+    let mut has_positive = false;
+    let mut has_negative = false;
+    let mut has_could_not_check = false;
+    let mut has_stale = false;
+    let mut any_relevant = false;
+
+    for state in states {
+        match state.class() {
+            // Rule 1: not-applicable is filtered out (neutral).
+            EvidenceClass::NotApplicable => continue,
+            EvidenceClass::ConclusivePositive => has_positive = true,
+            EvidenceClass::ConclusiveNegative => has_negative = true,
+            EvidenceClass::CouldNotCheck => has_could_not_check = true,
+            EvidenceClass::Stale => has_stale = true,
+        }
+        any_relevant = true;
+    }
+
+    // Rule 2: nothing relevant remains.
+    if !any_relevant {
+        return Verdict::Disclaimer;
+    }
+
+    // Rule 3: no conclusive evidence at all (only could-not-check and/or stale).
+    if !has_positive && !has_negative {
+        return Verdict::Disclaimer;
+    }
+
+    // Rule 4: conclusive evidence is present.
+    match (has_positive, has_negative) {
+        // Contradiction: queried both ways with opposite authoritative answers.
+        (true, true) => Verdict::Qualified,
+        // Only authoritative negatives — a trustworthy adverse finding.
+        (false, true) => Verdict::Adverse,
+        // Only authoritative positives.
+        (true, false) => {
+            if has_could_not_check || has_stale {
+                // Mixed sufficient + insufficient, or stale-degraded → caveat.
+                Verdict::Qualified
+            } else {
+                Verdict::Clean
+            }
+        }
+        // Unreachable: covered by Rule 3 above, but kept total for clarity.
+        (false, false) => Verdict::Disclaimer,
+    }
+}
+
+#[cfg(test)]
+#[path = "verdict_tests.rs"]
+mod tests;

--- a/src/evidence/verdict_tests.rs
+++ b/src/evidence/verdict_tests.rs
@@ -9,28 +9,52 @@ fn src(id: &str) -> SourceId {
 }
 
 fn hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedHit { source: src(id), detail: None }
+    EvidenceState::CheckedHit {
+        source: src(id),
+        detail: None,
+    }
 }
 fn no_hit(id: &str) -> EvidenceState {
-    EvidenceState::CheckedNoHit { source: src(id), detail: None }
+    EvidenceState::CheckedNoHit {
+        source: src(id),
+        detail: None,
+    }
 }
 fn failed(id: &str) -> EvidenceState {
-    EvidenceState::Failed { source: src(id), detail: None }
+    EvidenceState::Failed {
+        source: src(id),
+        detail: None,
+    }
 }
 fn timeout(id: &str) -> EvidenceState {
-    EvidenceState::Timeout { source: src(id), detail: None }
+    EvidenceState::Timeout {
+        source: src(id),
+        detail: None,
+    }
 }
 fn not_configured(id: &str) -> EvidenceState {
-    EvidenceState::NotConfigured { source: src(id), detail: None }
+    EvidenceState::NotConfigured {
+        source: src(id),
+        detail: None,
+    }
 }
 fn not_authorized(id: &str) -> EvidenceState {
-    EvidenceState::NotAuthorized { source: src(id), detail: None }
+    EvidenceState::NotAuthorized {
+        source: src(id),
+        detail: None,
+    }
 }
 fn stale(id: &str) -> EvidenceState {
-    EvidenceState::Stale { source: src(id), detail: None }
+    EvidenceState::Stale {
+        source: src(id),
+        detail: None,
+    }
 }
 fn skipped(id: &str) -> EvidenceState {
-    EvidenceState::SkippedNotApplicable { source: src(id), detail: None }
+    EvidenceState::SkippedNotApplicable {
+        source: src(id),
+        detail: None,
+    }
 }
 
 // --- Clean -----------------------------------------------------------------
@@ -79,7 +103,12 @@ fn failed_only_is_disclaimer_not_adverse() {
 
 #[test]
 fn each_could_not_check_variant_alone_is_disclaimer() {
-    for state in [failed("s"), timeout("s"), not_configured("s"), not_authorized("s")] {
+    for state in [
+        failed("s"),
+        timeout("s"),
+        not_configured("s"),
+        not_authorized("s"),
+    ] {
         assert_eq!(
             classify(&[state.clone()]),
             Verdict::Disclaimer,
@@ -91,7 +120,12 @@ fn each_could_not_check_variant_alone_is_disclaimer() {
 #[test]
 fn any_mix_of_could_not_check_is_disclaimer() {
     // GIVEN only could-not-check states (no conclusive evidence).
-    let v = classify(&[failed("a"), timeout("b"), not_configured("c"), not_authorized("d")]);
+    let v = classify(&[
+        failed("a"),
+        timeout("b"),
+        not_configured("c"),
+        not_authorized("d"),
+    ]);
     assert_eq!(v, Verdict::Disclaimer);
     assert_ne!(v, Verdict::Adverse);
 }

--- a/src/evidence/verdict_tests.rs
+++ b/src/evidence/verdict_tests.rs
@@ -1,0 +1,190 @@
+//! Tests for the state→verdict mapping, with emphasis on the load-bearing
+//! [`Verdict::Adverse`]-vs-[`Verdict::Disclaimer`] distinction.
+
+use super::*;
+use crate::evidence::state::SourceId;
+
+fn src(id: &str) -> SourceId {
+    SourceId::new(id)
+}
+
+fn hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedHit { source: src(id), detail: None }
+}
+fn no_hit(id: &str) -> EvidenceState {
+    EvidenceState::CheckedNoHit { source: src(id), detail: None }
+}
+fn failed(id: &str) -> EvidenceState {
+    EvidenceState::Failed { source: src(id), detail: None }
+}
+fn timeout(id: &str) -> EvidenceState {
+    EvidenceState::Timeout { source: src(id), detail: None }
+}
+fn not_configured(id: &str) -> EvidenceState {
+    EvidenceState::NotConfigured { source: src(id), detail: None }
+}
+fn not_authorized(id: &str) -> EvidenceState {
+    EvidenceState::NotAuthorized { source: src(id), detail: None }
+}
+fn stale(id: &str) -> EvidenceState {
+    EvidenceState::Stale { source: src(id), detail: None }
+}
+fn skipped(id: &str) -> EvidenceState {
+    EvidenceState::SkippedNotApplicable { source: src(id), detail: None }
+}
+
+// --- Clean -----------------------------------------------------------------
+
+#[test]
+fn single_checked_hit_maps_to_clean() {
+    // GIVEN one authoritative positive and nothing else.
+    // WHEN classified.
+    // THEN the verdict is Clean.
+    assert_eq!(classify(&[hit("registry")]), Verdict::Clean);
+}
+
+#[test]
+fn multiple_checked_hits_map_to_clean() {
+    assert_eq!(classify(&[hit("a"), hit("b"), hit("c")]), Verdict::Clean);
+}
+
+// --- Adverse vs Disclaimer: the load-bearing distinction --------------------
+
+#[test]
+fn checked_no_hit_is_adverse_not_disclaimer() {
+    // GIVEN a source queried that authoritatively returned no match.
+    // WHEN classified.
+    // THEN the verdict is Adverse (a trustworthy negative), NOT Disclaimer.
+    let v = classify(&[no_hit("directory")]);
+    assert_eq!(v, Verdict::Adverse);
+    assert_ne!(v, Verdict::Disclaimer);
+}
+
+#[test]
+fn multiple_checked_no_hits_are_adverse() {
+    let v = classify(&[no_hit("a"), no_hit("b")]);
+    assert_eq!(v, Verdict::Adverse);
+    assert_ne!(v, Verdict::Disclaimer);
+}
+
+#[test]
+fn failed_only_is_disclaimer_not_adverse() {
+    // GIVEN the only outcome is a failure to check.
+    // WHEN classified.
+    // THEN the verdict is Disclaimer (we could not check), NOT Adverse.
+    let v = classify(&[failed("directory")]);
+    assert_eq!(v, Verdict::Disclaimer);
+    assert_ne!(v, Verdict::Adverse);
+}
+
+#[test]
+fn each_could_not_check_variant_alone_is_disclaimer() {
+    for state in [failed("s"), timeout("s"), not_configured("s"), not_authorized("s")] {
+        assert_eq!(
+            classify(&[state.clone()]),
+            Verdict::Disclaimer,
+            "could-not-check state {state:?} must map to Disclaimer",
+        );
+    }
+}
+
+#[test]
+fn any_mix_of_could_not_check_is_disclaimer() {
+    // GIVEN only could-not-check states (no conclusive evidence).
+    let v = classify(&[failed("a"), timeout("b"), not_configured("c"), not_authorized("d")]);
+    assert_eq!(v, Verdict::Disclaimer);
+    assert_ne!(v, Verdict::Adverse);
+}
+
+#[test]
+fn disclaimer_and_adverse_never_collapse_across_inputs() {
+    // The defining property: a pure could-not-check input and a pure
+    // authoritative-negative input must yield DIFFERENT verdicts.
+    let could_not_check = classify(&[failed("s"), timeout("s")]);
+    let authoritative_negative = classify(&[no_hit("s")]);
+    assert_ne!(could_not_check, authoritative_negative);
+    assert_eq!(could_not_check, Verdict::Disclaimer);
+    assert_eq!(authoritative_negative, Verdict::Adverse);
+}
+
+// --- Qualified --------------------------------------------------------------
+
+#[test]
+fn hit_plus_could_not_check_is_qualified() {
+    // GIVEN sufficient (a hit) mixed with insufficient (a failure).
+    // THEN the verdict is Qualified.
+    assert_eq!(classify(&[hit("a"), failed("b")]), Verdict::Qualified);
+}
+
+#[test]
+fn hit_plus_no_hit_contradiction_is_qualified() {
+    // GIVEN one source says hit and another says no-hit (contradiction).
+    // THEN the verdict is Qualified — NOT Clean (there IS contradicting
+    // evidence) and NOT Adverse (there is a positive).
+    let v = classify(&[hit("a"), no_hit("b")]);
+    assert_eq!(v, Verdict::Qualified);
+    assert_ne!(v, Verdict::Clean);
+    assert_ne!(v, Verdict::Adverse);
+}
+
+#[test]
+fn stale_degrades_clean_to_qualified() {
+    // GIVEN a conclusive positive degraded by a stale state.
+    // THEN the otherwise-Clean verdict becomes Qualified.
+    assert_eq!(classify(&[hit("a"), stale("b")]), Verdict::Qualified);
+}
+
+// --- SkippedNotApplicable: neutral (advisor-flagged blind spot) -------------
+
+#[test]
+fn skipped_not_applicable_alone_is_disclaimer() {
+    // GIVEN only a not-applicable state (no relevant evidence).
+    // THEN the verdict is Disclaimer.
+    assert_eq!(classify(&[skipped("s")]), Verdict::Disclaimer);
+}
+
+#[test]
+fn skipped_not_applicable_does_not_degrade_clean() {
+    // GIVEN a conclusive positive plus a not-applicable state.
+    // THEN the not-applicable state is filtered out and the verdict stays Clean.
+    // (If it were wrongly bucketed with could-not-check this would be Qualified.)
+    assert_eq!(classify(&[hit("a"), skipped("b")]), Verdict::Clean);
+}
+
+#[test]
+fn skipped_not_applicable_does_not_turn_adverse_into_disclaimer() {
+    // GIVEN an authoritative negative plus a not-applicable state.
+    // THEN the verdict remains Adverse.
+    assert_eq!(classify(&[no_hit("a"), skipped("b")]), Verdict::Adverse);
+}
+
+// --- Empty / edge ----------------------------------------------------------
+
+#[test]
+fn empty_evidence_is_disclaimer() {
+    assert_eq!(classify(&[]), Verdict::Disclaimer);
+}
+
+#[test]
+fn stale_only_is_disclaimer() {
+    // GIVEN only stale data with nothing conclusive to modify.
+    // THEN the verdict is Disclaimer.
+    assert_eq!(classify(&[stale("a"), stale("b")]), Verdict::Disclaimer);
+}
+
+#[test]
+fn classify_is_order_independent() {
+    let a = classify(&[hit("x"), failed("y"), stale("z")]);
+    let b = classify(&[stale("z"), hit("x"), failed("y")]);
+    let c = classify(&[failed("y"), stale("z"), hit("x")]);
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+}
+
+#[test]
+fn verdict_ordering_reflects_support_level() {
+    // Clean is the most-supported, Disclaimer the least.
+    assert!(Verdict::Clean < Verdict::Qualified);
+    assert!(Verdict::Qualified < Verdict::Adverse);
+    assert!(Verdict::Adverse < Verdict::Disclaimer);
+}

--- a/src/evidence/verdict_tests.rs
+++ b/src/evidence/verdict_tests.rs
@@ -110,7 +110,7 @@ fn each_could_not_check_variant_alone_is_disclaimer() {
         not_authorized("s"),
     ] {
         assert_eq!(
-            classify(&[state.clone()]),
+            classify(std::slice::from_ref(&state)),
             Verdict::Disclaimer,
             "could-not-check state {state:?} must map to Disclaimer",
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,11 @@ pub mod context_compression;
 pub mod cost_accounting;
 pub mod discovery;
 pub mod error;
+/// Evidence-typed render guard apparatus (spike MIK-5854).
+///
+/// Standalone, additive measurement code — **not** wired into any production
+/// routing, invoke, or result-proxy path.
+pub mod evidence;
 pub mod failsafe;
 pub mod gateway;
 mod hashing;


### PR DESCRIPTION
**Draft / spike — not for merge as-is.** Preserving genuinely-unmerged work that was stranded on a local-only branch (Jun 8) during a branch-cleanup sweep.

## What this is
A ~1,800-line `src/evidence/` module spike for MIK-5854: an evidence-typed verdict plus a non-bypassable render guard, with an adapter from backend results to an `EvidenceState`.

Files: `src/evidence/{adapter,guard,harness,state,verdict,mod}.rs` (+ tests), wired via `src/lib.rs`.

## Status
- Experimental spike apparatus — not reviewed, not integrated into the dispatch path.
- Branch base is ~Jun 8; it is behind current `main` and will need a rebase before it could be considered.

## Why a draft PR rather than a branch
The local branch was the only copy. This PR preserves it on `origin`, makes it visible/tracked, and lets CI report build status — instead of it rotting as undeployed local work.

Decide: rebase + harden toward merge, or close if the spike is superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)