### PR TITLE
feat(helm): separate opt-in mcp-gateway-crds chart (MIK-6696)

### DIFF
--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: mcp-gateway-crds
+description: >-
+  EXPERIMENTAL (v1alpha1) Custom Resource Definitions for mcp-gateway. Shipped as
+  a SEPARATE, opt-in chart — they are NOT a stable API and are NOT reconciled by
+  any controller until the operator ships (ADR-004). Install only if you intend
+  to author these resources as typed config. Helm does not manage CRD
+  upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+type: application
+version: 0.1.0
+appVersion: "2.19.0"
+home: https://github.com/MikkoParkkola/mcp-gateway
+maintainers:
+  - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway-crds/crds/mcpgateway.io.yaml
+++ b/deploy/helm/mcp-gateway-crds/crds/mcpgateway.io.yaml
@@ -1,0 +1,341 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.mcpgateway.io
+  labels:
+    app.kubernetes.io/name: mcp-gateway
+    app.kubernetes.io/part-of: mcp-gateway-enterprise
+    mcp-gateway.io/license-tier: enterprise
+spec:
+  group: mcpgateway.io
+  scope: Namespaced
+  names:
+    plural: gateways
+    singular: gateway
+    kind: Gateway
+    shortNames: ["mcpgw"]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              required: ["replicas", "service", "runtimeProfileRef"]
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 2
+                  default: 2
+                service:
+                  type: object
+                  required: ["port"]
+                  properties:
+                    port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      default: 39400
+                runtimeProfileRef:
+                  type: string
+                policyRef:
+                  type: string
+                trustCardRefs:
+                  type: array
+                  items:
+                    type: string
+                evidence:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: true
+                    endpoint:
+                      type: string
+                protectedValueRefs:
+                  type: array
+                  items:
+                    type: object
+                    required: ["name"]
+                    properties:
+                      name:
+                        type: string
+                      mountPath:
+                        type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: ["type", "status", "reason"]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                observedGeneration:
+                  type: integer
+                driftDetected:
+                  type: boolean
+                rollbackRevision:
+                  type: string
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mcpservers.mcpgateway.io
+  labels:
+    app.kubernetes.io/name: mcp-gateway
+    app.kubernetes.io/part-of: mcp-gateway-enterprise
+    mcp-gateway.io/license-tier: enterprise
+spec:
+  group: mcpgateway.io
+  scope: Namespaced
+  names:
+    plural: mcpservers
+    singular: mcpserver
+    kind: MCPServer
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              required: ["transport", "endpoint"]
+              properties:
+                transport:
+                  type: string
+                  enum: ["stdio", "streamable_http", "sse"]
+                endpoint:
+                  type: string
+                runtimeProfileRef:
+                  type: string
+                policyRef:
+                  type: string
+                trustCardRef:
+                  type: string
+                protectedValueRefs:
+                  type: array
+                  items:
+                    type: object
+                    required: ["name"]
+                    properties:
+                      name:
+                        type: string
+                      env:
+                        type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: policies.mcpgateway.io
+  labels:
+    app.kubernetes.io/name: mcp-gateway
+    app.kubernetes.io/part-of: mcp-gateway-enterprise
+    mcp-gateway.io/license-tier: enterprise
+spec:
+  group: mcpgateway.io
+  scope: Namespaced
+  names:
+    plural: policies
+    singular: policy
+    kind: Policy
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              properties:
+                networkEgress:
+                  type: string
+                  enum: ["deny_all", "allow_list"]
+                  default: "deny_all"
+                allowedHosts:
+                  type: array
+                  items:
+                    type: string
+                runtime:
+                  type: object
+                  properties:
+                    allowPrivileged:
+                      type: boolean
+                      default: false
+                    defaultCpu:
+                      type: string
+                    defaultMemory:
+                      type: string
+                contextIntegrity:
+                  type: object
+                  properties:
+                    mode:
+                      type: string
+                      enum: ["monitor_only", "enforce"]
+                      default: "monitor_only"
+                exceptions:
+                  type: array
+                  items:
+                    type: object
+                    required: ["reason", "expiresAt"]
+                    properties:
+                      reason:
+                        type: string
+                      expiresAt:
+                        type: string
+                        format: date-time
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: runtimeprofiles.mcpgateway.io
+  labels:
+    app.kubernetes.io/name: mcp-gateway
+    app.kubernetes.io/part-of: mcp-gateway-enterprise
+    mcp-gateway.io/license-tier: enterprise
+spec:
+  group: mcpgateway.io
+  scope: Namespaced
+  names:
+    plural: runtimeprofiles
+    singular: runtimeprofile
+    kind: RuntimeProfile
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum: ["kubernetes", "container", "local_process"]
+                  default: "kubernetes"
+                restartPolicy:
+                  type: string
+                  enum: ["always", "on_failure", "never"]
+                  default: "on_failure"
+                resources:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                networkPolicyRef:
+                  type: string
+                health:
+                  type: object
+                  properties:
+                    readinessPath:
+                      type: string
+                      default: "/health"
+                    livenessPath:
+                      type: string
+                      default: "/health"
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: trustcardreferences.mcpgateway.io
+  labels:
+    app.kubernetes.io/name: mcp-gateway
+    app.kubernetes.io/part-of: mcp-gateway-enterprise
+    mcp-gateway.io/license-tier: enterprise
+spec:
+  group: mcpgateway.io
+  scope: Namespaced
+  names:
+    plural: trustcardreferences
+    singular: trustcardreference
+    kind: TrustCardReference
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              required: ["name", "digest"]
+              properties:
+                name:
+                  type: string
+                digest:
+                  type: string
+                source:
+                  type: string
+                evidenceEndpoint:
+                  type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+      subresources:
+        status: {}

