### PR TITLE
fix(transport): re-init session on HTTP 200 + JSON-RPC session-expiry error (MIK-6040, #247)

### DIFF
--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -39,12 +39,40 @@ use crate::{Error, Result};
 /// - any body containing "session not found" (case-insensitive)
 /// - bare `HTTP 404` responses, which the MCP Streamable HTTP spec defines as
 ///   "session terminated or expired" (callers gate this on having had a session)
+///
+/// This covers the cases where the backend surfaces the expiry as a transport
+/// `Err` (non-2xx HTTP status, or a transport-layer failure). When the backend
+/// instead returns HTTP 200 with the expiry encoded as a JSON-RPC `error`
+/// member, use [`is_session_expired_response`] (MIK-6040, #247).
 fn is_session_expired_error(err: &Error) -> bool {
     let Error::Transport(msg) = err else {
         return false;
     };
     let lower = msg.to_lowercase();
     lower.contains("session not found") || msg.contains("-32015") || lower.starts_with("http 404")
+}
+
+/// Detect the session-expiry signature in a *successful-transport* JSON-RPC
+/// response whose body carries an `error` member (MIK-6040, #247).
+///
+/// Some remotes (notably OAuth-protected Streamable HTTP servers that invalidate
+/// the MCP session on token refresh) return HTTP 200 with the expiry encoded as
+/// a JSON-RPC error rather than a non-2xx status. The transport layer sees this
+/// as `Ok(JsonRpcResponse)` with `error: Some(..)`, so the [`is_session_expired_error`]
+/// classifier — which only inspects transport `Err` strings — never fires. This
+/// sibling classifier inspects the embedded error and matches:
+/// - code `-32015` (rust-mcp-sdk "Session not found")
+/// - code `-32600` (Invalid Request, observed for session-not-found on some remotes)
+/// - any `message` containing "session not found" (case-insensitive)
+///
+/// Per MCP 2025-11-25 §2.5.4 the recovery is identical to the `Err` path: drop
+/// the stale `MCP-Session-Id`, send a fresh `InitializeRequest`, and retry once.
+fn is_session_expired_response(resp: &JsonRpcResponse) -> bool {
+    resp.error.as_ref().is_some_and(|e| {
+        e.code == -32015
+            || e.code == -32600
+            || e.message.to_lowercase().contains("session not found")
+    })
 }
 
 /// HTTP transport for MCP servers using SSE or Streamable HTTP protocol
@@ -624,18 +652,29 @@ impl Transport for HttpTransport {
 
         let result = self.send_request(&request).await;
 
-        // MIK-5982: when the backend daemon restarts, our stored session ID is
-        // dead and every request — including circuit-breaker half-open probes —
-        // fails with `Session not found` forever (observed live 2026-06-11:
-        // hebb unreachable 6.5h while healthy). On the session-expiry
-        // signature, drop the session, re-run the initialize handshake, and
-        // retry the original request exactly once. `initialize()` calls
+        // MIK-5982 / MIK-6040: when the backend's session expires (daemon restart,
+        // or a remote invalidating the MCP session on OAuth token refresh), every
+        // request — including circuit-breaker half-open probes — keeps failing
+        // until we re-handshake (observed live 2026-06-11: hebb unreachable 6.5h
+        // while healthy). Recovery lives here, inside `request`, so it also rescues
+        // half-open probes and is not gated behind the Backend failsafe/CB.
+        //
+        // The expiry arrives in one of two shapes, handled by one coherent path:
+        //   1. transport `Err` — non-2xx HTTP (404, or -32015 body) or a transport
+        //      failure, classified by `is_session_expired_error` (MIK-5982).
+        //   2. `Ok(JsonRpcResponse)` whose `error` member signals expiry even with
+        //      a 200 status (e.g. remotes returning `-32600`/`-32015`/"session not
+        //      found"), classified by `is_session_expired_response` (MIK-6040, #247).
+        //
+        // On either signature: drop the session, re-run the initialize handshake,
+        // and retry the original request exactly once. `initialize()` calls
         // `send_request` directly (not `request`), so this cannot recurse.
         let had_session = self.session_id.read().is_some();
-        if let Err(ref err) = result
-            && had_session
-            && is_session_expired_error(err)
-        {
+        let session_expired = match &result {
+            Err(err) => is_session_expired_error(err),
+            Ok(resp) => is_session_expired_response(resp),
+        };
+        if had_session && session_expired {
             warn!(
                 url = %self.base_url,
                 method = %method,

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -701,6 +701,118 @@ async fn request_reinitializes_session_and_retries_on_http_404() {
     server.abort();
 }
 
+/// MIK-6040 (#247): a remote that invalidates the MCP session on OAuth token
+/// refresh may answer a live request with HTTP **200** and the expiry encoded as
+/// a JSON-RPC `error` member (code `-32600`/`-32015`, message "Session not
+/// found") rather than a non-2xx status. The transport sees this as
+/// `Ok(JsonRpcResponse)` with `error: Some(..)`, so the `Err`-string classifier
+/// never fires. The `is_session_expired_response` path must catch it and run the
+/// same drop-session / re-initialize / retry-once recovery as the 404 and
+/// `-32015` cases above.
+#[tokio::test]
+async fn request_reinitializes_on_jsonrpc_session_error_response() {
+    use axum::{
+        Json, Router,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        response::IntoResponse,
+        routing::post,
+    };
+    use serde_json::json;
+
+    const FRESH_SESSION: &str = "fresh-session-after-jsonrpc-session-err";
+
+    async fn mcp_handler(
+        State(hits): State<Arc<std::sync::atomic::AtomicU32>>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> axum::response::Response {
+        hits.fetch_add(1, Ordering::Relaxed);
+        let session = headers
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let method = body["method"].as_str().unwrap_or("");
+
+        if body.get("id").is_none() {
+            return StatusCode::ACCEPTED.into_response();
+        }
+
+        if method == "initialize" {
+            let mut resp_headers = HeaderMap::new();
+            resp_headers.insert("mcp-session-id", FRESH_SESSION.parse().unwrap());
+            return (
+                StatusCode::OK,
+                resp_headers,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "0"}
+                    }
+                })),
+            )
+                .into_response();
+        }
+
+        if session == FRESH_SESSION {
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {"ok": true}
+                })),
+            )
+                .into_response()
+        } else {
+            // Stale session: HTTP 200 + JSON-RPC error (the MIK-6040 shape).
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {"code": -32600, "message": "Session not found"}
+                })),
+            )
+                .into_response()
+        }
+    }
+
+    // GIVEN: a backend that signals stale-session via 200 + jsonrpc error
+    let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/mcp", post(mcp_handler))
+        .with_state(Arc::clone(&hits));
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let transport = make_transport(&format!("http://{addr}/mcp"));
+    *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
+    *transport.session_id.write() = Some("stale-session-before-refresh".to_string());
+
+    // WHEN: a request rides the dead session and the remote answers 200 + error
+    let response = transport.request("tools/list", None).await.unwrap();
+
+    // THEN: recovery re-initialized (no stale session) and the retry succeeded
+    assert!(
+        response.error.is_none(),
+        "retried request after jsonrpc session error must succeed"
+    );
+    assert_eq!(
+        transport.session_id.read().as_deref(),
+        Some(FRESH_SESSION),
+        "fresh session ID must replace the stale one"
+    );
+
+    server.abort();
+}
+
 /// A request without any session that fails with a non-session error must NOT
 /// trigger the re-initialize path (no retry storm on genuinely broken backends).
 #[tokio::test]
