### PR TITLE
feat(helm): kind install, upgrade, and rollback lifecycle CI (MIK-6694)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
           MCP_GATEWAY_KIND_CLUSTER: mcp-gateway-rollback-smoke
           MCP_GATEWAY_KIND_KEEP: "1"
         run: deploy/kubernetes/enterprise-alpha/scripts/kind-rollback-smoke.sh
+      - name: Validate helm kind lifecycle script
+        run: bash -n scripts/dev/helm-kind-lifecycle.sh
+      - name: Helm install, upgrade, and rollback on the real cluster
+        env:
+          MCP_GATEWAY_KIND_CLUSTER: mcp-gateway-rollback-smoke
+          MCP_GATEWAY_KIND_KEEP: "1"
+        run: scripts/dev/helm-kind-lifecycle.sh
 
   check:
     name: Clippy (pedantic)

--- a/deploy/helm/mcp-gateway/templates/_helpers.tpl
+++ b/deploy/helm/mcp-gateway/templates/_helpers.tpl
@@ -7,7 +7,12 @@
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/mcp-gateway/templates/deployment.yaml
+++ b/deploy/helm/mcp-gateway/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
             - name: config
               mountPath: /etc/mcp-gateway
               readOnly: true
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
               path: /health
@@ -81,6 +82,7 @@ spec:
               port: http
             periodSeconds: 5
             failureThreshold: 12
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/deploy/helm/mcp-gateway/values.schema.json
+++ b/deploy/helm/mcp-gateway/values.schema.json
@@ -66,6 +66,11 @@
         "format": { "type": "string", "enum": ["json", "text"] },
         "level": { "type": "string", "enum": ["trace", "debug", "info", "warn", "error"] }
       }
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": { "enabled": { "type": "boolean" } }
     }
   }
 }

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -63,3 +63,8 @@ networkPolicy:
 logging:
   format: json
   level: info
+
+# HTTP /health probes. Default on. Disable only for images that don't serve the
+# health endpoint (e.g. lifecycle/CI tests with a placeholder image).
+probes:
+  enabled: true

--- a/scripts/dev/helm-kind-lifecycle.sh
+++ b/scripts/dev/helm-kind-lifecycle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Helm release lifecycle on a real kind cluster: install -> upgrade -> rollback,
+# asserting convergence at each step (MIK-6694 / HELM.2). Proves the CHART's
+# release mechanics (helm upgrade / helm rollback), not just raw kubectl.
+#
+# ponytail: the gateway image isn't published into the ephemeral cluster, so the
+# rollout is driven with a guaranteed-pullable image (registry.k8s.io/pause) and
+# probes disabled via the chart's probes.enabled=false. The real chart/manifests
+# are still rendered and applied. Upgrade path: swap to the real image+tag once
+# a published image exists.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART="$ROOT_DIR/deploy/helm/mcp-gateway"
+CLUSTER="${MCP_GATEWAY_KIND_CLUSTER:-mcp-gateway-helm-lifecycle}"
+NAMESPACE="${MCP_GATEWAY_HELM_NAMESPACE:-mcp-gateway-helm}"
+RELEASE="${MCP_GATEWAY_HELM_RELEASE:-gw}"
+KIND="${KIND:-kind}"
+HELM="${HELM:-helm}"
+KUBECTL="${KUBECTL:-kubectl}"
+KEEP="${MCP_GATEWAY_KIND_KEEP:-0}"
+TIMEOUT="${MCP_GATEWAY_ROLLOUT_TIMEOUT:-180s}"
+
+# Pullable images used only to drive deterministic rollout convergence.
+IMG_REG="registry.k8s.io"
+IMG_REPO="pause"
+V1="3.10"
+V2="3.9"
+
+created_cluster=0
+cleanup() {
+  if [ "$KEEP" != "1" ] && [ "$created_cluster" = "1" ]; then
+    "$KIND" delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+  fi
+}
+command -v "$KIND" >/dev/null 2>&1
+command -v "$HELM" >/dev/null 2>&1
+command -v "$KUBECTL" >/dev/null 2>&1
+
+if ! "$KIND" get clusters | grep -qx "$CLUSTER"; then
+  "$KIND" create cluster --name "$CLUSTER"
+  created_cluster=1
+  trap cleanup EXIT
+fi
+"$KUBECTL" config use-context "kind-$CLUSTER" >/dev/null
+
+common_args=(
+  --namespace "$NAMESPACE" --create-namespace
+  --set image.registry="$IMG_REG"
+  --set image.repository="$IMG_REPO"
+  --set probes.enabled=false
+  --wait --timeout "$TIMEOUT"
+)
+
+deploy_name() {
+  # Resolve by the release-scoped instance label — robust to any fullname scheme.
+  "$KUBECTL" get deployment -n "$NAMESPACE" \
+    -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/name=mcp-gateway" \
+    -o jsonpath='{.items[0].metadata.name}'
+}
+
+deploy_image() {
+  "$KUBECTL" get deployment -n "$NAMESPACE" \
+    -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/name=mcp-gateway" \
+    -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+}
+
+echo "== install (v1=$V1) =="
+"$HELM" upgrade --install "$RELEASE" "$CHART" "${common_args[@]}" --set image.tag="$V1"
+[ "$(deploy_image)" = "$IMG_REG/$IMG_REPO:$V1" ] || { echo "FAIL: install image mismatch" >&2; exit 1; }
+
+echo "== helm upgrade (v2=$V2) =="
+"$HELM" upgrade "$RELEASE" "$CHART" "${common_args[@]}" --set image.tag="$V2"
+[ "$(deploy_image)" = "$IMG_REG/$IMG_REPO:$V2" ] || { echo "FAIL: upgrade image mismatch" >&2; exit 1; }
+
+echo "== helm rollback -> revision 1 =="
+"$HELM" rollback "$RELEASE" 1 --namespace "$NAMESPACE" --wait --timeout "$TIMEOUT"
+"$KUBECTL" rollout status "deployment/$(deploy_name)" -n "$NAMESPACE" --timeout="$TIMEOUT"
+[ "$(deploy_image)" = "$IMG_REG/$IMG_REPO:$V1" ] || { echo "FAIL: rollback did not restore v1 (got $(deploy_image))" >&2; exit 1; }
+
+echo "helm kind lifecycle passed: install($V1) -> upgrade($V2) -> rollback($V1) on $CLUSTER"


### PR DESCRIPTION
Second Helm sub-slice (MIK-6694, RFC-0133 HELM.2). Drives the chart release lifecycle on a real kind cluster: helm install then helm upgrade then helm rollback, asserting image convergence at each step. Wired into the existing kind CI job (reuses the cluster, separate namespace).

- New chart value probes.enabled (default true) gates the HTTP health probes so a placeholder image (registry.k8s.io pause) converges under helm --wait in CI; the real workload keeps its probes.
- Chart fullname is now standard release-prefixed so resources are release-scoped.

## Review
GPT-5.5 caught a HIGH CI-blocker (chart rendered mcp-gateway vs the script targeting gw-mcp-gateway); fixed with release-prefixed fullname, then the residual hardcoded-name edge was fixed by resolving the deployment via its release-scoped label. Confirmation CLOSED. shellcheck clean, chart smoke green.

Generated with Claude Code
