### PR TITLE
fix(protocol-imports): GraphQL depth and complexity gate, YAML-bomb guard, slug-collision (MIK-6677)

### DIFF
--- a/src/commands/protocol_import.rs
+++ b/src/commands/protocol_import.rs
@@ -165,6 +165,7 @@ async fn apply_plan_to_directory(
     let manifest_path = output.join(manifest_file_name(plan));
     let mut writable = Vec::new();
     let mut skipped = Vec::new();
+    let mut claimed_paths = std::collections::HashSet::new();
 
     for draft in &plan.drafts {
         let Some(generated_yaml) = draft.generated_yaml.as_deref() else {
@@ -180,6 +181,21 @@ async fn apply_plan_to_directory(
         };
 
         let path = output.join(format!("{}.yaml", draft.name));
+        // In-batch collision: two source operations whose names slugify to the
+        // same file (e.g. "Delete User" in two Postman folders) would otherwise
+        // silently overwrite each other. Skip the later one with an explicit
+        // reason instead of clobbering the earlier write.
+        if !claimed_paths.insert(path.clone()) {
+            skipped.push(SkippedDraft {
+                draft_id: draft.id.clone(),
+                name: draft.name.clone(),
+                reason: format!(
+                    "output path {} already claimed by an earlier draft in this import (slug collision); rename the source operation to disambiguate",
+                    path.display()
+                ),
+            });
+            continue;
+        }
         writable.push((draft, generated_yaml, path));
     }
 
@@ -356,6 +372,8 @@ fn parse_document<T: DeserializeOwned>(
     content: &str,
 ) -> Result<T, String> {
     serde_json::from_str(content).or_else(|json_err| {
+        guard_untrusted_yaml(content)
+            .map_err(|guard_err| format!("rejected {label} {}: {guard_err}", file.display()))?;
         serde_yaml::from_str(content).map_err(|yaml_err| {
             format!(
                 "failed to parse {label} {} as JSON or YAML: {json_err}; {yaml_err}",
@@ -363,6 +381,60 @@ fn parse_document<T: DeserializeOwned>(
             )
         })
     })
+}
+
+/// Maximum byte size of an untrusted spec document.
+const MAX_SPEC_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum number of YAML alias references tolerated. Legitimate API specs use
+/// `$ref` (a spec-level mechanism), not YAML aliases, so this is ~0 in practice;
+/// a low cap kills the exponential "billion laughs" alias-amplification bomb.
+const MAX_YAML_ALIASES: usize = 64;
+
+/// Reject hostile untrusted YAML before it reaches `serde_yaml`, which expands
+/// anchor/alias references during deserialization (a "billion laughs" memory /
+/// stack `DoS`). JSON parsing is already bounded by `serde_json`'s recursion limit,
+/// so this guard only runs on the YAML fallback path.
+fn guard_untrusted_yaml(content: &str) -> Result<(), String> {
+    if content.len() > MAX_SPEC_BYTES {
+        return Err(format!(
+            "document is {} bytes, exceeds the {MAX_SPEC_BYTES}-byte spec limit",
+            content.len()
+        ));
+    }
+    let alias_count = count_yaml_aliases(content);
+    if alias_count > MAX_YAML_ALIASES {
+        return Err(format!(
+            "document uses {alias_count} YAML aliases (limit {MAX_YAML_ALIASES}); \
+             alias amplification is rejected — use $ref for spec-level reuse"
+        ));
+    }
+    Ok(())
+}
+
+/// Count YAML alias references (`*name` in node position) in raw text. A node
+/// alias appears at the start of a value, i.e. after a structural character
+/// (`:`, `-`, `[`, `{`, `,`) or at line start, followed by an anchor-name char.
+/// This deliberately over-counts conservatively rather than parse YAML.
+fn count_yaml_aliases(content: &str) -> usize {
+    let bytes = content.as_bytes();
+    let mut count = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'*' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            let prev = bytes[..i]
+                .iter()
+                .rev()
+                .find(|b| !b.is_ascii_whitespace())
+                .copied();
+            let at_node_position = matches!(prev, None | Some(b':' | b'-' | b'[' | b'{' | b','));
+            if at_node_position && (next.is_ascii_alphanumeric() || next == b'_') {
+                count += 1;
+            }
+        }
+        i += 1;
+    }
+    count
 }
 
 fn default_source_name(file: &Path) -> String {
@@ -528,6 +600,43 @@ mod tests {
     use mcp_gateway::protocol_imports::{ImportRiskKind, ImportSourceKind};
 
     use super::*;
+
+    #[test]
+    fn guard_rejects_yaml_alias_bomb() {
+        // A billion-laughs-style alias amplification must be rejected before
+        // serde_yaml expands it.
+        use std::fmt::Write as _;
+        let mut bomb = String::from("a: &a [x, x, x, x, x, x, x, x, x]\n");
+        for (i, prev) in ('b'..='z').zip('a'..='y') {
+            let _ = writeln!(
+                bomb,
+                "{i}: &{i} [*{prev}, *{prev}, *{prev}, *{prev}, *{prev}, *{prev}, *{prev}, *{prev}, *{prev}]"
+            );
+        }
+        let err = guard_untrusted_yaml(&bomb).expect_err("alias bomb must be rejected");
+        assert!(err.contains("alias"), "got: {err}");
+    }
+
+    #[test]
+    fn guard_allows_normal_yaml_without_aliases() {
+        let ok = "openapi: 3.0.0\ninfo:\n  title: x\npaths: {}\n";
+        assert!(guard_untrusted_yaml(ok).is_ok());
+    }
+
+    #[test]
+    fn guard_rejects_oversized_document() {
+        let big = "x".repeat(MAX_SPEC_BYTES + 1);
+        let err = guard_untrusted_yaml(&big).expect_err("oversized doc must be rejected");
+        assert!(err.contains("exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn count_yaml_aliases_ignores_scalar_stars() {
+        // `*` inside scalar text (not in node position) must not be counted.
+        assert_eq!(count_yaml_aliases("note: see 2 * 3 for math\n"), 0);
+        assert_eq!(count_yaml_aliases("ref: *anchor\n"), 1);
+        assert_eq!(count_yaml_aliases("list:\n  - *a\n  - *b\n"), 2);
+    }
 
     const OPENAPI_SPEC: &str = r#"
 openapi: 3.0.0

--- a/src/protocol_imports/helpers.rs
+++ b/src/protocol_imports/helpers.rs
@@ -205,6 +205,71 @@ pub(super) fn lacks_graphql_bounds(query: &str, variables_schema: &Value) -> boo
     !has_query_bounds && !has_variable_bounds
 }
 
+/// Maximum GraphQL selection-set nesting depth allowed before review is forced.
+pub(super) const MAX_GRAPHQL_DEPTH: usize = 12;
+/// Maximum GraphQL field-selection count (complexity proxy) before review.
+pub(super) const MAX_GRAPHQL_FIELDS: usize = 200;
+
+/// Compute `(max_depth, field_count)` for a GraphQL query by scanning braces
+/// outside string literals and comments.
+///
+/// `max_depth` is the deepest selection-set nesting (`{ ... }`); `field_count`
+/// is the number of selection sets opened (a cheap complexity proxy). The
+/// scanner skips `"..."` strings, `"""..."""` block strings, and `# ...`
+/// comments so braces inside them never inflate the metrics.
+pub(super) fn graphql_query_metrics(query: &str) -> (usize, usize) {
+    let bytes = query.as_bytes();
+    let mut i = 0;
+    let (mut depth, mut max_depth, mut field_count) = (0usize, 0usize, 0usize);
+    while i < bytes.len() {
+        match bytes[i] {
+            b'#' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'"' => {
+                if bytes[i..].starts_with(b"\"\"\"") {
+                    i += 3;
+                    while i + 2 < bytes.len() && !bytes[i..].starts_with(b"\"\"\"") {
+                        i += 1;
+                    }
+                    i += 3;
+                } else {
+                    i += 1;
+                    while i < bytes.len() && bytes[i] != b'"' {
+                        i += if bytes[i] == b'\\' { 2 } else { 1 };
+                    }
+                    i += 1;
+                }
+            }
+            b'{' => {
+                depth += 1;
+                field_count += 1;
+                max_depth = max_depth.max(depth);
+                i += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    (max_depth, field_count)
+}
+
+/// Whether a GraphQL query exceeds the depth or complexity limits and must be
+/// review-gated regardless of pagination bounds.
+pub(super) fn graphql_exceeds_limits(query: &str) -> Option<(usize, usize)> {
+    let (depth, fields) = graphql_query_metrics(query);
+    if depth > MAX_GRAPHQL_DEPTH || fields > MAX_GRAPHQL_FIELDS {
+        Some((depth, fields))
+    } else {
+        None
+    }
+}
+
 pub(super) fn gates_for_risks(risks: &[ImportRisk]) -> Vec<ImportReviewGate> {
     let mut gates = Vec::new();
     for risk in risks {
@@ -443,5 +508,44 @@ pub(super) fn human_title(value: &str) -> String {
         "Imported Tool".to_string()
     } else {
         words.join(" ")
+    }
+}
+
+#[cfg(test)]
+mod graphql_metrics_tests {
+    use super::{MAX_GRAPHQL_DEPTH, graphql_exceeds_limits, graphql_query_metrics};
+
+    #[test]
+    fn shallow_query_within_limits() {
+        let q = "query { user(id: 1) { name email } }";
+        let (depth, fields) = graphql_query_metrics(q);
+        assert_eq!(depth, 2, "user{{}} + outer {{}}");
+        assert_eq!(fields, 2);
+        assert!(graphql_exceeds_limits(q).is_none());
+    }
+
+    #[test]
+    fn deeply_nested_query_exceeds_depth() {
+        // Build a query nested past MAX_GRAPHQL_DEPTH.
+        let mut q = String::from("query ");
+        let levels = MAX_GRAPHQL_DEPTH + 3;
+        for _ in 0..levels {
+            q.push_str("{ a ");
+        }
+        for _ in 0..levels {
+            q.push('}');
+        }
+        let (depth, _) = graphql_query_metrics(&q);
+        assert!(depth > MAX_GRAPHQL_DEPTH, "depth was {depth}");
+        assert!(graphql_exceeds_limits(&q).is_some());
+    }
+
+    #[test]
+    fn braces_in_strings_and_comments_do_not_count() {
+        // Braces inside a string literal, block string, and comment must be ignored.
+        let q = "query { f(arg: \"{ { {\") } # trailing { { {\nquery2 { \"\"\" { { { \"\"\" g }";
+        let (depth, _fields) = graphql_query_metrics(q);
+        // Only the two real top-level selection sets contribute depth 1 each.
+        assert_eq!(depth, 1, "string/comment braces leaked into depth: {depth}");
     }
 }

--- a/src/protocol_imports/planner.rs
+++ b/src/protocol_imports/planner.rs
@@ -9,9 +9,9 @@ use super::{
     TrustCardDraft, TrustCardRiskVerdict, TrustEvidenceLevel,
     helpers::{
         PostmanRequest, aggregate_gates, classify_route_risks, classify_schema_risks,
-        collect_postman_requests, digest_for, empty_object_schema, gates_for_risks, human_title,
-        is_safe_method, lacks_graphql_bounds, plan_digest, policy_for_gates, postman_input_schema,
-        slugify, source_kind_slug,
+        collect_postman_requests, digest_for, empty_object_schema, gates_for_risks,
+        graphql_exceeds_limits, human_title, is_safe_method, lacks_graphql_bounds, plan_digest,
+        policy_for_gates, postman_input_schema, slugify, source_kind_slug,
     },
 };
 
@@ -294,6 +294,16 @@ impl ProtocolImportPlanner {
                 kind: ImportRiskKind::UnboundedQuery,
                 level: ImportRiskLevel::Medium,
                 reason: "GraphQL query lacks obvious pagination or complexity bounds".to_string(),
+                field: Some(operation.name.clone()),
+            });
+        }
+        if let Some((depth, fields)) = graphql_exceeds_limits(&operation.query) {
+            risks.push(ImportRisk {
+                kind: ImportRiskKind::UnboundedQuery,
+                level: ImportRiskLevel::High,
+                reason: format!(
+                    "GraphQL query exceeds depth/complexity limits (depth {depth}, {fields} selection sets); must be reviewed before activation"
+                ),
                 field: Some(operation.name.clone()),
             });
         }


### PR DESCRIPTION
Three findings from the PR #278 protocol-import security review. All degraded safe (generated drafts ship disabled and review-gated), so none blocked the merge, but the AC gap and the DoS hole are real.

## Fixes
- **H.1 GraphQL depth and complexity gate** (closes overstated AC MIK-6561.IMPORT.3). The previous bounds check was a substring `first:` heuristic; depth and complexity were never computed, so a deeply-nested query containing `first:` anywhere passed. Added `graphql_query_metrics` (brace scan that skips strings, block strings, and comments) and `graphql_exceeds_limits` (depth over 12 or over 200 selection sets), raising a High `UnboundedQuery` risk that forces review.
- **H.3 YAML billion-laughs DoS.** Untrusted spec YAML went straight to `serde_yaml`, which expands anchor and alias references during deserialization. Added `guard_untrusted_yaml` (16 MiB size cap plus reject more than 64 YAML aliases) before the YAML fallback. JSON parsing is already bounded by serde_json recursion limit. Legit specs use spec-level ref, not YAML aliases, so the cap is near zero in practice.
- **H.2 slug-collision silent overwrite.** Two operations whose names slugify to the same filename (e.g. Delete User in two Postman folders) silently clobbered each other at apply. The later one is now skipped with an explicit reason in the manifest, not overwritten.

## Tests
+3 GraphQL metrics, +4 YAML guard. cargo test green; clippy --all-targets and fmt clean. Full suite green in pre-push.

Generated with Claude Code