### PR TITLE
feat(helm): secure-by-default with authoritative Pod Security restricted (MIK-6695)

### DIFF
--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -56,7 +56,10 @@ serviceAccount:
 rbac:
   create: false
 
-# NetworkPolicy is opt-in; A3 hardens it to default-deny + explicit egress.
+# NetworkPolicy is opt-in. When enabled it is WORKLOAD-SCOPED (selects only the
+# gateway's own pods) and restrictive: ingress limited to the service port,
+# egress limited to HTTPS + DNS. It is NOT a namespace-wide default-deny — that
+# affects other workloads and is the cluster operator's responsibility.
 networkPolicy:
   enabled: false
 

--- a/docs/design/RFC-0133-trust-fabric-enterprise-dor.md
+++ b/docs/design/RFC-0133-trust-fabric-enterprise-dor.md
@@ -51,9 +51,12 @@ CRDs remain experimental and ship in a *separate* opt-in chart.
 - **MIK-6691.HELM.2** kind CI: `helm install` the chart, `helm upgrade` to a new
   image, assert rollout, `helm rollback`, assert convergence (extends MIK-6679,
   now via the chart not raw manifests).
-- **MIK-6691.HELM.3** rendered pods satisfy Pod Security `restricted` (CI policy
-  assertion via `kubeconform`/`conftest`); NetworkPolicy is default-deny with an
-  explicit DNS egress rule.
+- **MIK-6691.HELM.3** rendered pods satisfy Pod Security `restricted` — enforced
+  authoritatively in kind CI via a namespace labeled
+  `pod-security.kubernetes.io/enforce=restricted` (admission rejects violators),
+  with a fast offline field pre-check; the NetworkPolicy is workload-scoped and
+  restrictive (ingress to the service port, egress to HTTPS + DNS), not a
+  namespace-wide default-deny (an app chart must not impose that on the namespace).
 - **MIK-6691.HELM.4** CRDs live in a separate `mcp-gateway-crds` chart; the app
   chart installs and runs with zero CRDs present.
 - **MIK-6691.HELM.5** `helm package` + push to an **ephemeral OCI registry**,

--- a/scripts/dev/helm-chart-smoke.sh
+++ b/scripts/dev/helm-chart-smoke.sh
@@ -41,4 +41,36 @@ echo "== pod selector is release-scoped (immutable-selector + cross-route guard)
 "$HELM" template rel1 "$CHART" | grep -q 'app.kubernetes.io/instance: rel1' \
   || { echo "FAIL: selector/labels not release-scoped" >&2; exit 1; }
 
+echo "== Pod Security 'restricted' fields present (fast pre-check; kind CI enforces authoritatively) =="
+render="$("$HELM" template t "$CHART")"
+for field in \
+  'runAsNonRoot: true' \
+  'seccompProfile:' \
+  'type: RuntimeDefault' \
+  'allowPrivilegeEscalation: false' \
+  'readOnlyRootFilesystem: true' \
+  'drop: \["ALL"\]'; do
+  echo "$render" | grep -q "$field" \
+    || { echo "FAIL: restricted field missing: $field" >&2; exit 1; }
+done
+# Negative: no privilege-escalating or host-namespace escapes that restricted forbids.
+for bad in 'privileged: true' 'hostNetwork: true' 'hostPID: true' 'hostPath:' 'runAsUser: 0' 'allowPrivilegeEscalation: true'; do
+  ! echo "$render" | grep -q "$bad" \
+    || { echo "FAIL: restricted-forbidden field present: $bad" >&2; exit 1; }
+done
+
+echo "== NetworkPolicy is workload-scoped + restrictive with DNS egress (when enabled) =="
+np="$("$HELM" template t "$CHART" --set networkPolicy.enabled=true)"
+echo "$np" | grep -q 'policyTypes: \["Ingress", "Egress"\]' \
+  || { echo "FAIL: NetworkPolicy is not both Ingress+Egress (not restrictive)" >&2; exit 1; }
+echo "$np" | grep -q 'port: 53' \
+  || { echo "FAIL: NetworkPolicy lacks a DNS (53) egress rule" >&2; exit 1; }
+
+echo "== RBAC is least-privilege: empty Role, namespace-scoped only (no ClusterRole) =="
+rbac="$("$HELM" template t "$CHART" --set rbac.create=true)"
+echo "$rbac" | grep -q 'rules: \[\]' \
+  || { echo "FAIL: RBAC Role is not empty/least-privilege" >&2; exit 1; }
+! echo "$rbac" | grep -qE '^kind: ClusterRole' \
+  || { echo "FAIL: chart renders a ClusterRole (not namespace-scoped least-priv)" >&2; exit 1; }
+
 echo "helm chart smoke passed"

--- a/scripts/dev/helm-kind-lifecycle.sh
+++ b/scripts/dev/helm-kind-lifecycle.sh
@@ -44,8 +44,18 @@ if ! "$KIND" get clusters | grep -qx "$CLUSTER"; then
 fi
 "$KUBECTL" config use-context "kind-$CLUSTER" >/dev/null
 
+# Authoritative Pod Security proof: enforce the built-in `restricted` standard on
+# the namespace so the API server REJECTS any pod that violates it at admission.
+# If the chart's securityContext regresses, `helm install --wait` fails here —
+# far stronger than string-matching the rendered YAML (MIK-6695 / HELM.3).
+"$KUBECTL" create namespace "$NAMESPACE" --dry-run=client -o yaml \
+  | "$KUBECTL" apply -f -
+"$KUBECTL" label --overwrite namespace "$NAMESPACE" \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/enforce-version=latest
+
 common_args=(
-  --namespace "$NAMESPACE" --create-namespace
+  --namespace "$NAMESPACE"
   --set image.registry="$IMG_REG"
   --set image.repository="$IMG_REPO"
   --set probes.enabled=false


### PR DESCRIPTION
Third Helm sub-slice (MIK-6695, RFC-0133 HELM.3 and HELM.8). Locks in the chart security posture.

- kind CI installs into a namespace labeled pod-security.kubernetes.io/enforce=restricted, so the API server REJECTS any pod violating the restricted standard at admission (authoritative, not string-matching).
- Offline chart smoke adds positive restricted-field checks plus negative checks (no privileged, hostNetwork, hostPID, hostPath, runAsUser 0, allowPrivilegeEscalation true) as a fast pre-check.
- NetworkPolicy framed correctly as workload-scoped restrictive (ingress to the port, egress HTTPS plus DNS), not a namespace-wide default-deny; documented in values.
- RBAC assertion scoped: empty Role, no ClusterRole (namespace-scoped least-privilege).

## Review
GPT-5.5 flagged three Majors (grep too weak for a security gate; NetworkPolicy mislabeled; unscoped RBAC grep) then confirmed all CLOSED after fixes. pause pod admits under restricted.

Generated with Claude Code
