### PR TITLE
fix(attestation): enforce capability allow-list at boundary calls (MIK-6163)

### DIFF
--- a/src/attestation/launcher.rs
+++ b/src/attestation/launcher.rs
@@ -201,7 +201,7 @@ impl AttestedSandboxLauncher {
         let mut flow_trace = vec!["token_required"];
         let claims = self
             .validator
-            .validate_boundary_call(token, BOOT_BOUNDARY, now)
+            .validate_boundary_call(token, BOOT_BOUNDARY, None, now)
             .map_err(|rejection| match rejection {
                 AttestationRejection::MissingToken => BootDenial::MissingToken,
                 other => BootDenial::InvalidToken(other),

--- a/src/attestation/mod.rs
+++ b/src/attestation/mod.rs
@@ -15,7 +15,7 @@
 //!   └── rotate()           successor token; predecessor enters grace window
 //!
 //! AttestationValidator     (one per gateway; the single validation point)
-//!   ├── validate_boundary_call()  signature → claims → expiry → rotation
+//!   ├── validate_boundary_call()  signature → claims → expiry → rotation → capability
 //!   ├── audit: AuditRingBuffer    every rejection, with detection latency
 //!   └── checkpoint()/restore()    rotation state survives checkpoints (B3)
 //!

--- a/src/attestation/validator.rs
+++ b/src/attestation/validator.rs
@@ -81,6 +81,14 @@ pub enum AttestationRejection {
         /// `token_id` of the rejected predecessor token.
         token_id: String,
     },
+    /// The token is authentic and unexpired, but its capability allow-list
+    /// does not grant the requested action (MIK-6163, fail-closed).
+    CapabilityNotGranted {
+        /// The capability/action the call required.
+        required: String,
+        /// The capabilities the token actually carries.
+        granted: Vec<String>,
+    },
 }
 
 impl std::fmt::Display for AttestationRejection {
@@ -95,6 +103,10 @@ impl std::fmt::Display for AttestationRejection {
             Self::RotatedOut { token_id } => {
                 write!(f, "token {token_id} rotated out and past its grace window")
             }
+            Self::CapabilityNotGranted { required, granted } => write!(
+                f,
+                "token capabilities {granted:?} do not grant required action {required:?}"
+            ),
         }
     }
 }
@@ -216,6 +228,19 @@ pub struct RotationCheckpoint {
     pub retiring: Vec<RetiringToken>,
 }
 
+// ── Capability matching ──────────────────────────────────────────────────────
+
+/// Whether a token's capability allow-list grants the requested action.
+///
+/// Fail-closed: the empty allow-list grants nothing. A capability grants the
+/// requested action when it is the `"*"` wildcard (a deliberately broad,
+/// operator-minted grant) or an exact match for the action. Matching is exact
+/// otherwise — no prefix/substring coercion that could widen a narrow grant.
+#[must_use]
+fn capabilities_grant(capabilities: &[String], required: &str) -> bool {
+    capabilities.iter().any(|cap| cap == "*" || cap == required)
+}
+
 // ── Validator ────────────────────────────────────────────────────────────────
 
 /// Gateway-side validator — the single point every cross-boundary call goes
@@ -267,6 +292,14 @@ impl AttestationValidator {
     /// recorded in the audit ring buffer with its detection latency and
     /// emitted as an `attestation_audit` tracing event, then returned.
     ///
+    /// `required_capability` is the action/tool the call is requesting. When
+    /// `Some`, the token's capability allow-list MUST grant it (an exact match,
+    /// or the `"*"` wildcard) or the call is rejected with
+    /// [`AttestationRejection::CapabilityNotGranted`] — authenticity alone never
+    /// authorizes an out-of-scope action (MIK-6163, fail-closed). `None` is for
+    /// capability-agnostic boundaries (e.g. `sandbox_boot`), which validate
+    /// authenticity only.
+    ///
     /// # Errors
     ///
     /// Returns the [`AttestationRejection`] describing why the token was
@@ -275,10 +308,11 @@ impl AttestationValidator {
         &self,
         encoded: Option<&str>,
         boundary: &str,
+        required_capability: Option<&str>,
         now: DateTime<Utc>,
     ) -> Result<TokenClaims, AttestationRejection> {
         let started = Instant::now();
-        match self.check(encoded, now) {
+        match self.check(encoded, required_capability, now) {
             Ok(claims) => {
                 self.validations_total.fetch_add(1, Ordering::Relaxed);
                 Ok(claims)
@@ -309,13 +343,14 @@ impl AttestationValidator {
         }
     }
 
-    /// Signature → structure → issuer → expiry → rotation, in that order.
-    /// Returns parsed claims alongside the rejection when they were readable
-    /// (for audit attribution; never trusted for authorization).
+    /// Signature → structure → issuer → expiry → rotation → capability, in that
+    /// order. Returns parsed claims alongside the rejection when they were
+    /// readable (for audit attribution; never trusted for authorization).
     #[allow(clippy::result_large_err)]
     fn check(
         &self,
         encoded: Option<&str>,
+        required_capability: Option<&str>,
         now: DateTime<Utc>,
     ) -> Result<TokenClaims, (AttestationRejection, Option<TokenClaims>)> {
         let Some(encoded) = encoded else {
@@ -362,6 +397,19 @@ impl AttestationValidator {
         if rotated_out {
             let token_id = claims.token_id.clone();
             return Err((AttestationRejection::RotatedOut { token_id }, Some(claims)));
+        }
+        // Capability allow-list check — the token is authentic and live, but it
+        // must still be scoped for the requested action (MIK-6163, fail-closed).
+        // Authenticity answers WHO; this answers WHAT they may do. A `None`
+        // requirement is a capability-agnostic boundary (e.g. sandbox_boot).
+        if let Some(required) = required_capability
+            && !capabilities_grant(&claims.capabilities, required)
+        {
+            let rejection = AttestationRejection::CapabilityNotGranted {
+                required: required.to_string(),
+                granted: claims.capabilities.clone(),
+            };
+            return Err((rejection, Some(claims)));
         }
         Ok(claims)
     }
@@ -490,7 +538,7 @@ mod tests {
         let now = Utc::now();
         let token = issue(now);
         let claims = v
-            .validate_boundary_call(Some(token.encoded()), "test", now)
+            .validate_boundary_call(Some(token.encoded()), "test", None, now)
             .unwrap();
         assert_eq!(claims.agent_identity, "agent");
         assert_eq!(v.validations_total(), 1);
@@ -502,7 +550,7 @@ mod tests {
     fn missing_token_rejected_and_audited() {
         let v = validator();
         let err = v
-            .validate_boundary_call(None, "boot", Utc::now())
+            .validate_boundary_call(None, "boot", None, Utc::now())
             .unwrap_err();
         assert_eq!(err, AttestationRejection::MissingToken);
         assert_eq!(v.rejections_total(), 1);
@@ -512,13 +560,62 @@ mod tests {
     }
 
     #[test]
+    fn mik_5223_caps_1_rejects_token_lacking_required_capability() {
+        // MIK-5223.CAPS.1 — fail-closed: an authentic, unexpired token whose
+        // capability allow-list does NOT include the requested action is
+        // rejected. Authenticity alone must not authorize an out-of-scope call.
+        let v = validator();
+        let now = Utc::now();
+        let token = issue(now); // minted with capabilities = ["cap"]
+
+        // Requesting an action the token was not scoped for → rejected.
+        let err = v
+            .validate_boundary_call(Some(token.encoded()), "gateway_invoke", Some("write"), now)
+            .unwrap_err();
+        assert!(
+            matches!(err, AttestationRejection::CapabilityNotGranted { .. }),
+            "expected CapabilityNotGranted, got: {err:?}"
+        );
+        assert_eq!(v.rejections_total(), 1);
+
+        // The same token IS admitted for the capability it actually holds.
+        let granted = v
+            .validate_boundary_call(Some(token.encoded()), "gateway_invoke", Some("cap"), now)
+            .unwrap();
+        assert_eq!(granted.agent_identity, "agent");
+
+        // A capability-agnostic boundary (None, e.g. sandbox_boot) still passes.
+        v.validate_boundary_call(Some(token.encoded()), "boot", None, now)
+            .unwrap();
+    }
+
+    #[test]
+    fn wildcard_capability_grants_any_action() {
+        // A token holding the "*" wildcard authorizes any requested action.
+        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let now = Utc::now();
+        let token = signer.issue(
+            &TokenRequest {
+                agent_identity: "agent".to_string(),
+                task_uuid: Uuid::new_v4(),
+                capabilities: vec!["*".to_string()],
+            },
+            now,
+            TimeDelta::minutes(10),
+        );
+        let v = validator();
+        v.validate_boundary_call(Some(token.encoded()), "gateway_invoke", Some("write"), now)
+            .unwrap();
+    }
+
+    #[test]
     fn expired_token_rejected() {
         let v = validator();
         let issued = Utc::now();
         let token = issue(issued);
         let later = issued + TimeDelta::minutes(11);
         let err = v
-            .validate_boundary_call(Some(token.encoded()), "call", later)
+            .validate_boundary_call(Some(token.encoded()), "call", None, later)
             .unwrap_err();
         assert!(matches!(err, AttestationRejection::Expired { .. }));
     }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -255,7 +255,18 @@ impl MetaMcp {
             return Ok(());
         };
         let token = args.get("attestation").and_then(Value::as_str);
-        match validator.validate_boundary_call(token, "gateway_invoke", chrono::Utc::now()) {
+        // The requested action is the tool being invoked: the token's capability
+        // allow-list must grant it (MIK-6163). Missing tool → empty action,
+        // which only a "*" wildcard token can satisfy (fail-closed). The
+        // authenticity checks still run first, so a forged/expired token is
+        // rejected on those grounds regardless of capability.
+        let requested = args.get("tool").and_then(Value::as_str).unwrap_or_default();
+        match validator.validate_boundary_call(
+            token,
+            "gateway_invoke",
+            Some(requested),
+            chrono::Utc::now(),
+        ) {
             Ok(_claims) => Ok(()),
             Err(rejection) => match self.attestation_mode {
                 crate::attestation::AttestationMode::Enforce => Err(Error::json_rpc(

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -1269,18 +1269,72 @@ mod attestation_wiring {
     }
 
     fn valid_token() -> String {
+        token_with(vec!["t".to_string()])
+    }
+
+    fn token_with(capabilities: Vec<String>) -> String {
         BnautAttestationSigner::new(KEY.to_vec(), "wiring")
             .issue(
                 &TokenRequest {
                     agent_identity: "agent-9".to_string(),
                     task_uuid: Uuid::new_v4(),
-                    capabilities: vec!["tools:search".to_string()],
+                    capabilities,
                 },
                 Utc::now(),
                 TimeDelta::minutes(5),
             )
             .encoded()
             .to_string()
+    }
+
+    #[test]
+    fn mik_5223_caps_2_enforce_rejects_read_token_on_write_tool() {
+        // MIK-5223.CAPS.2 — a token minted for ["read"] must NOT authorize a
+        // write (non-read) tool under enforce mode (fail-closed, JSON-RPC -32002).
+        let v = validator();
+        let mm = make_meta_mcp().with_attestation(Arc::clone(&v), AttestationMode::Enforce);
+        let token = token_with(vec!["read".to_string()]);
+        // WHEN the read-scoped token invokes a write tool
+        let err = mm
+            .check_attestation(
+                &json!({"server": "s", "tool": "write", "attestation": token}),
+                Some("agent-9"),
+            )
+            .unwrap_err();
+        // THEN the call is rejected with the attestation JSON-RPC code -32002
+        assert_eq!(err.to_rpc_code(), -32002, "got: {err}");
+        assert!(err.to_string().contains("Attestation rejected"));
+        assert_eq!(v.rejections_total(), 1);
+
+        // AND the same read-scoped token IS admitted for the read tool.
+        let ok = mm.check_attestation(
+            &json!({"server": "s", "tool": "read", "attestation": token_with(vec!["read".to_string()])}),
+            Some("agent-9"),
+        );
+        assert!(ok.is_ok());
+    }
+
+    #[test]
+    fn mik_5223_caps_3_observe_logs_capability_mismatch_without_blocking() {
+        // MIK-5223.CAPS.3 — observe mode records the capability mismatch in the
+        // audit ring buffer but does NOT block the call.
+        let v = validator();
+        let mm = make_meta_mcp().with_attestation(Arc::clone(&v), AttestationMode::Observe);
+        let token = token_with(vec!["read".to_string()]);
+        let res = mm.check_attestation(
+            &json!({"server": "s", "tool": "write", "attestation": token}),
+            Some("agent-9"),
+        );
+        // THEN the call is NOT blocked...
+        assert!(res.is_ok());
+        // ...but the capability mismatch is audited.
+        assert_eq!(v.rejections_total(), 1);
+        let records = v.audit().snapshot();
+        assert_eq!(records.len(), 1);
+        assert!(matches!(
+            records[0].rejection,
+            crate::attestation::AttestationRejection::CapabilityNotGranted { .. }
+        ));
     }
 
     #[test]

--- a/tests/mik_5223_acs.rs
+++ b/tests/mik_5223_acs.rs
@@ -129,7 +129,7 @@ fn ac_3_every_cross_boundary_call_validates_and_rejections_hit_ring_buffer() {
     // Every cross-boundary call goes through the gateway validator.
     for boundary in ["gateway_invoke", "gateway_search", "backend_proxy"] {
         let claims = v
-            .validate_boundary_call(Some(token.encoded()), boundary, now)
+            .validate_boundary_call(Some(token.encoded()), boundary, None, now)
             .expect("valid token must pass on every boundary");
         assert_eq!(claims.token_id, token.claims().token_id);
     }
@@ -139,7 +139,7 @@ fn ac_3_every_cross_boundary_call_validates_and_rejections_hit_ring_buffer() {
     // A rejected call logs to the audit ring buffer.
     let tampered = format!("{}x", token.encoded());
     let err = v
-        .validate_boundary_call(Some(&tampered), "gateway_invoke", now)
+        .validate_boundary_call(Some(&tampered), "gateway_invoke", None, now)
         .unwrap_err();
     assert!(matches!(
         err,
@@ -169,17 +169,17 @@ fn ac_4_rotation_does_not_disrupt_in_flight_syscalls() {
     // An in-flight syscall still carrying the predecessor token is NOT
     // disrupted: it validates inside the grace window.
     let in_flight = now + TimeDelta::seconds(5);
-    v.validate_boundary_call(Some(original.encoded()), "syscall", in_flight)
+    v.validate_boundary_call(Some(original.encoded()), "syscall", None, in_flight)
         .expect("in-flight syscall with predecessor token must not be disrupted");
 
     // The successor validates too, on the same path.
-    v.validate_boundary_call(Some(successor.encoded()), "syscall", in_flight)
+    v.validate_boundary_call(Some(successor.encoded()), "syscall", None, in_flight)
         .expect("successor token must validate");
 
     // After the grace window closes, the predecessor is rejected.
     let after_grace = now + TimeDelta::seconds(31);
     let err = v
-        .validate_boundary_call(Some(original.encoded()), "syscall", after_grace)
+        .validate_boundary_call(Some(original.encoded()), "syscall", None, after_grace)
         .unwrap_err();
     assert!(matches!(err, AttestationRejection::RotatedOut { .. }));
     assert_eq!(v.rotations_total(), 1);
@@ -240,7 +240,7 @@ fn ac_5_forgery_detected_and_logged_within_100ms_over_100_cases() {
     let before = v.audit().total_pushed();
     for (i, forged) in forgeries.iter().enumerate() {
         let started = Instant::now();
-        let result = v.validate_boundary_call(Some(forged), "forgery_probe", now);
+        let result = v.validate_boundary_call(Some(forged), "forgery_probe", None, now);
         let elapsed = started.elapsed();
         assert!(result.is_err(), "forgery case {i} must be detected");
         assert!(
@@ -317,7 +317,7 @@ fn ac_7_b1_ident_every_token_and_audit_record_uniquely_attributable() {
 
     // Every audit record is uniquely attributable: monotonic seq numbers.
     for _ in 0..3 {
-        let _ = v.validate_boundary_call(None, "probe", now);
+        let _ = v.validate_boundary_call(None, "probe", None, now);
     }
     let seqs: Vec<u64> = v.audit().snapshot().iter().map(|r| r.seq).collect();
     assert_eq!(seqs, vec![0, 1, 2]);
@@ -337,7 +337,7 @@ fn ac_8_b2_mem_na_token_consumable_downstream() {
     let token = signer().issue(&request(), now, TimeDelta::minutes(5));
     let v = validator();
     let claims = v
-        .validate_boundary_call(Some(token.encoded()), "runtime_b_bridge", now)
+        .validate_boundary_call(Some(token.encoded()), "runtime_b_bridge", None, now)
         .expect("downstream consumer must be able to validate the token");
     assert_eq!(&claims, token.claims());
 }
@@ -361,17 +361,17 @@ fn ac_9_b3_durable_rotation_state_persists_across_checkpoint() {
     // Grace window honored after restore: in-flight predecessor still valid…
     let in_flight = now + TimeDelta::seconds(5);
     fresh
-        .validate_boundary_call(Some(original.encoded()), "syscall", in_flight)
+        .validate_boundary_call(Some(original.encoded()), "syscall", None, in_flight)
         .expect("grace window must survive checkpoint/restore");
     // …and post-grace rejection also survives the checkpoint.
     let after_grace = now + TimeDelta::seconds(31);
     let err = fresh
-        .validate_boundary_call(Some(original.encoded()), "syscall", after_grace)
+        .validate_boundary_call(Some(original.encoded()), "syscall", None, after_grace)
         .unwrap_err();
     assert!(matches!(err, AttestationRejection::RotatedOut { .. }));
     // The successor is unaffected.
     fresh
-        .validate_boundary_call(Some(successor.encoded()), "syscall", after_grace)
+        .validate_boundary_call(Some(successor.encoded()), "syscall", None, after_grace)
         .expect("successor valid after restore");
 }
 


### PR DESCRIPTION
## Summary
The per-action attestation merged via #259 authenticated **WHO** (signature, issuer, expiry, rotation) but never checked **WHAT** the token was scoped to: `validate_boundary_call` ignored the token's `capabilities` allow-list, so a token minted for `["read"]` authorized *any* tool. This is the [HIGH] privilege gap surfaced by the #259 adversarial review (MIK-6163).

This PR adds **fail-closed capability enforcement** as the final validation step.

## What changed
- New `AttestationRejection::CapabilityNotGranted { required, granted }`.
- `validate_boundary_call` gains a `required_capability: Option<&str>` arg. When `Some(action)`, the token's allow-list must grant it (exact match, or the `"*"` wildcard) or the call is rejected. `None` is a capability-agnostic boundary (e.g. `sandbox_boot`, which validates authenticity only).
- `check_attestation` (the `gateway_invoke` wiring point from #259) derives the required capability from the requested `tool` and threads it through. Enforce mode returns JSON-RPC `-32002`; Observe mode audits the mismatch in the ring buffer and does not block.
- Capability matching is exact plus the `"*"` wildcard only, with no coercion that could silently widen a narrow grant.

## Enforcement point
- Authorization decision: `validator.rs` in `check()`, capability step after signature, issuer, expiry, and rotation.
- Wiring and mode handling: `invoke.rs` in `check_attestation()`, which derives the action from the requested tool and applies the Enforce or Observe mode.

## Tests (TDD, failing first then green)
- `MIK-5223.CAPS.1` `mik_5223_caps_1_rejects_token_lacking_required_capability` (validator unit)
- `MIK-5223.CAPS.2` `mik_5223_caps_2_enforce_rejects_read_token_on_write_tool` (wiring, Enforce returns -32002)
- `MIK-5223.CAPS.3` `mik_5223_caps_3_observe_logs_capability_mismatch_without_blocking` (wiring, Observe audits)
- `wildcard_capability_grants_any_action` (validator unit)

Results: `cargo test --lib attestation` 33 passed / 0 failed; `cargo test --test mik_5223_acs` 11 passed / 0 failed; pre-push gate (fmt check, clippy with -D warnings, full lib suite 2932 passed) all green.

## Safety
No production path is flipped to Enforce; the default remains Observe (`AttestationMode::default()`). Enabling enforcement stays an operator decision. **Do not merge** without operator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
