### PR TITLE
docs(adr): ADR-004/005/006 — Helm over operator, reuse-first persistence, reuse gate

### DIFF
--- a/docs/adr/ADR-004-k8s-helm-over-operator.md
+++ b/docs/adr/ADR-004-k8s-helm-over-operator.md
@@ -1,0 +1,78 @@
+# ADR-004: Kubernetes deployment via Helm chart; bespoke operator deferred to demand
+
+**Date**: 2026-07-01
+**Status**: Accepted
+**Deciders**: Mikko Parkkola
+**References**: MIK-6560, MIK-6672 (GA epic), MIK-6679 (kind rollback CI), ADR-002
+
+---
+
+## Context
+
+The enterprise Kubernetes track (MIK-6672) was scoped as a full custom operator:
+a `kube-runtime` reconcile loop (MIK-6680), HA leader election (MIK-6681),
+status subresource management (MIK-6682), and a validating admission webhook
+(MIK-6683). The `enterprise-alpha` package already ships CRDs
+(`gateways`, `mcpservers`, `policies`, `runtimeprofiles`, `trustcardreferences`)
+plus base manifests, and MIK-6679 added a CI job that proves apply → upgrade →
+rollback works on a real `kind` (Kubernetes-in-Docker) cluster.
+
+The stated enterprise need is: **templated, versioned, safe deploy + upgrade +
+rollback**. A custom operator delivers that need's *reconciliation* extra —
+continuous drift-correction of the custom resources — at the cost of the
+heaviest dependency tree in the Rust Kubernetes ecosystem (`kube`,
+`kube-runtime`, `k8s-openapi`), plus HA, an admission webhook, and permanent
+maintenance. mcp-gateway's value proposition is a compact Meta-MCP tool router
+with a strong security posture; it is not a Kubernetes operator.
+
+## Decision
+
+**Ship a Helm chart as the enterprise Kubernetes deployment surface. Defer the
+bespoke operator until a customer demand signal requires CRD-driven
+reconciliation.**
+
+- Helm natively provides templating, release versioning, `helm upgrade`, and
+  `helm rollback` — the entire stated need. MIK-6679 already proves the rollout
+  and rollback mechanics on a real cluster.
+- The operator adds only continuous reconciliation/drift-correction of the
+  custom resources. That is speculative value for an alpha feature with no user
+  currently requesting it, so it is not built on spec.
+- The CRDs remain in the repo as typed configuration; they are not reconciled by
+  an in-cluster controller until the operator is built.
+
+### CRD contract risk (adversarial-review mitigation, GPT-5.5 2026-07-01)
+
+Shipping CRDs with no controller risks a *fake enterprise contract*: users may
+treat the CRDs as a reconciled source-of-truth when there is no reconciliation,
+status truth, or admission-time guardrail yet. Mitigation:
+
+- The **Helm values file is the supported deployment contract.** The CRDs are
+  explicitly `v1alpha1` and are documented as experimental / not-a-stable-API
+  until the operator ships — no compatibility guarantee across versions.
+- Prefer plain Kubernetes resources (Deployment/Service/ConfigMap via the chart)
+  as the primary interface; the CRDs are opt-in and clearly labelled alpha.
+- Do not grow CRD surface while the operator is deferred — every new CRD field
+  without reconciliation deepens the compatibility debt.
+- MIK-6684 (image digest pinning, least-privilege RBAC split, cosign
+  verification) is real supply-chain hardening independent of the operator and
+  folds into the Helm chart.
+
+### Demand-gate (when to build the operator)
+
+Build MIK-6680–6683 only when at least one of these is true, and record which:
+- a customer contractually requires CRD-driven reconciliation / GitOps
+  drift-correction of gateway resources, or
+- fleet operation across many clusters makes manual `helm upgrade` per cluster
+  the actual bottleneck, or
+- the CRDs need server-side admission validation that a chart cannot express.
+
+## Consequences
+
+- Positive: weeks of Spark-bound build collapse into a days-long Mac-buildable
+  Helm chart; zero new heavy dependencies; scope matches the product.
+- Positive: the chart serves non-enterprise single-cluster users too.
+- Negative: no automatic drift-correction of custom resources until the operator
+  ships. Acceptable — `helm upgrade` is the reconciliation trigger in the
+  interim, and there is no user depending on continuous reconciliation.
+- Reversible: the CRDs and the alpha planner code remain; the operator can be
+  added later behind the demand-gate without rework of the chart.

