### PR TITLE
fix(runtime): enforce egress + capability divergence on both substrates (MIK-6164)

### DIFF
--- a/src/runtime/compiler.rs
+++ b/src/runtime/compiler.rs
@@ -13,11 +13,12 @@
 //! compiler targets produce OCI-conformant output, with Apple VM-spec as
 //! a macOS-native representation of the same semantics.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
+use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
 
-use super::descriptor::SandboxDescriptor;
+use super::descriptor::{NetworkEgressPolicy, SandboxDescriptor};
 use super::divergence::{DivergenceRegistry, SubstrateTag};
 use super::substrate::Substrate;
 
@@ -54,6 +55,16 @@ pub struct OciBundle {
     /// Environment variables.
     #[serde(default)]
     pub env: HashMap<String, String>,
+
+    /// Enforceable network-egress configuration emitted to the substrate.
+    ///
+    /// **MIK-5226.SEC.2**: previously `network_egress` was decorative — the
+    /// gVisor compiler never emitted it, so every sandbox got a full network
+    /// namespace regardless of policy (fail-open). This field carries the
+    /// compiled, enforceable policy so a launcher applies it deterministically
+    /// and so the two substrates can be compared for divergence.
+    #[serde(default)]
+    pub egress: EgressConfig,
 }
 
 /// OCI process configuration.
@@ -69,6 +80,64 @@ pub struct OciProcess {
     /// Terminal flag.
     #[serde(default)]
     pub terminal: bool,
+
+    /// Linux capabilities granted to the process.
+    ///
+    /// **MIK-5226.SEC.1**: previously `descriptor.capabilities` were silently
+    /// dropped by the gVisor compiler while the Apple VM target passed them
+    /// through as entitlements — the same descriptor therefore ran at a
+    /// different privilege level depending on the host. The compiler now emits
+    /// the requested capabilities here so the privilege grant is explicit and
+    /// comparable across substrates.
+    #[serde(default)]
+    pub capabilities: Option<OciCapabilities>,
+}
+
+/// OCI process capability sets (subset of the runtime-spec `Capabilities`).
+///
+/// The requested descriptor capabilities are emitted into the `bounding`,
+/// `effective`, and `permitted` sets — the sets that actually constrain what
+/// the process may do. `inheritable`/`ambient` are intentionally left empty
+/// (capabilities are not propagated to `execve`'d children by default).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct OciCapabilities {
+    /// Bounding set — the ceiling of capabilities the process may ever hold.
+    #[serde(default)]
+    pub bounding: Vec<String>,
+    /// Effective set — capabilities currently in force.
+    #[serde(default)]
+    pub effective: Vec<String>,
+    /// Permitted set — capabilities the process may raise into effective.
+    #[serde(default)]
+    pub permitted: Vec<String>,
+    /// Inheritable set — preserved across `execve` (empty by default).
+    #[serde(default)]
+    pub inheritable: Vec<String>,
+    /// Ambient set — inheritable + permitted on `execve` (empty by default).
+    #[serde(default)]
+    pub ambient: Vec<String>,
+}
+
+impl OciCapabilities {
+    /// Build capability sets from a flat list of requested capabilities.
+    ///
+    /// The list is mirrored into bounding/effective/permitted.
+    #[must_use]
+    pub fn from_list(caps: &[String]) -> Self {
+        Self {
+            bounding: caps.to_vec(),
+            effective: caps.to_vec(),
+            permitted: caps.to_vec(),
+            inheritable: Vec::new(),
+            ambient: Vec::new(),
+        }
+    }
+
+    /// The set of granted capabilities (the bounding set), for comparison.
+    #[must_use]
+    pub fn granted(&self) -> BTreeSet<String> {
+        self.bounding.iter().cloned().collect()
+    }
 }
 
 /// OCI root filesystem configuration.
