### PR TITLE
feat(attestation): wire per-action attestation in Observe mode (MIK-6163)

### DIFF
--- a/src/attestation/mod.rs
+++ b/src/attestation/mod.rs
@@ -34,6 +34,7 @@ pub mod launcher;
 pub mod signer;
 pub mod token;
 pub mod validator;
+pub mod wiring;
 
 pub use launcher::{
     ATTESTATION_FLAG_ENV, AttestationEnforcement, AttestedSandboxLauncher, BootDenial,
@@ -44,4 +45,8 @@ pub use token::{AttestationToken, BNAUT_ISSUER, SIGNING_ALGORITHM, TokenClaims};
 pub use validator::{
     AttestationAuditRecord, AttestationMode, AttestationRejection, AttestationValidator,
     AuditRingBuffer, RetiringToken, RotationCheckpoint,
+};
+pub use wiring::{
+    ATTESTATION_KEY_ID_ENV, ATTESTATION_MODE_ENV, ATTESTATION_SIGNING_KEY_ENV,
+    attestation_wiring_from_env, resolve_attestation_wiring,
 };

--- a/src/attestation/wiring.rs
+++ b/src/attestation/wiring.rs
@@ -1,0 +1,165 @@
+//! Env-driven wiring of the gateway attestation validator (MIK-6163 rollout).
+//!
+//! The validator and the [`MetaMcp::with_attestation`] builder already exist
+//! (MIK-5223 / #259, #261); this module is the missing seam that decides — from
+//! operator config — *whether* to attach a validator on a live gateway and in
+//! which [`AttestationMode`].
+//!
+//! Rollout posture (operator directive 2026-06-19):
+//! - Default is **observe**: the validator audits every presented token but
+//!   never blocks a call, so enabling it on live traffic cannot break
+//!   unattested or mis-attested calls.
+//! - `off` attaches no validator at all — a pure no-op, byte-identical to the
+//!   pre-wiring gateway.
+//! - `enforce` is *intentionally not yet a recognised value*. Flipping to
+//!   fail-closed is a future one-liner here (add the `Some("enforce")` arm),
+//!   which is why an unrecognised mode falls back to observe rather than
+//!   silently enforcing.
+//!
+//! [`MetaMcp::with_attestation`]: crate::gateway::meta_mcp::MetaMcp::with_attestation
+//! [`AttestationMode`]: super::validator::AttestationMode
+
+use std::sync::Arc;
+
+use super::signer::BnautAttestationSigner;
+use super::validator::{AttestationMode, AttestationValidator};
+
+/// Env var selecting the wired attestation mode at the `gateway_invoke`
+/// boundary: `observe` (default) or `off`.
+///
+/// `enforce` is deliberately NOT recognised yet — see the module docs.
+pub const ATTESTATION_MODE_ENV: &str = "GATEWAY_ATTESTATION_MODE";
+
+/// Env var carrying the HMAC-SHA256 signing key shared with bnaut-attestation.
+///
+/// When unset/empty the validator still initialises; in observe mode every
+/// presented token simply fails signature verification and is audit-logged
+/// (the call is never blocked).
+pub const ATTESTATION_SIGNING_KEY_ENV: &str = "GATEWAY_ATTESTATION_SIGNING_KEY";
+
+/// Env var for the signing key id (namespaced under `bnaut/` by the signer).
+/// Defaults to [`DEFAULT_KEY_ID`].
+pub const ATTESTATION_KEY_ID_ENV: &str = "GATEWAY_ATTESTATION_KEY_ID";
+
+/// Default signing key id when [`ATTESTATION_KEY_ID_ENV`] is unset.
+pub const DEFAULT_KEY_ID: &str = "gateway";
+
+/// Resolve the attestation wiring from explicit settings — the unit-testable
+/// core that performs no process-environment reads.
+///
+/// Returns `None` when the mode is `off` (attach no validator — a pure no-op).
+/// Returns `Some((validator, mode))` otherwise. The mode is matched
+/// case-insensitively after trimming; unset/empty resolves to
+/// [`AttestationMode::Observe`] (the default rollout posture), and any
+/// unrecognised value — including `enforce`, which is not yet wired — also
+/// falls back to observe with a warning.
+#[must_use]
+pub fn resolve_attestation_wiring(
+    mode: Option<&str>,
+    signing_key: Option<&[u8]>,
+    key_id: Option<&str>,
+) -> Option<(Arc<AttestationValidator>, AttestationMode)> {
+    let normalized = mode.map(|m| m.trim().to_ascii_lowercase());
+    let mode = match normalized.as_deref() {
+        Some("off") => return None,
+        None | Some("" | "observe") => AttestationMode::Observe,
+        Some(other) => {
+            tracing::warn!(
+                requested = other,
+                "GATEWAY_ATTESTATION_MODE unrecognised (enforce is not yet wired); \
+                 defaulting to observe"
+            );
+            AttestationMode::Observe
+        }
+    };
+
+    let key = signing_key.unwrap_or_default().to_vec();
+    if key.is_empty() {
+        tracing::warn!(
+            env = ATTESTATION_SIGNING_KEY_ENV,
+            "attestation observe mode enabled without a signing key; presented tokens \
+             will fail verification and be audit-logged only (never blocked)"
+        );
+    }
+    let key_id = key_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_KEY_ID);
+
+    let signer = BnautAttestationSigner::new(key, key_id);
+    let validator = Arc::new(AttestationValidator::new(signer));
+    Some((validator, mode))
+}
+
+/// Read the attestation wiring from the process environment.
+///
+/// Thin wrapper over [`resolve_attestation_wiring`] reading
+/// [`ATTESTATION_MODE_ENV`], [`ATTESTATION_SIGNING_KEY_ENV`], and
+/// [`ATTESTATION_KEY_ID_ENV`]. With no env set the default is observe.
+#[must_use]
+pub fn attestation_wiring_from_env() -> Option<(Arc<AttestationValidator>, AttestationMode)> {
+    let mode = std::env::var(ATTESTATION_MODE_ENV).ok();
+    let key = std::env::var(ATTESTATION_SIGNING_KEY_ENV).ok();
+    let key_id = std::env::var(ATTESTATION_KEY_ID_ENV).ok();
+    resolve_attestation_wiring(
+        mode.as_deref(),
+        key.as_deref().map(str::as_bytes),
+        key_id.as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_unset_is_observe_with_validator() {
+        // Unset mode → default rollout posture: validator attached, observe.
+        let (_, mode) = resolve_attestation_wiring(None, Some(b"k"), None)
+            .expect("default must attach a validator");
+        assert_eq!(mode, AttestationMode::Observe);
+    }
+
+    #[test]
+    fn explicit_observe_attaches_validator() {
+        let (_, mode) = resolve_attestation_wiring(Some("observe"), Some(b"k"), Some("kid"))
+            .expect("observe must attach a validator");
+        assert_eq!(mode, AttestationMode::Observe);
+    }
+
+    #[test]
+    fn mode_parsing_is_case_and_whitespace_insensitive() {
+        let (_, mode) = resolve_attestation_wiring(Some("  ObSeRvE  "), Some(b"k"), None)
+            .expect("trimmed/cased observe must attach a validator");
+        assert_eq!(mode, AttestationMode::Observe);
+    }
+
+    #[test]
+    fn off_is_a_pure_no_op_returning_none() {
+        // off → no validator attached at all (byte-identical to pre-wiring).
+        assert!(resolve_attestation_wiring(Some("off"), Some(b"k"), None).is_none());
+        assert!(resolve_attestation_wiring(Some("  OFF "), None, None).is_none());
+    }
+
+    #[test]
+    fn unrecognised_mode_falls_back_to_observe_not_enforce() {
+        // enforce (and any unknown value) must NOT silently enable fail-closed;
+        // it falls back to the safe observe posture.
+        for raw in ["enforce", "block", "true", "1"] {
+            let (_, mode) = resolve_attestation_wiring(Some(raw), Some(b"k"), None)
+                .unwrap_or_else(|| panic!("{raw} should still attach an observe validator"));
+            assert_eq!(mode, AttestationMode::Observe, "mode={raw}");
+        }
+    }
+
+    #[test]
+    fn missing_signing_key_still_initialises_validator() {
+        // No key configured → validator still inits (observe will audit-only).
+        let wiring = resolve_attestation_wiring(Some("observe"), None, None);
+        assert!(wiring.is_some(), "validator must init even without a key");
+        let (validator, _) = wiring.unwrap();
+        // A token cannot verify against the empty key, so observe would audit it;
+        // assert the validator is live and starts with an empty audit buffer.
+        assert!(validator.audit().is_empty());
+    }
+}

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -1434,4 +1434,41 @@ mod attestation_wiring {
         assert_eq!(v.validations_total(), 1);
         assert!(v.audit().is_empty());
     }
+
+    #[test]
+    fn resolved_observe_wiring_admits_under_capability_token_and_audits() {
+        // End-to-end of the wiring decision: the env-driven resolver builds an
+        // observe-mode validator, which is then attached via with_attestation.
+        // An under-capability / invalid token must be ADMITTED (never blocked)
+        // while the mismatch is recorded in the audit ring buffer.
+        let (validator, mode) =
+            crate::attestation::resolve_attestation_wiring(Some("observe"), Some(KEY), None)
+                .expect("observe must attach a validator");
+        assert_eq!(mode, AttestationMode::Observe);
+        let mm = make_meta_mcp().with_attestation(Arc::clone(&validator), mode);
+
+        // A forged/garbage token (under-capability is also covered by the CAPS
+        // tests above) — observe admits it but audits the rejection.
+        let res = mm.check_attestation(
+            &json!({"server": "s", "tool": "write", "attestation": "forged.token"}),
+            Some("agent-9"),
+        );
+        assert!(res.is_ok(), "observe must never block the call");
+        assert_eq!(validator.rejections_total(), 1);
+        assert_eq!(validator.audit().snapshot().len(), 1);
+    }
+
+    #[test]
+    fn resolved_off_wiring_is_a_pure_no_op() {
+        // off → resolver attaches no validator; the gateway behaves exactly as
+        // an un-wired one (the gate is a zero-cost no-op even without a token).
+        assert!(
+            crate::attestation::resolve_attestation_wiring(Some("off"), Some(KEY), None).is_none()
+        );
+        let mm = make_meta_mcp(); // no attestation attached, as off would leave it
+        assert!(
+            mm.check_attestation(&json!({"server": "s", "tool": "t"}), None)
+                .is_ok()
+        );
+    }
 }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -230,6 +230,19 @@ impl Gateway {
             meta_mcp_builder = meta_mcp_builder.with_cost_governance(enforcer, registry);
         }
 
