### PR TITLE
feat(meta_mcp): surface capability tools directly (one-hop) for chat clients

### DIFF
--- a/.symphony/worker-cargo-shims/dispatch-ecae1ade-0383-4af4-88bb-98e96e938f4f/cargo
+++ b/.symphony/worker-cargo-shims/dispatch-ecae1ade-0383-4af4-88bb-98e96e938f4f/cargo
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "/home/mikko/github/symphony-plus-converge/target/release/symphony-plus" worker-cargo-governor --real-cargo "/home/mikko/.cargo/bin/cargo" -- "$@"

--- a/src/gateway/meta_mcp/surfaced.rs
+++ b/src/gateway/meta_mcp/surfaced.rs
@@ -113,16 +113,40 @@ impl MetaMcp {
             return None;
         }
 
-        let backend = self.backends.get(&surfaced.server)?;
-        let tool = backend.get_cached_tool(&surfaced.tool);
-        if tool.is_none() {
+        // MCP backend path: resolve from the backend's tool cache.
+        if let Some(backend) = self.backends.get(&surfaced.server) {
+            let tool = backend.get_cached_tool(&surfaced.tool);
+            if tool.is_none() {
+                debug!(
+                    server = %surfaced.server,
+                    tool = %surfaced.tool,
+                    "Surfaced tool not in backend cache — omitting from tools/list"
+                );
+            }
+            return tool;
+        }
+
+        // Capability backend path: capability tools (e.g. the `fulcrum`
+        // capability provider) live in a separate subsystem from MCP backends,
+        // so surface them by name from the capability tool set. This gives
+        // chat clients direct one-hop access to high-value capabilities
+        // (search, weather, travel, ...) instead of the gateway_search +
+        // gateway_invoke two-hop, which chat models handle poorly.
+        if let Some(cap) = self.get_capabilities() {
+            if let Some(tool) = cap
+                .get_tools()
+                .into_iter()
+                .find(|tl| tl.name == surfaced.tool)
+            {
+                return Some(tool);
+            }
             debug!(
                 server = %surfaced.server,
                 tool = %surfaced.tool,
-                "Surfaced tool not in backend cache — omitting from tools/list"
+                "Surfaced capability tool not found — omitting from tools/list"
             );
         }
-        tool
+        None
     }
 }
 


### PR DESCRIPTION
Lets surfaced_tools pin capability-backend tools (fulcrum: brave/trvl/weather/+320), not just MCP backends. resolve_surfaced_tool falls through to get_capabilities().get_tools(). Routing-profile + meta-name checks still apply. Unblocks one-hop tool use for chat clients (Open WebUI) that handle the gateway_search+invoke two-hop poorly. Verified: 20 curated tools surface + a chat model calls them directly. clippy+fmt clean.