### PR TITLE
feat(helm): OCI package push pull round-trip CI plus schema version marker (MIK-6697)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           done
           # Pull the app chart back and render the pulled artifact.
           ver="$(grep -E '^version:' deploy/helm/mcp-gateway/Chart.yaml | awk '{print $2}')"
+          mkdir -p "$out/pulled"
           helm pull oci://localhost:5000/charts/mcp-gateway --version "$ver" -d "$out/pulled" --plain-http
           test -f "$out/pulled/mcp-gateway-$ver.tgz"
           helm template t "$out/pulled/mcp-gateway-$ver.tgz" | grep -q '^kind: Deployment'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,33 @@ jobs:
       - name: Lint, render, and schema-validate the chart
         run: scripts/dev/helm-chart-smoke.sh
 
+  helm-oci-roundtrip:
+    name: Helm OCI package/push/pull
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - name: Package, push to OCI, pull, and render the same artifact
+        run: |
+          set -euo pipefail
+          out="$(mktemp -d)"
+          helm package deploy/helm/mcp-gateway -d "$out"
+          helm package deploy/helm/mcp-gateway-crds -d "$out"
+          for tgz in "$out"/*.tgz; do
+            helm push "$tgz" oci://localhost:5000/charts --plain-http
+          done
+          # Pull the app chart back and render the pulled artifact.
+          ver="$(grep -E '^version:' deploy/helm/mcp-gateway/Chart.yaml | awk '{print $2}')"
+          helm pull oci://localhost:5000/charts/mcp-gateway --version "$ver" -d "$out/pulled" --plain-http
+          test -f "$out/pulled/mcp-gateway-$ver.tgz"
+          helm template t "$out/pulled/mcp-gateway-$ver.tgz" | grep -q '^kind: Deployment'
+          echo "OCI round-trip ok: pushed + pulled + rendered mcp-gateway $ver"
+
   k8s-kind-rollback:
     name: K8s kind apply+upgrade+rollback
     runs-on: ubuntu-latest

--- a/deploy/helm/mcp-gateway/values.schema.json
+++ b/deploy/helm/mcp-gateway/values.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/MikkoParkkola/mcp-gateway/deploy/helm/mcp-gateway/values.schema.json",
+  "$comment": "schemaVersion: 1 — evolve additively within a chart minor; a breaking values change requires a chart major + a note in the release.",
   "title": "mcp-gateway Helm values",
   "type": "object",
   "additionalProperties": true,

--- a/scripts/dev/helm-chart-smoke.sh
+++ b/scripts/dev/helm-chart-smoke.sh
@@ -92,4 +92,14 @@ SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deploy/kubernetes/enter
 diff -q "$SRC" "$CRDS_CHART/crds/mcpgateway.io.yaml" >/dev/null \
   || { echo "FAIL: crds chart CRD drifted from enterprise-alpha source" >&2; exit 1; }
 
+echo "== chart packages to a versioned artifact + schema carries a version marker =="
+pkgdir="$(mktemp -d)"
+trap 'rm -rf "$pkgdir"' EXIT
+"$HELM" package "$CHART" -d "$pkgdir" >/dev/null
+ver="$(grep -E '^version:' "$CHART/Chart.yaml" | awk '{print $2}')"
+[ -f "$pkgdir/mcp-gateway-$ver.tgz" ] \
+  || { echo "FAIL: helm package did not produce mcp-gateway-$ver.tgz" >&2; exit 1; }
+grep -q 'schemaVersion:' "$CHART/values.schema.json" \
+  || { echo "FAIL: values.schema.json lacks a schemaVersion marker" >&2; exit 1; }
+
 echo "helm chart smoke passed"


### PR DESCRIPTION
Fifth Helm sub-slice (MIK-6697, RFC-0133 HELM.5 and HELM.9).

- New helm-oci-roundtrip CI job: registry:2 service on localhost:5000, helm package (app and crds charts), helm push --plain-http, helm pull --plain-http, then render the pulled artifact. Proves OCI distribution end to end.
- values.schema.json gains an id plus a schemaVersion marker; offline smoke asserts helm package produces a versioned tgz and the schema carries the marker.
- Image digest-pin mechanism already exists (digest wins over tag, from MIK-6693); real digest stamping is a release-workflow step, not a fabricated value here.

## Review
GPT-5.5 LGTM: confirmed registry:2 as a runner service (not a container job) with port mapping and --plain-http and the helm ref conventions are correct for helm 4.x; the schema comment is a non-enforced marker used as a presence check.

Generated with Claude Code