+        // ── Per-action attestation (MIK-5223 / MIK-6163, B1-IDENT) ────────────
+        // Wire the attestation validator from operator config (env-driven).
+        // Default posture is OBSERVE: audit every presented token at the
+        // `gateway_invoke` boundary but never block a call. `off` attaches no
+        // validator (pure no-op). Enforce is intentionally not yet a wired mode.
+        if let Some((validator, mode)) = crate::attestation::attestation_wiring_from_env() {
+            info!(
+                ?mode,
+                "Per-action attestation wired at gateway_invoke boundary"
+            );
+            meta_mcp_builder = meta_mcp_builder.with_attestation(validator, mode);
+        }
+
         let mut meta_mcp = Arc::new(meta_mcp_builder);
         meta_mcp.set_transition_tracker(Arc::clone(&transition_tracker));
 


### PR DESCRIPTION
## What

Wires the dormant per-action attestation validator into the live gateway in **Observe mode** (audits capability/identity mismatches at the `gateway_invoke` boundary, never blocks). Enforce is **not** enabled.

Background: #259 added the validator + `MetaMcp::with_attestation(validator, AttestationMode)` builder (opt-in; unset = no-op). #261 (MIK-6163) added fail-closed capability enforcement inside `validate_boundary_call`. Nothing called `with_attestation`, so attestation was dormant. This PR adds the construction seam that turns it on in Observe.

