### PR TITLE
fix(capability): wolfram_llm_query — dedupe appid + add text response format

### DIFF
--- a/capabilities/knowledge/wolfram_llm.yaml
+++ b/capabilities/knowledge/wolfram_llm.yaml
@@ -1,4 +1,4 @@
-sha256: 954dd55587bbf274e84144cc7abdf9917442eb70e6707c500cb1ef76d4fb4ff6
+sha256: 7d7881af47ce0151cddf20c9747ae7c2b220911afbca4e259e18833d16ad7fb2
 fulcrum: "1.0"
 name: wolfram_llm_query
 description: >
@@ -53,12 +53,12 @@ providers:
       base_url: https://www.wolframalpha.com
       path: /api/v1/llm-api
       method: GET
+      response_format: text
       headers:
         Accept: "text/plain"
       params:
         input: "{query}"
         units: "{units}"
-        appid: "{env.WOLFRAM_APPID}"
 
 cache:
   strategy: exact

--- a/src/capability/executor/params.rs
+++ b/src/capability/executor/params.rs
@@ -54,6 +54,15 @@ impl CapabilityExecutor {
         }
 
         let response_format = config.response_format.to_ascii_lowercase();
+        if response_format == "text" {
+            // Plain-text responses (e.g. Wolfram|Alpha LLM API) aren't JSON.
+            // Wrap the raw body so downstream output mapping has a JSON value.
+            let text = response
+                .text()
+                .await
+                .map_err(|e| Error::Protocol(format!("Failed to read text response: {e}")))?;
+            return Ok(serde_json::json!({ "answer": text, "confidence": "high" }));
+        }
         if response_format == "binary" {
             let mime_type = response
                 .headers()


### PR DESCRIPTION
## Problem
The `wolfram_llm_query` capability never worked. Two bugs:

1. **Duplicate appid** — the key was declared twice (auth block `param: appid` + `params.appid` template), so the executor injected `appid=X&appid=X`. Wolfram|Alpha rejects a duplicated appid with a misleading `400: Appid Missing` (verified: single works, double fails).
2. **No plain-text response mode** — the LLM API returns `text/plain`, but `handle_response` only decoded json/xml/binary and errored on parse.

## Fix
1. Drop the redundant `params.appid` line; keep the canonical `auth` block (single injection).
2. Add a `text` `response_format` that wraps the raw body as `{answer, confidence}`; set it on the capability.

## Verification
- fmt clean · clippy `-D warnings` clean · executor tests 77/77 pass
- End-to-end: capability returns the full answer (mass of the sun = 1.988×10³⁰ kg), `isError:false`
- SHA-256 pin recomputed for the edited capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)