@@ -172,6 +241,13 @@ pub struct AppleVmSpec {
     #[serde(default)]
     pub network: AppleVmNetwork,
 
+    /// Enforceable network-egress configuration (MIK-5226.SEC.2).
+    ///
+    /// Carries the same compiled policy as the gVisor bundle so egress is
+    /// restricted identically on both substrates.
+    #[serde(default)]
+    pub egress: EgressConfig,
+
     /// Capabilities (translated from Linux capabilities where applicable).
     #[serde(default)]
     pub entitlements: Vec<String>,
@@ -217,6 +293,112 @@ pub struct AppleVmNetwork {
 
 fn default_true() -> bool {
     true
+}
+
+// ── EgressConfig ─────────────────────────────────────────────────────────
+
+/// Compiled, enforceable network-egress configuration.
+///
+/// **MIK-5226.SEC.2**: this is the substrate-agnostic representation of a
+/// [`NetworkEgressPolicy`] that is emitted into *both* the gVisor OCI bundle
+/// and the Apple VM-spec, so the same descriptor restricts egress identically
+/// regardless of host. [`EgressConfig::allows`] is the single decision
+/// procedure a launcher (gVisor netstack filter, or Apple VM packet filter)
+/// applies; the test suite asserts on it directly so a blocked destination is
+/// provably unreachable in the emitted config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct EgressConfig {
+    /// Whether any non-loopback egress is permitted.
+    ///
+    /// `false` means the sandbox can reach loopback only (if `loopback`) or
+    /// nothing at all.
+    pub enabled: bool,
+
+    /// Whether loopback (localhost) traffic is permitted.
+    pub loopback: bool,
+
+    /// Allowlisted destination CIDRs.
+    ///
+    /// When `enabled` and this is **non-empty**, egress is restricted to
+    /// exactly these CIDRs. When `enabled` and this is **empty**, egress is
+    /// unrestricted (full internet). When `!enabled`, this is ignored.
+    #[serde(default)]
+    pub allowed_cidrs: Vec<String>,
+}
+
+impl EgressConfig {
+    /// Compile a [`NetworkEgressPolicy`] into an enforceable config.
+    #[must_use]
+    pub fn from_policy(policy: &NetworkEgressPolicy) -> Self {
+        match policy {
+            NetworkEgressPolicy::None => Self {
+                enabled: false,
+                loopback: false,
+                allowed_cidrs: Vec::new(),
+            },
+            NetworkEgressPolicy::Loopback => Self {
+                enabled: false,
+                loopback: true,
+                allowed_cidrs: Vec::new(),
+            },
+            NetworkEgressPolicy::Full => Self {
+                enabled: true,
+                loopback: true,
+                allowed_cidrs: Vec::new(),
+            },
+            NetworkEgressPolicy::Allowlist(cidrs) => Self {
+                enabled: true,
+                loopback: true,
+                allowed_cidrs: cidrs.clone(),
+            },
+        }
+    }
+
+    /// Decide whether traffic to `dest` (an IPv4 literal) is permitted by this
+    /// config. Unparseable destinations and unparseable allowlist entries are
+    /// treated as **denied** (fail-closed).
+    #[must_use]
+    pub fn allows(&self, dest: &str) -> bool {
+        let Ok(ip) = dest.parse::<Ipv4Addr>() else {
+            return false;
+        };
+        if ip.is_loopback() {
+            return self.loopback;
+        }
+        if !self.enabled {
+            return false;
+        }
+        if self.allowed_cidrs.is_empty() {
+            // Full egress.
+            return true;
+        }
+        self.allowed_cidrs.iter().any(|cidr| ipv4_in_cidr(ip, cidr))
+    }
+}
+
+/// Returns `true` if `ip` falls within the IPv4 `cidr` (e.g. `"10.0.0.0/8"`).
+///
+/// A bare address (no `/prefix`) is treated as a `/32`. Malformed CIDRs return
+/// `false` (fail-closed).
+fn ipv4_in_cidr(ip: Ipv4Addr, cidr: &str) -> bool {
+    let (base, prefix) = match cidr.split_once('/') {
+        Some((b, p)) => (b, p),
+        None => (cidr, "32"),
+    };
+    let Ok(base_addr) = base.trim().parse::<Ipv4Addr>() else {
+        return false;
+    };
+    let Ok(prefix) = prefix.trim().parse::<u32>() else {
+        return false;
+    };
+    if prefix > 32 {
+        return false;
+    }
+    if prefix == 0 {
+        return true;
+    }
+    let mask: u32 = u32::MAX << (32 - prefix);
+    (u32::from(ip) & mask) == (u32::from(base_addr) & mask)
 }
 
 // ── Compiler ─────────────────────────────────────────────────────────────
@@ -334,6 +516,10 @@ impl Compiler {
                 args: vec!["/init".to_string()],
                 cwd: "/".to_string(),
                 terminal: false,
+                // MIK-5226.SEC.1: emit the requested capabilities instead of
+                // silently dropping them. Empty list ⇒ empty sets (no extra
+                // privilege), never a dropped grant.
+                capabilities: Some(OciCapabilities::from_list(&descriptor.capabilities)),
             },
             root: OciRoot {
                 path: format!("rootfs-{}", descriptor.name),
@@ -343,6 +529,8 @@ impl Compiler {
             mounts,
             linux,
             env: descriptor.env.clone(),
+            // MIK-5226.SEC.2: emit the enforceable egress policy.
+            egress: EgressConfig::from_policy(&descriptor.network_egress),
         }
     }
 
@@ -363,18 +551,15 @@ impl Compiler {
             })
             .collect();
 