@@ -752,4 +864,47 @@ fn session_expired_detection_matches_known_signatures() {
     assert!(!is_session_expired_error(&Error::Protocol(
         "Session not found".to_string()
     )));
+}
+
+#[test]
+fn session_expired_response_detection_matches_known_signatures() {
+    use crate::protocol::JsonRpcError;
+
+    let make = |code: i32, message: &str| JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message: message.to_string(),
+            data: None,
+        }),
+    };
+
+    // MIK-6040: 200 + JSON-RPC error shapes a remote may use for session expiry.
+    assert!(is_session_expired_response(&make(
+        -32600,
+        "Session not found"
+    )));
+    assert!(is_session_expired_response(&make(
+        -32015,
+        "Bad Request: Session not found"
+    )));
+    // Match on message alone, even with an unexpected code.
+    assert!(is_session_expired_response(&make(
+        -32000,
+        "session not found"
+    )));
+    // Unrelated JSON-RPC errors must not match.
+    assert!(!is_session_expired_response(&make(
+        -32601,
+        "Method not found"
+    )));
+    // A successful response (no error) must not match.
+    assert!(!is_session_expired_response(&JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        result: Some(serde_json::json!({"ok": true})),
+        error: None,
+    }));
 }


### PR DESCRIPTION
## What

Extends the existing MIK-5982 (#248) session-recovery path so the gateway also recovers when a backend signals MCP session expiry as **HTTP 200 with a JSON-RPC `error` member**, instead of as a non-2xx transport error.

Refs: GH #247, MIK-6040.

## Why

The MIK-5982 path (`is_session_expired_error`) only inspects transport `Err` strings — non-2xx HTTP status (404), `-32015`, or a body containing "session not found". Some remotes — notably OAuth-protected Streamable HTTP servers that invalidate the MCP session on token refresh — instead answer a live request with **HTTP 200** and the expiry encoded in the JSON-RPC `error` (code `-32600` / `-32015`, or message "session not found"). The transport sees `Ok(JsonRpcResponse)` with `error: Some(..)`, the existing classifier never fires, and the dead session is never re-handshook (the failure class behind #247).

## How it extends the MIK-5982 path

- Adds `is_session_expired_response`, the `Ok(JsonRpcResponse)` sibling of `is_session_expired_error`, matching error code `-32015` / `-32600` or a message containing "session not found".
- Folds both shapes into **one** coherent recovery decision in `HttpTransport::request`: whether the result is an `Err` matching the transport classifier or an `Ok` whose embedded error matches the response classifier, the recovery is identical — drop the stale `MCP-Session-Id`, re-run `initialize`, and retry the original request exactly once. No duplicate recovery block. Per MCP 2025-11-25 §2.5.4.
- Recovery stays inside `request` (not gated behind the Backend failsafe / circuit-breaker), so it also rescues half-open CB probes, matching the MIK-5982 design.

## Tests

- `request_reinitializes_on_jsonrpc_session_error_response` — end-to-end: a mock backend that answers the stale session with HTTP 200 + JSON-RPC error, and a fresh session on `initialize`; asserts the retry succeeds and the stale session ID is replaced.
- `session_expired_response_detection_matches_known_signatures` — unit coverage for the new classifier (matches `-32600`/`-32015`/message; ignores unrelated errors and successful responses).

Verification (sccache disabled): `cargo build --lib`, `cargo test --lib transport::http` (32 passed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt` — all green.

## Credit

The HTTP-200 detection insight and the original regression-test shape come from the `symphony/MIK-6040/grok-native` branch; this PR reconciles that work onto current `main` (which already carries the MIK-5982/#248 reinit path) as a single non-duplicated detection path and excludes the unrelated churn on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)