### PR TITLE
docs: cross-link related agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,14 @@ mcp-gateway is part of a suite of MCP tools:
 | [nab](https://github.com/MikkoParkkola/nab) | Web content extraction — fetch any URL with cookies + anti-bot bypass |
 | [axterminator](https://github.com/MikkoParkkola/axterminator) | macOS GUI automation — 34 MCP tools via Accessibility API |
 
+## Related projects
+
+Independent, no-API-key tools for AI agents — each useful alone:
+
+- [trvl](https://github.com/MikkoParkkola/trvl) — travel MCP server + CLI (flights, hotels, trains, cars, ferries)
+- [nab](https://github.com/MikkoParkkola/nab) — token-lean web fetch (any URL → clean markdown) for agents
+- [axterminator](https://github.com/MikkoParkkola/axterminator) — macOS desktop automation over the Accessibility API
+
 ## License
 
 mcp-gateway is **dual-licensed** as of v2.11.0:


### PR DESCRIPTION
Adds a "Related projects" section to the README cross-linking the sibling agent-infra tools (trvl, nab, axterminator), so visitors can discover the others. Neutral, factual descriptions; no other changes.