--- a/deploy/helm/mcp-gateway-crds/templates/NOTES.txt
+++ b/deploy/helm/mcp-gateway-crds/templates/NOTES.txt
@@ -1,0 +1,8 @@
+mcp-gateway CRDs (v1alpha1, EXPERIMENTAL) installed.
+
+These Custom Resource Definitions are NOT reconciled by any controller yet
+(ADR-004). They exist as typed config only. Helm does not manage CRD
+upgrade/delete lifecycle — remove them manually if you uninstall.
+
+The supported deployment contract is the mcp-gateway chart's values file, not
+these CRDs.

--- a/scripts/dev/helm-chart-smoke.sh
+++ b/scripts/dev/helm-chart-smoke.sh
@@ -73,4 +73,23 @@ echo "$rbac" | grep -q 'rules: \[\]' \
 ! echo "$rbac" | grep -qE '^kind: ClusterRole' \
   || { echo "FAIL: chart renders a ClusterRole (not namespace-scoped least-priv)" >&2; exit 1; }
 
+echo "== app chart renders ZERO CRDs (CRDs are a separate opt-in chart) =="
+# Must use --include-crds: plain `helm template` omits a chart's crds/ dir, so a
+# default render would falsely pass even if the app chart wrongly bundled CRDs.
+! "$HELM" template t "$CHART" --include-crds | grep -q '^kind: CustomResourceDefinition' \
+  || { echo "FAIL: app chart bundles CRDs (should be in mcp-gateway-crds)" >&2; exit 1; }
+[ ! -d "$CHART/crds" ] \
+  || { echo "FAIL: app chart has a crds/ dir (CRDs belong in mcp-gateway-crds)" >&2; exit 1; }
+
+echo "== separate CRDs chart lints and carries the CRDs =="
+CRDS_CHART="$(dirname "$CHART")/mcp-gateway-crds"
+"$HELM" lint "$CRDS_CHART" >/dev/null
+[ -f "$CRDS_CHART/crds/mcpgateway.io.yaml" ] \
+  || { echo "FAIL: crds chart missing the CRD file" >&2; exit 1; }
+
+echo "== CRDs chart copy matches the enterprise-alpha source (drift guard) =="
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deploy/kubernetes/enterprise-alpha/crds/mcpgateway.io.yaml"
+diff -q "$SRC" "$CRDS_CHART/crds/mcpgateway.io.yaml" >/dev/null \
+  || { echo "FAIL: crds chart CRD drifted from enterprise-alpha source" >&2; exit 1; }
+
 echo "helm chart smoke passed"


### PR DESCRIPTION
Fourth Helm sub-slice (MIK-6696, RFC-0133 HELM.4). Moves the 5 alpha CRDs into a separate mcp-gateway-crds chart (Helm crds convention: installed on install, not templated, no upgrade lifecycle; documented in Chart.yaml + NOTES). The app chart stays CRD-free; values file remains the supported contract.

Smoke: app chart renders zero CRDs (via --include-crds, and no crds dir) plus a drift guard that the chart CRD copy matches the enterprise-alpha source.

## Review
GPT-5.5 LGTM on the crds mechanism and copy-with-drift-guard; caught a false-negative in the zero-CRD assertion (plain helm template omits crds) which was fixed and re-verified to catch a deliberately-bundled CRD.

Generated with Claude Code
