### PR TITLE
feat(helm): minimal mcp-gateway app chart with lint and render CI smoke (MIK-6693)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
       - name: Validate noninteractive setup and routed first call
         run: scripts/dev/usability-smoke.sh
 
+  helm-chart-smoke:
+    name: Helm chart lint + render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - name: Validate helm chart smoke script
+        run: bash -n scripts/dev/helm-chart-smoke.sh
+      - name: Lint, render, and schema-validate the chart
+        run: scripts/dev/helm-chart-smoke.sh
+
   k8s-kind-rollback:
     name: K8s kind apply+upgrade+rollback
     runs-on: ubuntu-latest

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: mcp-gateway
+description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
+type: application
+# Chart version tracks the packaging; appVersion tracks the gateway release.
+version: 0.1.0
+appVersion: "2.19.0"
+home: https://github.com/MikkoParkkola/mcp-gateway
+sources:
+  - https://github.com/MikkoParkkola/mcp-gateway
+maintainers:
+  - name: Mikko Parkkola
+# CRDs are NOT bundled here — they ship in the separate, opt-in
+# `mcp-gateway-crds` chart (ADR-004). The values file is the supported contract.

--- a/deploy/helm/mcp-gateway/templates/_helpers.tpl
+++ b/deploy/helm/mcp-gateway/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* Common name + label helpers */}}
+{{- define "mcp-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mcp-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mcp-gateway.labels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: mcp-gateway-enterprise
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}
+
+{{- define "mcp-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "mcp-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "mcp-gateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Resolve the image ref: digest wins over tag for immutability. */}}
+{{- define "mcp-gateway.image" -}}
+{{- $reg := .Values.image.registry -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s/%s@%s" $reg $repo .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s/%s:%s" $reg $repo (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/mcp-gateway/templates/configmap.yaml
+++ b/deploy/helm/mcp-gateway/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-config
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+data:
+  gateway.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deploy/helm/mcp-gateway/templates/deployment.yaml
+++ b/deploy/helm/mcp-gateway/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-gateway.selectorLabels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.service.port | quote }}
+    spec:
+      serviceAccountName: {{ include "mcp-gateway.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: {{ include "mcp-gateway.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "serve"
+            - "--config"
+            - "/etc/mcp-gateway/gateway.yaml"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - {{ .Values.service.port | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: MCP_GATEWAY_LOG_FORMAT
+              value: {{ .Values.logging.format | quote }}
+            - name: MCP_GATEWAY_LOG_LEVEL
+              value: {{ .Values.logging.level | quote }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mcp-gateway
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mcp-gateway.fullname" . }}-config

--- a/deploy/helm/mcp-gateway/templates/networkpolicy.yaml
+++ b/deploy/helm/mcp-gateway/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+  policyTypes: ["Ingress", "Egress"]
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end }}

--- a/deploy/helm/mcp-gateway/templates/rbac.yaml
+++ b/deploy/helm/mcp-gateway/templates/rbac.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-gateway.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mcp-gateway.fullname" . }}
+{{- end }}

--- a/deploy/helm/mcp-gateway/templates/service.yaml
+++ b/deploy/helm/mcp-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "mcp-gateway.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/deploy/helm/mcp-gateway/templates/serviceaccount.yaml
+++ b/deploy/helm/mcp-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+{{- end }}

--- a/deploy/helm/mcp-gateway/values.schema.json
+++ b/deploy/helm/mcp-gateway/values.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "mcp-gateway Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["replicaCount", "image", "service"],
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registry", "repository", "pullPolicy"],
+      "properties": {
+        "registry": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "digest": { "type": "string", "pattern": "^(sha256:[a-f0-9]{64})?$" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": { "name": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "port"],
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "resources": { "type": "object" },
+    "config": { "type": "object" },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "automountToken": { "type": "boolean" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": { "create": { "type": "boolean" } }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": { "enabled": { "type": "boolean" } }
+    },
+    "logging": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "format": { "type": "string", "enum": ["json", "text"] },
+        "level": { "type": "string", "enum": ["trace", "debug", "info", "warn", "error"] }
+      }
+    }
+  }
+}

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -1,0 +1,65 @@
+# Default values for mcp-gateway.
+# The values file is the supported enterprise deployment contract (ADR-004).
+
+# nameOverride / fullnameOverride feed the pod selector (app.kubernetes.io/name),
+# which Kubernetes makes IMMUTABLE after install. Set them at install time and do
+# not change them on upgrade (a changed selector is rejected). The release-scoped
+# app.kubernetes.io/instance label prevents cross-install pod routing.
+# nameOverride: ""
+# fullnameOverride: ""
+
+replicaCount: 2
+
+image:
+  registry: ghcr.io
+  repository: mikkoparkkola/mcp-gateway
+  # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
+  # When `digest` is set it takes precedence over `tag`.
+  tag: "2.19.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 39400
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+# Gateway config rendered into a ConfigMap and mounted read-only.
+config:
+  server:
+    host: 0.0.0.0
+    port: 39400
+  security:
+    firewall:
+      enabled: true
+      scan_requests: true
+      scan_responses: true
+  backends: []
+
+serviceAccount:
+  create: true
+  name: ""
+  # Data-plane gateway needs no API token; automount stays off unless required.
+  automountToken: false
+
+# RBAC is off by default: the data-plane gateway needs no cluster permissions
+# without the (deferred) operator. A3/least-privilege refines this.
+rbac:
+  create: false
+
+# NetworkPolicy is opt-in; A3 hardens it to default-deny + explicit egress.
+networkPolicy:
+  enabled: false
+
+logging:
+  format: json
+  level: info

--- a/scripts/dev/helm-chart-smoke.sh
+++ b/scripts/dev/helm-chart-smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Helm chart smoke: lint, render the expected Kind set, and prove values.schema
+# rejects invalid input. Mac/CI-buildable, no cluster required (MIK-6693 / HELM.1).
+set -euo pipefail
+
+CHART="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../deploy/helm/mcp-gateway" && pwd)"
+HELM="${HELM:-helm}"
+
+echo "== helm lint =="
+"$HELM" lint "$CHART"
+
+echo "== default render: exactly ConfigMap/Deployment/Service/ServiceAccount =="
+got="$("$HELM" template t "$CHART" | grep '^kind:' | awk '{print $2}' | sort -u | paste -sd, -)"
+want="ConfigMap,Deployment,Service,ServiceAccount"
+[ "$got" = "$want" ] || { echo "FAIL: default Kinds = [$got], want [$want]" >&2; exit 1; }
+
+echo "== opt-in render adds NetworkPolicy + Role + RoleBinding =="
+optin="$("$HELM" template t "$CHART" --set rbac.create=true --set networkPolicy.enabled=true \
+  | grep '^kind:' | awk '{print $2}' | sort -u | paste -sd, -)"
+for k in NetworkPolicy Role RoleBinding; do
+  case ",$optin," in *",$k,"*) : ;; *) echo "FAIL: opt-in missing $k (got [$optin])" >&2; exit 1;; esac
+done
+
+echo "== schema rejects invalid values (bad port type) =="
+if "$HELM" template t "$CHART" --set service.port=notanumber >/dev/null 2>&1; then
+  echo "FAIL: schema accepted a non-integer port" >&2; exit 1
+fi
+
+echo "== schema rejects unknown image field =="
+if "$HELM" template t "$CHART" --set image.bogus=x >/dev/null 2>&1; then
+  echo "FAIL: schema accepted an unknown property" >&2; exit 1
+fi
+
+echo "== digest takes precedence over tag =="
+"$HELM" template t "$CHART" \
+  --set image.digest=sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  | grep -q 'mcp-gateway@sha256:' \
+  || { echo "FAIL: digest did not override tag" >&2; exit 1; }
+
+echo "== pod selector is release-scoped (immutable-selector + cross-route guard) =="
+"$HELM" template rel1 "$CHART" | grep -q 'app.kubernetes.io/instance: rel1' \
+  || { echo "FAIL: selector/labels not release-scoped" >&2; exit 1; }
+
+echo "helm chart smoke passed"


### PR DESCRIPTION
First shippable slice of MIK-6691 (Helm chart) per RFC-0133 Slice A (HELM.1). The large Helm work was decomposed into sub-slices MIK-6693..6699; this is the first.

## What
The chart at deploy/helm/mcp-gateway templatizes the enterprise-alpha base workload from values.
- Always renders Deployment, Service, ConfigMap, ServiceAccount.
- Opt-in NetworkPolicy and Role plus RoleBinding, both default off (data-plane needs no cluster perms without the deferred operator).
- CRDs not bundled (separate crds chart, later slice).
- values.schema.json rejects invalid input.
- Secure defaults preserved: runAsNonRoot, readOnlyRootFilesystem, cap-drop ALL, seccomp RuntimeDefault.
- Image resolves digest over tag.
- CI job (setup-helm SHA-pinned v4.3.0) runs lint, render, schema-negative, selector-scoping smoke; no cluster needed.

## Review
GPT-5.5 adversarial review caught a MAJOR release-blind pod selector (mutable on upgrade plus cross-install routing); fixed with a release-scoped instance label plus smoke assertion, and two schema tightenings. Confirmation pass CLOSED. Smoke green, shellcheck clean.

Generated with Claude Code