--- a/docs/adr/ADR-005-control-plane-persistence.md
+++ b/docs/adr/ADR-005-control-plane-persistence.md
@@ -1,0 +1,77 @@
+# ADR-005: Control-plane persistence — reuse the transparency log; file-core, no Postgres
+
+**Date**: 2026-07-01
+**Status**: Accepted
+**Deciders**: Mikko Parkkola
+**References**: MIK-6558, MIK-6673 (ControlPlaneUI enterprise), MIK-6685, MIK-6689, issue #133 (transparency log)
+
+---
+
+## Context
+
+The ControlPlaneUI enterprise track (MIK-6673) was scoped with a Postgres
+durable store (MIK-6685) backing grants, policies, and audit events, plus a
+SIEM/OTel export (MIK-6689). The read-only control-plane view ships today with
+its **grants** view wired (MIK-6558) but its **audit-evidence** view empty
+because nothing persists governance events.
+
+Two facts reshape this:
+
+1. **The gateway has no database today.** All durable state is local JSON/YAML
+   (identity grants, config). Introducing Postgres would bolt a mandatory
+   *external service* onto a single-binary, minimal-ops, `#![deny(unsafe_code)]`
+   gateway — a heavier product — and would add a *second* database technology to
+   the portfolio (hebb already uses SurrealDB).
+2. **A tamper-evident audit log already exists.** `TransparencyLogger`
+   (`src/security/transparency_log.rs`) is an append-only, hash-chained
+   (`prev_hash` → genesis), independently verifiable (`verify_log`) NDJSON log.
+   `ControlPlaneAuditEvent` (actor / action / target / reason) maps onto it.
+
+## Decision
+
+**Do not make a database mandatory. Persist behind a backend-agnostic
+`ControlPlaneStore` trait; reuse the transparency-log engine for the audit
+trail; keep config file-based for free/core; a server-backed durable store is a
+demand-gated enterprise choice made per deployment.**
+
+- **Audit events (MIK-6685 audit half, MIK-6689):** reuse the tamper-evident
+  append-only hash-chain engine — a governance-scoped log instance alongside the
+  invocation log. The audit-evidence view reads from it; SIEM/OTel export
+  streams that NDJSON to a sink. No new store for the audit path. (Audit is
+  append-only and hash-chained — a genuinely different job from mutable config,
+  and the log is the right fit for it.)
+- **Grants / policies (small mutable config):** stay file-based (matching the
+  existing identity-grants file pattern), behind a `ControlPlaneStore` trait that
+  is the seam for later backends and for the mutation routes (MIK-6686/6687).
+- **Durable server-backed store:** demand-gated, and the backend is **chosen at
+  demand time per deployment, not hardcoded here.** Options, in order of default
+  preference: SurrealDB embedded (portfolio-consistent, no external service);
+  **Postgres is acceptable when the customer already operates it** and wants
+  boring shared durability / backup-restore / retention / SIEM-friendly
+  indexing. The trait keeps this swappable. What this ADR rejects is a
+  *mandatory* database in the default build — not Postgres as an option.
+  (Adversarial-review correction, GPT-5.5 2026-07-01: "never Postgres" was
+  ideology; "no mandatory DB, customer-fit backend" is the defensible line.)
+
+### Demand-gate (when to add a server-backed durable store)
+
+- concurrent multi-writer control-plane mutations exceed what atomic file writes
+  safely handle, or
+- an enterprise deployment requires a shared store across gateway replicas, or
+- query / retention / backup-restore requirements exceed the file + log model.
+
+When triggered, evaluate the mutable-config backend independently from the audit
+log — they need not share a technology.
+
+## Consequences
+
+- Positive: kills the external-Postgres dependency and keeps the portfolio on
+  one database technology; the audit-evidence view becomes real by reusing an
+  already-verified engine rather than building persistence from scratch.
+- Positive: MIK-6685 shrinks to a Mac-buildable trait + file/in-memory impl +
+  audit-view wiring — no heavy dependency.
+- Negative: file-based config does not support multi-replica shared state until
+  the demand-gated backend lands. Acceptable for single-node/core; the trait
+  makes the upgrade non-breaking.
+- Reversible: the trait boundary means the backend can change without touching
+  callers.

