### PR TITLE
docs: add brew trust step for Homebrew 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Your agent will install the binary, run the setup wizard, import your existing M
 **Or four commands:**
 
 ```bash
+brew trust --tap MikkoParkkola/tap   # Homebrew 6.0+
 brew install MikkoParkkola/tap/mcp-gateway   # 1. install
 mcp-gateway setup wizard --configure-client  # 2. import existing servers + wire up clients
 mcp-gateway serve                            # 3. run


### PR DESCRIPTION
Adds the `brew trust --tap MikkoParkkola/tap` step (Homebrew 6.0 tap-trust). Required when HOMEBREW_REQUIRE_TAP_TRUST is set, harmless otherwise. Matches the canonical homebrew-tap README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)