-        let network = match &descriptor.network_egress {
-            super::descriptor::NetworkEgressPolicy::None => AppleVmNetwork {
-                enabled: false,
-                nat: false,
-            },
-            // Loopback, Full, and Allowlist all enable the VM NAT interface;
-            // fine-grained allowlisting is applied at the egress firewall, not
-            // the VM network toggle.
-            _ => AppleVmNetwork {
-                enabled: true,
-                nat: true,
-            },
+        // MIK-5226.SEC.2: derive the VM network toggle faithfully from the
+        // policy. Previously Loopback/Full/Allowlist all collapsed to
+        // NAT-enabled (fail-open) — Loopback-only sandboxes silently got full
+        // outbound NAT. Now only Full/Allowlist enable the NAT interface; the
+        // egress firewall (see `egress` below) applies the fine-grained rules.
+        let egress = EgressConfig::from_policy(&descriptor.network_egress);
+        let network = AppleVmNetwork {
+            enabled: egress.enabled,
+            nat: egress.enabled,
         };
 
         AppleVmSpec {
@@ -387,6 +572,7 @@ impl Compiler {
             env: descriptor.env.clone(),
             virtiofs_mounts,
             network,
+            egress,
             entitlements: descriptor.capabilities.clone(),
             attestation: descriptor.attestation.clone(),
             hebb_bridge: descriptor.hebb_bridge.clone(),
@@ -463,6 +649,36 @@ impl Compiler {
                 "env-count: gVisor={} vs AppleVM={}",
                 gvisor.env.len(),
                 apple.env.len()
+            ));
+        }
+
+        // MIK-5226.SEC.3: compare the *granted capability set* on each
+        // substrate. The historical bug was that gVisor dropped capabilities
+        // entirely while Apple VM passed them through as entitlements, so the
+        // same descriptor ran at different privilege per host with no record.
+        // We now emit caps on both sides; this check fails CI if they ever
+        // drift apart again.
+        let gvisor_caps: BTreeSet<String> = gvisor
+            .process
+            .capabilities
+            .as_ref()
+            .map(OciCapabilities::granted)
+            .unwrap_or_default();
+        let apple_caps: BTreeSet<String> = apple.entitlements.iter().cloned().collect();
+        if gvisor_caps != apple_caps {
+            divergences.push(format!(
+                "capabilities: gVisor={gvisor_caps:?} vs AppleVM entitlements={apple_caps:?}"
+            ));
+        }
+
+        // MIK-5226.SEC.3: compare the compiled egress policy on each substrate.
+        // Both are derived from `descriptor.network_egress`; any inequality
+        // means one substrate restricts egress differently from the other
+        // (the original fail-open divergence) and must be recorded.
+        if gvisor.egress != apple.egress {
+            divergences.push(format!(
+                "egress: gVisor={:?} vs AppleVM={:?}",
+                gvisor.egress, apple.egress
             ));
         }
 

--- a/src/runtime/compiler_tests.rs
+++ b/src/runtime/compiler_tests.rs
@@ -101,9 +101,13 @@ fn compile_apple_vm_produces_vm_spec() {
     assert!(spec.virtiofs_mounts[0].read_only);
     assert!(!spec.virtiofs_mounts[1].read_only);
 
-    // Network
-    assert!(spec.network.enabled);
-    assert!(spec.network.nat);
+    // Network: descriptor uses Loopback egress, which must NOT enable the VM
+    // NAT interface (MIK-5226.SEC.2 — Loopback no longer collapses to NAT).
+    assert!(!spec.network.enabled);
+    assert!(!spec.network.nat);
+    // Loopback egress: localhost reachable, external denied.
+    assert!(spec.egress.allows("127.0.0.1"));
+    assert!(!spec.egress.allows("8.8.8.8"));
 
     // Environment
     assert_eq!(spec.env.get("TEST"), Some(&"value".to_string()));
@@ -375,4 +379,180 @@ fn apple_vm_spec_serializes_to_standard_json() {
     // Round-trip
     let restored: AppleVmSpec = serde_json::from_str(&json).unwrap();
     assert_eq!(spec, restored);
+}
+
+// ── MIK-5226.SEC.1: gVisor emits capabilities (no silent drop) ───────────
+
+#[test]
+fn gvisor_emits_requested_capabilities_into_oci_bundle() {
+    let compiler = Compiler::new();
+    let mut descriptor = make_descriptor();
+    descriptor.capabilities = vec!["CAP_NET_BIND_SERVICE".to_string(), "CAP_CHOWN".to_string()];
+
+    let bundle = compiler.compile_gvisor(&descriptor);
+    let caps = bundle
+        .process
+        .capabilities
+        .as_ref()
+        .expect("capabilities must be emitted, never dropped");
+
+    for set in [&caps.bounding, &caps.effective, &caps.permitted] {
+        assert!(set.contains(&"CAP_NET_BIND_SERVICE".to_string()));
+        assert!(set.contains(&"CAP_CHOWN".to_string()));
+    }
+}
+
+#[test]
+fn gvisor_empty_capabilities_emits_empty_sets_not_none_grant() {
+    let compiler = Compiler::new();
+    let mut descriptor = make_descriptor();
+    descriptor.capabilities = vec![];
+    let bundle = compiler.compile_gvisor(&descriptor);
+    let caps = bundle.process.capabilities.as_ref().unwrap();
+    assert!(caps.bounding.is_empty());
+    assert!(caps.effective.is_empty());
+    assert!(caps.permitted.is_empty());
+}
+
+#[test]
+fn gvisor_and_apple_grant_the_same_capability_set() {
+    let compiler = Compiler::new();
+    let mut descriptor = make_descriptor();
+    descriptor.capabilities = vec!["CAP_NET_BIND_SERVICE".to_string()];
+
+    let gvisor = compiler.compile_gvisor(&descriptor);
+    let apple = compiler.compile_apple_vm(&descriptor);
+
+    let gvisor_caps = gvisor.process.capabilities.as_ref().unwrap().granted();
+    let apple_caps: std::collections::BTreeSet<String> =
+        apple.entitlements.iter().cloned().collect();
+    assert_eq!(
+        gvisor_caps, apple_caps,
+        "same descriptor must grant identical capabilities on both substrates"
+    );
+}
+
+// ── MIK-5226.SEC.2: egress is enforceable on both substrates ─────────────
+
+#[test]
+fn egress_none_blocks_everything() {
+    let cfg = EgressConfig::from_policy(&NetworkEgressPolicy::None);
+    assert!(!cfg.allows("127.0.0.1"));
+    assert!(!cfg.allows("10.0.0.1"));
+    assert!(!cfg.allows("8.8.8.8"));
+}
+
+#[test]
+fn egress_loopback_allows_only_localhost() {
+    let cfg = EgressConfig::from_policy(&NetworkEgressPolicy::Loopback);
+    assert!(cfg.allows("127.0.0.1"));
+    assert!(!cfg.allows("8.8.8.8"));
+    assert!(!cfg.allows("10.0.0.1"));
+}
+
+#[test]
+fn egress_full_allows_everything() {
+    let cfg = EgressConfig::from_policy(&NetworkEgressPolicy::Full);
+    assert!(cfg.allows("127.0.0.1"));
+    assert!(cfg.allows("8.8.8.8"));
+    assert!(cfg.allows("10.0.0.1"));
+}
+
+#[test]
+fn egress_allowlist_blocks_destination_outside_cidr() {
+    let cfg = EgressConfig::from_policy(&NetworkEgressPolicy::Allowlist(vec![
+        "10.0.0.0/8".to_string(),
+        "192.168.1.0/24".to_string(),
+    ]));
+    // Inside the allowlist.
+    assert!(cfg.allows("10.255.0.1"));
+    assert!(cfg.allows("192.168.1.42"));
+    // A blocked destination is provably unreachable.
+    assert!(!cfg.allows("8.8.8.8"));
+    assert!(!cfg.allows("192.168.2.1"));
+}
+
+#[test]
+fn egress_fails_closed_on_unparseable_destination() {
+    let cfg = EgressConfig::from_policy(&NetworkEgressPolicy::Full);
+    assert!(!cfg.allows("not-an-ip"));
+    assert!(!cfg.allows(""));
+}
+
+#[test]
+fn both_substrates_emit_identical_egress_for_same_descriptor() {
+    let compiler = Compiler::new();
+    let mut descriptor = make_descriptor();
+    descriptor.network_egress = NetworkEgressPolicy::Allowlist(vec!["10.0.0.0/8".to_string()]);
+
+    let gvisor = compiler.compile_gvisor(&descriptor);
+    let apple = compiler.compile_apple_vm(&descriptor);
+
+    assert_eq!(
+        gvisor.egress, apple.egress,
+        "egress must be identical across substrates (no fail-open divergence)"
+    );
+    // Apple VM NAT interface reflects the restricted-but-enabled policy.
+    assert!(apple.network.enabled);
+    assert!(!gvisor.egress.allows("8.8.8.8"));
+}
+
+// ── MIK-5226.SEC.3: divergence detection compares caps AND egress ────────
+
+#[test]
+fn detect_divergence_flags_capability_mismatch() {
+    let compiler = Compiler::new();
+    let descriptor = make_descriptor();
+    let mut gvisor = compiler.compile_gvisor(&descriptor);
+    let apple = compiler.compile_apple_vm(&descriptor);
+
+    // Force a capability mismatch: gVisor grants a cap the Apple VM does not.
+    gvisor.process.capabilities = Some(OciCapabilities::from_list(&[
+        "CAP_NET_BIND_SERVICE".to_string()
+    ]));
+
+    let divergences = compiler.detect_divergence(&descriptor, &gvisor, &apple);
+    assert!(
+        divergences.iter().any(|d| d.contains("capabilities")),
+        "capability mismatch must be reported as divergence: {divergences:?}"
+    );
+}
+
+#[test]
+fn detect_divergence_flags_egress_mismatch() {
+    let compiler = Compiler::new();
+    let descriptor = make_descriptor();
+    let gvisor = compiler.compile_gvisor(&descriptor);
+    let mut apple = compiler.compile_apple_vm(&descriptor);
+
+    // Force an egress mismatch.
+    apple.egress = EgressConfig::from_policy(&NetworkEgressPolicy::Full);
+
+    let divergences = compiler.detect_divergence(&descriptor, &gvisor, &apple);
+    assert!(
+        divergences.iter().any(|d| d.contains("egress")),
+        "egress mismatch must be reported as divergence: {divergences:?}"
+    );
+}
+
+#[test]
+fn no_capability_or_egress_divergence_for_same_descriptor() {
+    let compiler = Compiler::new();
+    let mut descriptor = make_descriptor();
+    descriptor.capabilities = vec!["CAP_NET_BIND_SERVICE".to_string()];
+    descriptor.network_egress = NetworkEgressPolicy::Allowlist(vec!["10.0.0.0/8".to_string()]);
+
+    let (gvisor, apple, divergences) = compiler.compile_both(&descriptor);
+    let _ = (&gvisor, &apple);
+
+    // The same descriptor must NOT diverge on capabilities or egress — only
+    // the known structural deltas (mount-count for /proc, possibly cpu).
+    assert!(
+        !divergences.iter().any(|d| d.contains("capabilities")),
+        "identical descriptor must not diverge on capabilities: {divergences:?}"
+    );
+    assert!(
+        !divergences.iter().any(|d| d.contains("egress")),
+        "identical descriptor must not diverge on egress: {divergences:?}"
+    );
 }

--- a/src/runtime/provision.rs
+++ b/src/runtime/provision.rs
@@ -162,6 +162,11 @@ pub fn preflight(
     descriptor: &SandboxDescriptor,
     effective: Substrate,
 ) -> Result<Vec<String>, PreflightError> {
+    // `effective` is retained in the signature for call-site stability and
+    // future substrate-specific gating; egress/capability handling is now
+    // substrate-symmetric (MIK-5226.SEC.1/2), so it is not branched on here.
+    let _ = effective;
+
     // 1. Schema validation (closes the "compile never validates" finding).
     descriptor.validate().map_err(PreflightError::Schema)?;
 
@@ -203,33 +208,25 @@ pub fn preflight(
         }
     }
 
-    // 5. Non-fatal warnings: behaviours the compiler silently swallows today.
+    // 5. Non-fatal warnings: behaviours an operator should be aware of.
     let mut warnings = Vec::new();
 
-    // Egress policy is decorative in the current compiler (neither substrate
-    // enforces it). Warn loudly so operators do not assume isolation.
+    // MIK-5226.SEC.2: egress is now compiled into an enforceable `EgressConfig`
+    // emitted to BOTH substrate bundles (no longer decorative). The remaining
+    // caveat is that a launcher must apply the emitted config; surface that as
+    // an informational note rather than a fail-open alarm.
     match &descriptor.network_egress {
         NetworkEgressPolicy::None => warnings.push(
-            "network_egress=None is NOT enforced by the current compiler; the sandbox \
-             will still have a network namespace. Treat as fail-open until a launcher \
-             enforces it."
+            "network_egress=None compiles to a deny-all EgressConfig (no loopback, \
+             no external). The launcher must apply the emitted egress config."
                 .to_string(),
         ),
         NetworkEgressPolicy::Allowlist(cidrs) => warnings.push(format!(
-            "network_egress allowlist ({} entries) is NOT enforced; both substrates \
-             compile it to full NAT egress (fail-open).",
+            "network_egress allowlist ({} entries) compiles to a restricted EgressConfig \
+             on both substrates; the launcher must apply the emitted egress config.",
             cidrs.len()
         )),
         NetworkEgressPolicy::Loopback | NetworkEgressPolicy::Full => {}
-    }
-
-    if effective == Substrate::GVisor && !descriptor.capabilities.is_empty() {
-        warnings.push(format!(
-            "{} capability(ies) requested but the gVisor compiler does not emit them \
-             into the OCI bundle — they are silently dropped (privilege divergence vs \
-             Apple VM, which passes them through as entitlements).",
-            descriptor.capabilities.len()
-        ));
     }
 
     Ok(warnings)

--- a/src/runtime/provision_tests.rs
+++ b/src/runtime/provision_tests.rs
@@ -188,48 +188,87 @@ fn wiring_allows_safe_mount() {
     assert!(compile_descriptor(&d, false).is_ok());
 }
 
-// ── Finding #5/#6: fail-open egress surfaces a warning ───────────────────────
+// ── MIK-5226.SEC.2: egress is compiled into an enforceable config ────────────
 
 #[test]
-fn wiring_warns_on_unenforced_none_egress() {
+fn wiring_emits_none_egress_as_deny_all() {
     let mut d = base();
     d.network_egress = NetworkEgressPolicy::None;
     let report = compile_descriptor(&d, false).expect("None egress still compiles");
+    // Informational note references the policy.
     assert!(
         report
             .warnings
             .iter()
             .any(|w| w.contains("network_egress=None")),
-        "operator must be warned that None egress is not enforced"
+        "operator should be told None compiles to deny-all and needs launcher enforcement"
     );
+    // The emitted bundle proves a blocked destination is unreachable.
+    match &report.bundle {
+        crate::runtime::compiler::CompiledBundle::GVisor(b) => {
+            assert!(!b.egress.allows("8.8.8.8"));
+            assert!(!b.egress.allows("127.0.0.1"));
+        }
+        crate::runtime::compiler::CompiledBundle::AppleVm(s) => {
+            assert!(!s.egress.allows("8.8.8.8"));
+            assert!(!s.egress.allows("127.0.0.1"));
+        }
+    }
 }
 
 #[test]
-fn wiring_warns_on_unenforced_allowlist_egress() {
+fn wiring_emits_allowlist_egress_as_restricted() {
     let mut d = base();
     d.network_egress = NetworkEgressPolicy::Allowlist(vec!["10.0.0.0/8".to_string()]);
     let report = compile_descriptor(&d, false).expect("allowlist still compiles");
     assert!(
         report.warnings.iter().any(|w| w.contains("allowlist")),
-        "operator must be warned the egress allowlist is not enforced (fail-open)"
+        "operator should be told the allowlist compiles to a restricted config"
     );
+    // The emitted bundle proves a destination outside the allowlist is blocked.
+    match &report.bundle {
+        crate::runtime::compiler::CompiledBundle::GVisor(b) => {
+            assert!(b.egress.allows("10.1.2.3"));
+            assert!(!b.egress.allows("8.8.8.8"));
+        }
+        crate::runtime::compiler::CompiledBundle::AppleVm(s) => {
+            assert!(s.egress.allows("10.1.2.3"));
+            assert!(!s.egress.allows("8.8.8.8"));
+        }
+    }
 }
 
-// ── Finding #4: dropped-capability divergence warning on gVisor ──────────────
+// ── MIK-5226.SEC.1: gVisor now EMITS capabilities (no silent drop) ───────────
 
 #[test]
-fn wiring_warns_on_gvisor_dropped_capabilities() {
+fn wiring_gvisor_no_longer_warns_dropped_capabilities() {
     let mut d = base();
     d.substrate_override = Some(Substrate::GVisor);
     d.capabilities = vec!["CAP_NET_BIND_SERVICE".to_string()];
     let report = compile_descriptor(&d, false).expect("benign cap compiles");
     assert!(
-        report
+        !report
             .warnings
             .iter()
             .any(|w| w.contains("silently dropped")),
-        "gVisor compile must warn that capabilities are dropped"
+        "capabilities are now emitted into the OCI bundle — the drop warning must be gone"
     );
+    // And they are actually present in the emitted gVisor bundle.
+    match &report.bundle {
+        crate::runtime::compiler::CompiledBundle::GVisor(b) => {
+            let caps = b
+                .process
+                .capabilities
+                .as_ref()
+                .expect("gVisor bundle must carry capabilities");
+            assert!(caps.bounding.contains(&"CAP_NET_BIND_SERVICE".to_string()));
+            assert!(caps.effective.contains(&"CAP_NET_BIND_SERVICE".to_string()));
+            assert!(caps.permitted.contains(&"CAP_NET_BIND_SERVICE".to_string()));
+        }
+        crate::runtime::compiler::CompiledBundle::AppleVm(_) => {
+            panic!("substrate_override=GVisor must yield a gVisor bundle")
+        }
+    }
 }
 
 // ── File path entry point ─────────────────────────────────────────────────────

--- a/tests/mik_5226_acs.rs
+++ b/tests/mik_5226_acs.rs
@@ -178,7 +178,10 @@ fn ac_2_mik_new_runtime_d_2_compiler_descriptor_gviso() {
     assert_eq!(apple_spec.virtiofs_mounts.len(), 1);
     assert!(apple_spec.virtiofs_mounts[0].read_only);
     assert_eq!(apple_spec.virtiofs_mounts[0].source, "/host/data");
-    assert!(apple_spec.network.enabled);
+    // MIK-6164: Loopback egress no longer collapses to NAT — Apple VM
+    // networking stays disabled unless the policy actually permits egress
+    // (matches the Loopback assertion in src/runtime/compiler_tests.rs).
+    assert!(!apple_spec.network.enabled);
 
     // 3. Auto-detection: effective_substrate() uses current platform
     let substrate = descriptor.effective_substrate();


### PR DESCRIPTION
## Summary

Closes two security gaps in the dual-substrate OCI runtime merged off-by-default in #260 (behind the `runtime-substrate` feature). Found by the #260 adversarial review.

**The `runtime-substrate` feature stays OFF by default — operator's call. Do not merge without operator review.**

### MIK-5226.SEC.1 — privilege divergence (capabilities)
`compile_gvisor` silently **dropped** `descriptor.capabilities` (never emitted to the OCI bundle) while `compile_apple_vm` passed them through as entitlements — the same descriptor ran at a *different privilege level* depending on the host.
- gVisor compiler now emits capabilities into `OciProcess.capabilities` (`bounding`/`effective`/`permitted` sets). Empty list ⇒ empty sets, never a dropped grant.
- The dangerous-capability allowlist gate in `provision::preflight` is unchanged (still hard-fails `CAP_SYS_ADMIN` et al.).

### MIK-5226.SEC.2 — egress fail-open
`network_egress` was decorative: never emitted to the gVisor bundle, and on Apple VM `Loopback`/`Full`/`Allowlist` all collapsed to NAT-enabled.
- New `EgressConfig`, compiled from `NetworkEgressPolicy` and emitted to **both** the `OciBundle` and `AppleVmSpec`.
- `EgressConfig::allows(dest)` is the single **fail-closed** decision procedure (IPv4 CIDR match; unparseable dest/CIDR ⇒ denied): `None`=deny-all, `Loopback`=localhost-only, `Allowlist`=restricted to CIDRs, `Full`=open.
- Apple VM NAT toggle now derives faithfully from the policy (Loopback no longer silently gets outbound NAT).

### MIK-5226.SEC.3 — divergence detection
`detect_divergence` now compares the **granted capability set** AND the **compiled egress config** across substrates, in addition to the existing mount-count/CPU/env checks. Drift is recorded to the `DivergenceRegistry` so CI fails on undocumented divergence.

## Tests (TDD — failing first, then green)
New, in `compiler_tests.rs` / `provision_tests.rs`:
- `gvisor_emits_requested_capabilities_into_oci_bundle`, `gvisor_empty_capabilities_emits_empty_sets_not_none_grant`, `gvisor_and_apple_grant_the_same_capability_set`
- `egress_none_blocks_everything`, `egress_loopback_allows_only_localhost`, `egress_full_allows_everything`, `egress_allowlist_blocks_destination_outside_cidr`, `egress_fails_closed_on_unparseable_destination`, `both_substrates_emit_identical_egress_for_same_descriptor`
- `detect_divergence_flags_capability_mismatch`, `detect_divergence_flags_egress_mismatch`, `no_capability_or_egress_divergence_for_same_descriptor`
- provision wiring: `wiring_gvisor_no_longer_warns_dropped_capabilities`, `wiring_emits_none_egress_as_deny_all`, `wiring_emits_allowlist_egress_as_restricted`

Existing tests that encoded the old vulnerable behavior were updated (Apple VM Loopback NAT assertion; preflight warning copy no longer claims "fail-open" / dropped caps).

## Verification
- `cargo test --lib --features runtime-substrate runtime::` → **84 passed, 0 failed**
- `cargo clippy --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

## Enforced vs follow-up
- **Enforced now (in the emitted config):** caps present on both substrates; egress policy compiled to a fail-closed `EgressConfig` on both substrates; divergence detection covers caps + egress.
- **Follow-up (out of scope here):** an actual launcher that *applies* the emitted `EgressConfig` at the gVisor netstack / Apple VM packet-filter layer, and IPv6 CIDR matching (`allows` is IPv4-only today, fail-closed on non-IPv4). Preflight surfaces an informational note that the launcher must apply the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