--- a/docs/adr/ADR-006-reuse-first-gate.md
+++ b/docs/adr/ADR-006-reuse-first-gate.md
@@ -1,0 +1,75 @@
+# ADR-006: Reuse-first gate on all remaining roadmap tickets
+
+**Date**: 2026-07-01
+**Status**: Accepted
+**Deciders**: Mikko Parkkola
+**References**: MIK-6550 roadmap, ADR-004, ADR-005
+
+---
+
+## Context
+
+The public roadmap (`docs/roadmap/mik-6550-trust-fabric-roadmap.md`) was written
+as a feature wishlist. Two of its child tickets, taken at face value, pushed
+toward heavy net-new architecture that the codebase did not need:
+
+- MIK-6685 said "Postgres" — but the gateway has no database and already has a
+  tamper-evident audit log (`TransparencyLogger`). → ADR-005.
+- MIK-6672 said "operator + HA" — but the enterprise need is deploy/upgrade/
+  rollback, which Helm delivers, and MIK-6679 already proved rollback on a real
+  cluster. → ADR-004.
+
+In both cases the wishlist framing hid existing primitives and led toward
+weeks of Spark-bound builds. A code-first "what do we already have / what is the
+actual need" pass converted them into days of Mac-buildable reuse.
+
+Two more remaining tickets show the same pattern:
+- MIK-6688 (identity feed) is ~80% delivered by MIK-6648: `VerifiedIdentity`
+  already carries `groups` and the policy engine already matches on group. It is
+  a role-mapping wiring job, not new identity infrastructure.
+- MIK-6689 (SIEM export) is a stream of the transparency-log NDJSON, not a new
+  export subsystem.
+
+## Decision
+
+**Every remaining roadmap ticket passes a reuse-first gate before
+implementation starts. Record the answers in the ticket.**
+
+For each ticket, before writing code, answer:
+
+1. **Does this need to exist at all?** (YAGNI — is there a real user/demand
+   signal, or is it speculative maturity theater?)
+2. **What existing gateway primitive covers part or all of it?** (transparency
+   log, OIDC + policy engine, TrustCard, identity grants, ranking, response
+   inspection, config-export — search the codebase, do not assume net-new.)
+3. **What portfolio primitive covers it?** (SurrealDB before a new DB; existing
+   crates before new dependencies.)
+4. **Only then:** the minimum new code, and name any new third-party dependency
+   plus its build-cost tier (Mac-buildable vs Spark-bound heavy compile).
+
+A ticket that fails gate 1 (no demand) moves to **Blocked** with a written
+demand-gate condition rather than being built on spec.
+
+### Blocked-ticket hygiene (adversarial-review mitigation, GPT-5.5 2026-07-01)
+
+The reuse gate must not become a veto machine, and Blocked must not become a
+graveyard. Therefore every Blocked-by-this-gate ticket MUST carry:
+
+- a **named owner**,
+- an explicit **unblock condition** (the demand signal that reopens it), and
+- a **review cadence** — Blocked-for-demand tickets are revisited on the
+  quarterly gate-pruning review, so a capability whose demand only appears after
+  it exists is not permanently vetoed.
+
+The gate blocks *speculative* builds, not *necessary platform bets*; when a bet's
+value is genuinely pre-demand and strategic, that is recorded as the
+justification and the ticket proceeds rather than being blocked.
+
+## Consequences
+
+- Positive: the roadmap's scope is continuously matched to the product and the
+  existing codebase; heavy speculative builds are caught before they start.
+- Positive: makes the build-vs-integrate reasoning auditable per ticket.
+- Negative: a small upfront analysis cost per ticket. Acceptable — it has
+  already paid for itself several times over on this roadmap.
+- This gate is the generalization of the specific calls in ADR-004 and ADR-005.

--- a/docs/roadmap/mik-6550-trust-fabric-roadmap.md
+++ b/docs/roadmap/mik-6550-trust-fabric-roadmap.md
@@ -35,6 +35,25 @@ reused; MIK-6208 per-user vault precedent is reused; MIK-6209 personal versus
 public gating is superseded by the IdentityGrantStore path. No second grant or
 ownership model should be introduced.
 