## Changes

- **New `src/attestation/wiring.rs`** — env-driven resolver:
  - `resolve_attestation_wiring(mode, signing_key, key_id)` — unit-testable core (no process-env reads). `off` → `None` (no validator, pure no-op); unset/empty/`observe` → `Some((validator, Observe))`; any unrecognised value (including `enforce`) → falls back to Observe with a warning. Enforce is intentionally **not** a wired mode — flipping to fail-closed is a future one-liner here.
  - `attestation_wiring_from_env()` — thin wrapper reading the env vars below.
  - If no signing key is configured the validator still initialises; in Observe every presented token simply fails signature verification and is audit-logged (never blocks).
- **`src/gateway/server/mod.rs`** — in the live `MetaMcp` builder chain, call `attestation_wiring_from_env()` and `.with_attestation(validator, mode)` when not `off`. Logs the wired mode.
- **`src/attestation/mod.rs`** — register + re-export the wiring module.

## Config / toggle

| Env var | Values | Default |
|---|---|---|
| `GATEWAY_ATTESTATION_MODE` | `observe` \| `off` | `observe` |
| `GATEWAY_ATTESTATION_SIGNING_KEY` | HMAC-SHA256 key (shared with bnaut-attestation) | unset → audit-only |
| `GATEWAY_ATTESTATION_KEY_ID` | signing key id (namespaced `bnaut/`) | `gateway` |

Disable without redeploy: set `GATEWAY_ATTESTATION_MODE=off`. Future Enforce: add the `Some("enforce")` arm in `resolve_attestation_wiring`.

## Observe never blocks (by construction)

A missing/invalid/under-capability token in Observe → audit ring buffer + `attestation_observe_reject` warn log, request proceeds. Verified by tests.

## Tests (same-package, lib)

- `attestation::wiring::tests`:
  - `default_unset_is_observe_with_validator`
  - `explicit_observe_attaches_validator`
  - `mode_parsing_is_case_and_whitespace_insensitive`
  - `off_is_a_pure_no_op_returning_none`
  - `unrecognised_mode_falls_back_to_observe_not_enforce`
  - `missing_signing_key_still_initialises_validator`
- `gateway::meta_mcp::tests::attestation_wiring`:
  - `resolved_observe_wiring_admits_under_capability_token_and_audits` — Observe admits an invalid/under-cap token while emitting the audit
  - `resolved_off_wiring_is_a_pure_no_op`

`cargo test --lib attestation` → 41 passed / 0 failed. `cargo test --lib attestation_wiring` → 10 passed / 0 failed. `cargo clippy --lib --all-features` + `cargo fmt --all` clean.

## Safety

Observe is non-blocking by construction — enabling the validator on live traffic cannot break unattested or mis-attested calls. **Enforce was NOT enabled.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