+## Architecture Decisions (updated 2026-07-01)
+
+Implementation surfaced existing primitives and demand questions that revise the
+enterprise scope. See the ADRs for full rationale:
+
+- **ADR-004 — Kubernetes: Helm chart over bespoke operator.** The enterprise K8s
+  need (templated deploy + upgrade + rollback) is met by a Helm chart; MIK-6679
+  already proves apply/upgrade/rollback on a real cluster. The custom operator
+  (kube-runtime reconcile loop, HA, admission webhook) is **deferred to a demand
+  signal** rather than built on spec.
+- **ADR-005 — Control-plane persistence: reuse, no Postgres.** The gateway has
+  no database; a tamper-evident hash-chain audit log already exists
+  (`TransparencyLogger`). Audit/SIEM reuse it; config stays file-based behind a
+  `ControlPlaneStore` trait; a server-backed durable store is demand-gated and,
+  if built, uses SurrealDB (portfolio-consistent), not Postgres.
+- **ADR-006 — Reuse-first gate.** Every remaining ticket answers "does this need
+  to exist / what existing primitive covers it" before implementation; failing
+  the demand test moves a ticket to Blocked with a written gate condition.
+
 ## Child Rows
 
 ## MIK-6551: Public Repo Hygiene
@@ -224,7 +243,10 @@ ownership model should be introduced.
 - License tier: Free/core for read-only local status; Enterprise for mutation,
   RBAC, approvals, durable storage, and SIEM export.
 - Build vs integrate: Build+Integrate - build MCP domain model and local UI;
-  integrate OIDC, Postgres, OTel, and SIEM sinks in enterprise mode.
+  integrate OIDC and reuse the transparency-log engine for audit/SIEM in
+  enterprise mode. Persistence is file-based behind a `ControlPlaneStore` trait;
+  a server-backed durable store is demand-gated and uses SurrealDB, not Postgres
+  (see ADR-005).
 - Dependencies: Depends on MIK-6553 and MIK-6556. Benefits from MIK-6554 and
   MIK-6557.
 - Target areas: src/control_plane, src/gateway/ui/control_plane.rs, embedded
@@ -272,10 +294,12 @@ ownership model should be introduced.
 - User outcome: Enterprise teams can run mcp-gateway in Kubernetes with safe
   preflight, rollout, rollback, and evidence.
 - Contribution class: Enterprise deployment and infrastructure.
-- License tier: Enterprise for operator, HA, and fleet policy; Free/core keeps
-  Docker Compose and single-node services.
-- Build vs integrate: Build+Integrate - build gateway-specific CRDs, planner,
-  and controller behavior; integrate native Kubernetes APIs and tooling.
+- License tier: Enterprise for HA and fleet policy; Free/core keeps Docker
+  Compose and single-node services.
+- Build vs integrate: Ship a **Helm chart** as the deployment surface (templated
+  deploy + upgrade + rollback; MIK-6679 proves rollback on a real cluster). The
+  bespoke operator (kube-runtime reconcile loop, HA, admission webhook) is
+  **deferred to a demand signal** — see ADR-004. CRDs remain as typed config.
 - Dependencies: Depends on MIK-6552 and MIK-6555. Benefits from MIK-6558.
 - Target areas: deploy/kubernetes/enterprise-alpha, src/kubernetes,
   docs/DEPLOYMENT.md, and Kubernetes manifest tests.


### PR DESCRIPTION
Post-implementation architecture review of the Trust Fabric enterprise scope, generalizing the earlier database discussion (question the wishlist, reuse existing primitives, YAGNI plus demand-gate speculative builds).

## ADRs
- **ADR-004** enterprise K8s ships as a Helm chart (deploy, upgrade, rollback — already proven on a real cluster by MIK-6679). The bespoke kube-runtime operator is deferred to a customer demand signal. CRDs stay alpha with the Helm values file as the supported contract.
- **ADR-005** no MANDATORY database. Reuse the existing tamper-evident TransparencyLogger for audit plus SIEM; config stays file-based behind a backend-agnostic ControlPlaneStore trait; a durable server store is demand-gated with the backend chosen per deployment (SurrealDB default, Postgres acceptable if the customer already runs it).
- **ADR-006** reuse-first gate on every remaining ticket; Blocked tickets carry owner, unblock condition, and quarterly review.

## Reviewed
Adversarially reviewed by GPT-5.5, which corrected 'never Postgres' to 'no mandatory DB' and flagged CRD-contract and Blocked-graveyard risks — all incorporated.

## Linear restructure (done)
Operator slices MIK-6680 to 6683 moved to Blocked (demand-gated); new MIK-6691 Helm chart and MIK-6692 demand-gated durable store filed; MIK-6685, 6688, 6689 re-scoped to reuse. Net: roughly 6 heavy Spark tickets became roughly 4 Mac-buildable reuse tickets plus 2 deferrals.

Generated with Claude Code