### PR TITLE
control-plane: governance mutation routes via validate_for_actor (MIK-6686)

### DIFF
--- a/src/control_plane/store.rs
+++ b/src/control_plane/store.rs
@@ -206,8 +206,37 @@ pub trait ControlPlaneStore: Send + Sync {
     /// Read audit events in chain order, honouring the filter's limit/offset.
     ///
     /// # Errors
-    /// Errors on an invalid filter, I/O failure, or a corrupt log line.
+    /// Errors on an invalid filter, an I/O failure, a corrupt log line.
     fn read_audit(&self, filter: &AuditFilter) -> StoreResult<Vec<ControlPlaneAuditEvent>>;
+
+    /// Atomically append a write-ahead audit event, then upsert the grant, as a
+    /// single serialized unit. Guarantees a committed grant is never unaudited
+    /// and that audit order matches commit order. The default appends then
+    /// commits; durable backends override to hold one lock across both.
+    ///
+    /// # Errors
+    /// Errors on an I/O failure, a serialisation failure, a corrupt collection.
+    fn commit_grant_audited(
+        &self,
+        grant: ControlPlaneGrant,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<()> {
+        self.append_audit(event)?;
+        self.put_grant(grant)
+    }
+
+    /// Policy counterpart of [`Self::commit_grant_audited`].
+    ///
+    /// # Errors
+    /// Errors on an I/O failure, a serialisation failure, a corrupt collection.
+    fn commit_policy_audited(
+        &self,
+        policy: ControlPlanePolicy,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<()> {
+        self.append_audit(event)?;
+        self.put_policy(policy)
+    }
 }
 
 // ── Audit event <-> transparency-log entry mapping ─────────────────────────────
@@ -504,6 +533,16 @@ impl FileControlPlaneStore {
             }
         }
     }
+
+    /// Append one governance audit entry, assuming the caller already holds the
+    /// audit lock. Re-syncs the chain tail from disk under the lock (so separate
+    /// processes never write the same counter) and fsyncs for durability.
+    fn append_audit_locked(&self, event: &ControlPlaneAuditEvent) -> StoreResult<()> {
+        self.audit
+            .append_event_synced(audit_fields(event))
+            .map(|_| ())
+            .map_err(StoreError::from)
+    }
 }
 
 impl ControlPlaneStore for FileControlPlaneStore {
@@ -562,16 +601,44 @@ impl ControlPlaneStore for FileControlPlaneStore {
     }
 
     fn append_audit(&self, event: &ControlPlaneAuditEvent) -> StoreResult<()> {
-        // Cross-process safety: a CLI and the server each hold their own logger
-        // with a cached counter. Serialise audit appends across processes with a
-        // dedicated lock and re-sync the chain tail from disk under it, so two
-        // processes never write the same counter (which would fork the chain and
-        // fail `verify_log`).
         let _lock = ExclusiveFileLock::acquire(&self.dir.join(".audit.lock"))?;
-        self.audit
-            .append_event_synced(audit_fields(event))
-            .map(|_| ())
-            .map_err(StoreError::from)
+        self.append_audit_locked(event)
+    }
+
+    fn commit_grant_audited(
+        &self,
+        grant: ControlPlaneGrant,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<()> {
+        // Hold the audit lock across BOTH the write-ahead audit and the commit
+        // so the pair is one serialized, ordered unit: no interleaving can make
+        // the audit order disagree with the committed order, and a committed
+        // grant is never unaudited.
+        let _lock = ExclusiveFileLock::acquire(&self.dir.join(".audit.lock"))?;
+        self.append_audit_locked(event)?;
+        self.mutate::<ControlPlaneGrant, _>(&self.grants_file(), |items| {
+            if let Some(existing) = items.iter_mut().find(|g| g.grant_id == grant.grant_id) {
+                *existing = grant.clone();
+            } else {
+                items.push(grant.clone());
+            }
+        })
+    }
+
+    fn commit_policy_audited(
+        &self,
+        policy: ControlPlanePolicy,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<()> {
+        let _lock = ExclusiveFileLock::acquire(&self.dir.join(".audit.lock"))?;
+        self.append_audit_locked(event)?;
+        self.mutate::<ControlPlanePolicy, _>(&self.policies_file(), |items| {
+            if let Some(existing) = items.iter_mut().find(|p| p.policy_id == policy.policy_id) {
+                *existing = policy.clone();
+            } else {
+                items.push(policy.clone());
+            }
+        })
     }
 
     fn read_audit(&self, filter: &AuditFilter) -> StoreResult<Vec<ControlPlaneAuditEvent>> {
@@ -1160,5 +1227,30 @@ mod tests {
             store.read_audit(&AuditFilter::new(10)),
             Err(StoreError::Corrupt(_))
         ));
+    }
+
+    // MIK-6686.CP.2 — the audited commit persists the grant AND appends a
+    // verifiable audit entry as one unit, under a single lock.
+    #[test]
+    fn audited_commit_persists_grant_and_appends_verifiable_audit() {
+        let dir = tempfile::tempdir().unwrap();
+        let logger = governance_logger(dir.path());
+        let store =
+            FileControlPlaneStore::open(dir.path().join("store"), Arc::clone(&logger)).unwrap();
+
+        let g = grant("g1", ControlPlaneGrantStatus::Approved);
+        let event = audit_event("e1", "alice", ControlPlaneAction::MutateGrant);
+        store.commit_grant_audited(g, &event).unwrap();
+
+        assert_eq!(store.list_grants().unwrap().len(), 1);
+        let audit = store.read_audit(&AuditFilter::new(10)).unwrap();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].event_id, "e1");
+        let result = crate::security::transparency_log::verify_log(&logger.path()).unwrap();
+        assert!(
+            result.ok,
+            "audit chain must verify: {:?}",
+            result.error_message
+        );
     }
 }

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -15,6 +15,7 @@ use super::proxy::ProxyManager;
 use super::streaming::NotificationMultiplexer;
 use crate::backend::BackendRegistry;
 use crate::config::{AgentIdentityConfig, StreamingConfig};
+use crate::control_plane::ControlPlaneStore;
 use crate::key_server::{KeyServer, handler::key_server_routes};
 use crate::mtls::MtlsPolicy;
 use crate::security::ToolPolicy;
@@ -79,6 +80,10 @@ pub struct AppState {
     pub firewall: Option<Arc<Firewall>>,
     /// Per-agent identity configuration (OWASP ASI03).
     pub agent_identity_config: AgentIdentityConfig,
+    /// Durable control-plane store (grants/policies + governance audit log).
+    /// `None` when the control-plane data directory could not be opened, in
+    /// which case governance mutation routes return 503 (MIK-6686).
+    pub control_plane_store: Option<Arc<dyn ControlPlaneStore>>,
 }
 
 /// Create the router.

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -64,6 +64,7 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 
@@ -106,6 +107,7 @@ fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 
@@ -144,6 +146,7 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 
@@ -191,6 +194,7 @@ fn test_router_app_state_with_ssrf(
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 
@@ -246,6 +250,7 @@ fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -79,6 +79,62 @@ async fn load_configured_identity_grants(
     }
 }
 
+/// Open the durable control-plane store (grants/policies plus a
+/// governance-scoped audit log, separate from the invocation transparency log;
+/// ADR-005, MIK-6685).
+///
+/// Returns `None` — disabling the governance mutation routes (they answer 503) —
+/// when auth is disabled, since an auth-disabled gateway treats every caller as
+/// an anonymous admin and a durable governance mutation surface must not be open
+/// to unauthenticated callers. Also returns `None` if the data directory or the
+/// audit log cannot be opened; never fatal to startup.
+///
+/// The store is rooted next to the config file when one is known
+/// (`<config-dir>/control-plane`), so distinct gateway instances do not share
+/// governance state; otherwise it falls back to `~/.mcp-gateway/control-plane`.
+/// Governance audit entries reuse the transparency log's signing identity, so
+/// they are signed iff the invocation log is.
+fn build_control_plane_store(
+    config: &Config,
+    config_path: Option<&std::path::Path>,
+) -> Option<Arc<dyn crate::control_plane::ControlPlaneStore>> {
+    use crate::control_plane::FileControlPlaneStore;
+    use crate::security::TransparencyLogger;
+    use crate::security::transparency_log::TransparencyLogConfig;
+
+    if !config.auth.enabled {
+        info!(
+            "control-plane governance mutations disabled: auth is off (would expose an anonymous-admin mutation surface)"
+        );
+        return None;
+    }
+
+    let base = config_path.and_then(|p| p.parent()).map_or_else(
+        || expand_home_path("~/.mcp-gateway/control-plane"),
+        |dir| dir.join("control-plane"),
+    );
+    let audit_cfg = Arc::new(TransparencyLogConfig {
+        enabled: true,
+        path: base.join("audit.jsonl").to_string_lossy().into_owned(),
+        key_id: config.security.transparency_log.key_id.clone(),
+        shared_secret: config.security.transparency_log.shared_secret.clone(),
+    });
+    let audit = match TransparencyLogger::open(audit_cfg) {
+        Ok(logger) => Arc::new(logger),
+        Err(e) => {
+            warn!(error = %e, "control-plane audit log unavailable; governance mutations disabled");
+            return None;
+        }
+    };
+    match FileControlPlaneStore::open(base.join("store"), audit) {
+        Ok(store) => Some(Arc::new(store) as Arc<dyn crate::control_plane::ControlPlaneStore>),
+        Err(e) => {
+            warn!(error = %e, "control-plane store unavailable; governance mutations disabled");
+            None
+        }
+    }
+}
+
 /// MCP Gateway server
 pub struct Gateway {
     /// Configuration
@@ -697,6 +753,9 @@ impl Gateway {
         // persistence and graceful shutdown cost saves use this handle).
         let meta_mcp_for_shutdown = Arc::clone(&meta_mcp);
 
+        let control_plane_store =
+            build_control_plane_store(&self.config, self.config_path.as_deref());
+
         let state = Arc::new(AppState {
             backends: Arc::clone(&self.backends),
             meta_mcp,
@@ -723,6 +782,7 @@ impl Gateway {
             #[cfg(feature = "firewall")]
             firewall: firewall_arc,
             agent_identity_config: self.config.security.agent_identity.clone(),
+            control_plane_store,
         });
 
         // Create router

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -109,9 +109,17 @@ fn build_control_plane_store(
         return None;
     }
 
-    let base = config_path.and_then(|p| p.parent()).map_or_else(
+    // Derive a per-config store directory so distinct gateway instances do not
+    // share governance state. Include the config file stem, so two config files
+    // in the SAME directory (a.yaml, b.yaml) get distinct control-plane dirs.
+    // With no config file we assume a single instance and use the global path.
+    let base = config_path.map_or_else(
         || expand_home_path("~/.mcp-gateway/control-plane"),
-        |dir| dir.join("control-plane"),
+        |p| {
+            let dir = p.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("gateway");
+            dir.join(format!("{stem}-control-plane"))
+        },
     );
     let audit_cfg = Arc::new(TransparencyLogConfig {
         enabled: true,

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -6,19 +6,22 @@ use std::sync::Arc;
 use axum::extract::{Extension, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::Serialize;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
 
 use super::super::auth::AuthenticatedClient;
 use super::super::router::AppState;
 use super::errors::auth_required;
 use crate::control_plane::{
-    ControlPlaneAction, ControlPlaneActor, ControlPlaneAuthorization, ControlPlaneDecisionQueue,
-    ControlPlaneDomainCoverage, ControlPlaneFeature, ControlPlaneGrant, ControlPlaneGrantStatus,
-    ControlPlaneHealth, ControlPlaneLicenseTier, ControlPlaneRbac, ControlPlaneReadOnlyView,
-    ControlPlaneRole, ControlPlaneRuntimeHealth, ControlPlaneServer, ControlPlaneServerStatus,
-    ControlPlaneSnapshot, ControlPlaneTool, ControlPlaneTrustCard, ControlPlaneUser,
+    ControlPlaneAction, ControlPlaneActor, ControlPlaneAuditEvent, ControlPlaneAuthorization,
+    ControlPlaneDecisionQueue, ControlPlaneDomainCoverage, ControlPlaneFeature, ControlPlaneGrant,
+    ControlPlaneGrantStatus, ControlPlaneHealth, ControlPlaneLicenseTier, ControlPlaneMutation,
+    ControlPlanePolicy, ControlPlaneRbac, ControlPlaneReadOnlyView, ControlPlaneRole,
+    ControlPlaneRollbackPlan, ControlPlaneRuntimeHealth, ControlPlaneServer,
+    ControlPlaneServerStatus, ControlPlaneSnapshot, ControlPlaneStore, ControlPlaneTool,
+    ControlPlaneTrustCard, ControlPlaneUser,
 };
 use crate::discovery::AutoDiscovery;
 use crate::discovery::shadow::{
@@ -28,9 +31,13 @@ use crate::discovery::shadow::{
 use crate::hashing::canonical_json_sha256;
 use crate::trust::TrustCard;
 
-/// Build the read-only control-plane API router.
+/// Build the control-plane API router: a read-only snapshot plus governance
+/// mutation routes (grants/policies) gated by RBAC + mandatory audit (MIK-6686).
 pub fn control_plane_router() -> Router<Arc<AppState>> {
-    Router::new().route("/ui/api/control-plane", get(control_plane_snapshot))
+    Router::new()
+        .route("/ui/api/control-plane", get(control_plane_snapshot))
+        .route("/ui/api/control-plane/grants", post(mutate_grant))
+        .route("/ui/api/control-plane/policies", post(mutate_policy))
 }
 
 async fn control_plane_snapshot(
@@ -55,8 +62,171 @@ async fn control_plane_snapshot(
         view,
         decision_queue,
         shadow_radar,
+        state.control_plane_store.is_some(),
     );
     Json(response).into_response()
+}
+
+/// Request body for a grant upsert mutation.
+#[derive(Debug, Deserialize)]
+struct GrantMutationRequest {
+    /// The grant to upsert (insert/replace).
+    grant: ControlPlaneGrant,
+    /// Reason (ticket id) for the audit trail.
+    reason: String,
+    /// Rollback plan recorded with the audit event.
+    rollback: ControlPlaneRollbackPlan,
+}
+
+/// Request body for a policy upsert mutation.
+#[derive(Debug, Deserialize)]
+struct PolicyMutationRequest {
+    /// The policy to upsert (insert/replace).
+    policy: ControlPlanePolicy,
+    /// Reason (ticket id) for the audit trail.
+    reason: String,
+    /// Rollback plan recorded with the audit event.
+    rollback: ControlPlaneRollbackPlan,
+}
+
+/// Result of a governance mutation.
+#[derive(Debug, Serialize)]
+struct MutationResponse {
+    ok: bool,
+    reason_code: String,
+    reason: String,
+}
+
+/// POST a grant upsert: RBAC plus mandatory audit via `validate_for_actor`,
+/// then persist to the control-plane store and append the audit event.
+async fn mutate_grant(
+    State(state): State<Arc<AppState>>,
+    client: Option<Extension<AuthenticatedClient>>,
+    Json(req): Json<GrantMutationRequest>,
+) -> impl IntoResponse {
+    let actor = actor_from_client(client.map(|Extension(c)| c).as_ref());
+    let target_id = req.grant.grant_id.clone();
+    apply_mutation(
+        state.control_plane_store.as_ref(),
+        &actor,
+        ControlPlaneAction::MutateGrant,
+        target_id,
+        format!("upsert grant {}", req.grant.grant_id),
+        req.reason,
+        req.rollback,
+        |store, event| store.commit_grant_audited(req.grant.clone(), event),
+    )
+}
+
+/// POST a policy upsert: same RBAC plus audit contract as [`mutate_grant`].
+async fn mutate_policy(
+    State(state): State<Arc<AppState>>,
+    client: Option<Extension<AuthenticatedClient>>,
+    Json(req): Json<PolicyMutationRequest>,
+) -> impl IntoResponse {
+    let actor = actor_from_client(client.map(|Extension(c)| c).as_ref());
+    let target_id = req.policy.policy_id.clone();
+    apply_mutation(
+        state.control_plane_store.as_ref(),
+        &actor,
+        ControlPlaneAction::MutatePolicy,
+        target_id,
+        format!("upsert policy {}", req.policy.policy_id),
+        req.reason,
+        req.rollback,
+        |store, event| store.commit_policy_audited(req.policy.clone(), event),
+    )
+}
+
+/// Shared mutation path: build the audited mutation, authorize it with
+/// `validate_for_actor`, then commit it as one audited unit (write-ahead audit
+/// plus persistence under a single lock, provided by the store).
+#[allow(clippy::too_many_arguments)]
+fn apply_mutation(
+    store: Option<&Arc<dyn ControlPlaneStore>>,
+    actor: &ControlPlaneActor,
+    action: ControlPlaneAction,
+    target_id: String,
+    summary: String,
+    reason: String,
+    rollback: ControlPlaneRollbackPlan,
+    commit: impl FnOnce(
+        &Arc<dyn ControlPlaneStore>,
+        &ControlPlaneAuditEvent,
+    ) -> Result<(), crate::control_plane::StoreError>,
+) -> axum::response::Response {
+    let Some(store) = store else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(MutationResponse {
+                ok: false,
+                reason_code: "CONTROL_STORE_UNAVAILABLE".to_string(),
+                reason: "Control-plane store is not configured".to_string(),
+            }),
+        )
+            .into_response();
+    };
+
+    // event_id embeds a millisecond timestamp, giving both a unique id and a
+    // coarse time for the audit trail (the hash chain provides ordering).
+    let event = ControlPlaneAuditEvent {
+        event_id: format!("cpa-{}-{target_id}", Utc::now().timestamp_millis()),
+        actor_id: actor.actor_id.clone(),
+        action,
+        target_id: target_id.clone(),
+        reason,
+        rollback,
+    };
+    let mutation = ControlPlaneMutation {
+        action,
+        target_id,
+        summary,
+        audit_event: Some(event.clone()),
+    };
+
+    let report = mutation.validate_for_actor(actor);
+    if !report.allowed {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(MutationResponse {
+                ok: false,
+                reason_code: report.reason_code,
+                reason: report.reason,
+            }),
+        )
+            .into_response();
+    }
+
+    // The store commits the write-ahead audit and the persistence as one
+    // serialized, ordered unit (see `commit_grant_audited`).
+    if let Err(e) = commit(store, &event) {
+        return internal_error("CONTROL_MUTATION_WRITE_FAILED", &e);
+    }
+
+    (
+        StatusCode::OK,
+        Json(MutationResponse {
+            ok: true,
+            reason_code: report.reason_code,
+            reason: report.reason,
+        }),
+    )
+        .into_response()
+}
+
+/// Log the underlying error server-side and return a generic client message, so
+/// filesystem paths and other internals are not leaked in the HTTP response.
+fn internal_error(code: &str, err: &crate::control_plane::StoreError) -> axum::response::Response {
+    tracing::error!(reason_code = code, error = %err, "control-plane mutation failed");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(MutationResponse {
+            ok: false,
+            reason_code: code.to_string(),
+            reason: "Control-plane mutation could not be persisted".to_string(),
+        }),
+    )
+        .into_response()
 }
 
 fn actor_from_client(client: Option<&AuthenticatedClient>) -> ControlPlaneActor {
@@ -289,13 +459,33 @@ impl ControlPlaneApiResponse {
         view: ControlPlaneReadOnlyView,
         decision_queue: ControlPlaneDecisionQueue,
         shadow_radar: ControlPlaneShadowRadar,
+        mutation_enabled: bool,
     ) -> Self {
         let coverage = snapshot.domain_coverage();
         let inventory_counts = ControlPlaneInventoryCounts::from_snapshot(snapshot, &shadow_radar);
+        let current_limits = if mutation_enabled {
+            vec![
+                "local_runtime_only",
+                "mutation_endpoint_active",
+                "no_enterprise_export",
+            ]
+        } else {
+            vec![
+                "read_only_api",
+                "local_runtime_only",
+                "no_persistence",
+                "no_mutation_endpoint",
+                "no_enterprise_export",
+            ]
+        };
         Self {
             schema_version: "control_plane.api.v1",
             source: "local_runtime_snapshot",
-            route: ControlPlaneRouteMode::default(),
+            route: ControlPlaneRouteMode {
+                read_only: !mutation_enabled,
+                mutation_endpoint: mutation_enabled,
+                mutating_actions_require_audit: true,
+            },
             features: feature_entitlements(),
             authorizations: ControlPlaneAuthorizationSet::for_actor(&actor),
             coverage,
@@ -305,13 +495,7 @@ impl ControlPlaneApiResponse {
             actor,
             view,
             decision_queue,
-            current_limits: vec![
-                "read_only_api",
-                "local_runtime_only",
-                "no_persistence",
-                "no_mutation_endpoint",
-                "no_enterprise_export",
-            ],
+            current_limits,
         }
     }
 }
@@ -542,5 +726,102 @@ mod grant_projection_tests {
             control_plane_grant_from_identity(g, Utc::now()).subject_id,
             "oidc:sub-123"
         );
+    }
+}
+
+#[cfg(test)]
+mod mutation_tests {
+    use super::apply_mutation;
+    use crate::control_plane::{
+        AuditFilter, ControlPlaneAction, ControlPlaneActor, ControlPlaneGrant,
+        ControlPlaneGrantStatus, ControlPlaneRole, ControlPlaneRollbackPlan, ControlPlaneStore,
+        InMemoryControlPlaneStore,
+    };
+    use axum::http::StatusCode;
+    use std::sync::Arc;
+
+    fn actor(role: ControlPlaneRole) -> ControlPlaneActor {
+        ControlPlaneActor {
+            actor_id: "gateway-client:tester".to_string(),
+            display_name: "tester".to_string(),
+            role,
+            group_ids: vec!["g".to_string()],
+        }
+    }
+
+    fn grant() -> ControlPlaneGrant {
+        ControlPlaneGrant {
+            grant_id: "grant-1".to_string(),
+            subject_id: "user-1".to_string(),
+            server_id: "srv-1".to_string(),
+            tool_id: None,
+            status: ControlPlaneGrantStatus::Approved,
+        }
+    }
+
+    fn rollback() -> ControlPlaneRollbackPlan {
+        ControlPlaneRollbackPlan {
+            summary: "revert".to_string(),
+            step: "restore prior grant".to_string(),
+        }
+    }
+
+    // MIK-6686.CP.2 — an admin mutation is authorized, persisted, and audited.
+    #[test]
+    fn admin_grant_mutation_persists_and_audits() {
+        let store: Arc<dyn ControlPlaneStore> = Arc::new(InMemoryControlPlaneStore::new());
+        let g = grant();
+        let resp = apply_mutation(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            ControlPlaneAction::MutateGrant,
+            g.grant_id.clone(),
+            "upsert".to_string(),
+            "MIK-1".to_string(),
+            rollback(),
+            |s, event| s.commit_grant_audited(g.clone(), event),
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(store.list_grants().unwrap().len(), 1);
+        let audit = store.read_audit(&AuditFilter::new(10)).unwrap();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].action, ControlPlaneAction::MutateGrant);
+        assert_eq!(audit[0].actor_id, "gateway-client:tester");
+    }
+
+    // MIK-6686.CP.2 — a non-admin is denied; nothing is persisted or audited.
+    #[test]
+    fn auditor_grant_mutation_is_denied_with_no_side_effects() {
+        let store: Arc<dyn ControlPlaneStore> = Arc::new(InMemoryControlPlaneStore::new());
+        let g = grant();
+        let resp = apply_mutation(
+            Some(&store),
+            &actor(ControlPlaneRole::Auditor),
+            ControlPlaneAction::MutateGrant,
+            g.grant_id.clone(),
+            "upsert".to_string(),
+            "MIK-1".to_string(),
+            rollback(),
+            |s, event| s.commit_grant_audited(g.clone(), event),
+        );
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(store.list_grants().unwrap().is_empty());
+        assert!(store.read_audit(&AuditFilter::new(10)).unwrap().is_empty());
+    }
+
+    // MIK-6686.CP.2 — with no store configured the route reports 503.
+    #[test]
+    fn mutation_without_store_returns_503() {
+        let resp = apply_mutation(
+            None,
+            &actor(ControlPlaneRole::Admin),
+            ControlPlaneAction::MutateGrant,
+            "grant-1".to_string(),
+            "upsert".to_string(),
+            "MIK-1".to_string(),
+            rollback(),
+            |_s, _event| Ok(()),
+        );
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -298,6 +298,14 @@ impl TransparencyLogger {
 
         writeln!(inner.writer, "{line}")?;
         inner.writer.flush()?;
+        // The synced path (governance audit) fsyncs for durability parity with
+        // the control-plane store's fsync'd collection writes, so a power loss
+        // cannot preserve a committed mutation while losing its audit record.
+        // The hot invocation path only flushes (fsync-per-entry there is too
+        // costly and its durability bar is lower).
+        if resync {
+            inner.writer.get_ref().sync_all()?;
+        }
 
         // ── Advance chain state only after the write succeeded ─────────────────
         inner.counter = counter;

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -129,6 +129,18 @@ impl TransparencyLogger {
 
         let file = OpenOptions::new().create(true).append(true).open(&path)?;
 
+        // Make the log file's directory entry durable, so a governance audit
+        // file created on the first append cannot be lost by a crash while a
+        // control-plane commit that depends on it is already durable. Unix only
+        // (opening a directory as a file is not portable); best-effort.
+        #[cfg(unix)]
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+            && let Ok(dir) = File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+
         Ok(Self {
             inner: Mutex::new(Inner {
                 writer: BufWriter::new(file),

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -109,6 +109,7 @@ async fn test_stdio_initialize_produces_valid_response() {
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     });
 
     // Call handle_initialize directly — this is what dispatch_single calls

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -96,6 +96,7 @@ fn make_app_state(cap_dir: Option<&str>, config_path: Option<std::path::PathBuf>
         #[cfg(feature = "firewall")]
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
     })
 }
 
@@ -162,6 +163,7 @@ fn make_app_state_with_reload(
             #[cfg(feature = "firewall")]
             firewall: None,
             agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
+            control_plane_store: None,
         }),
         live_config,
     )


### PR DESCRIPTION
## MIK-6686 (CP.2) — control-plane governance mutation routes

Wires live POST routes for grants and policies through `ControlPlaneMutation::validate_for_actor` (previously tested but unreachable), persisting to the MIK-6685 store with a mandatory audit trail. Part of epic MIK-6673.

### What landed
- `POST /ui/api/control-plane/grants` and `/policies`: resolve the actor, build an audited mutation, authorize with `validate_for_actor`, then commit. Denied requests return 403 with no side effects. `route.mutation_endpoint` flips true when a store is configured.
- `AppState` carries an optional `ControlPlaneStore`; the server opens a durable file-backed store + governance audit log at startup.

### AC (MIK-6686.CP.2)
- POST routes call `validate_for_actor` then commit to the CP.1 store — done
- `route.mutation_endpoint` flips true — done

### GPT adversarial review (DoD §12) — confirmed findings incorporated
- **Security**: store only built when auth is enabled, so an auth-disabled gateway (which treats callers as anonymous admin) does not expose a durable governance mutation surface — routes answer 503.
- **Audit integrity**: mutations go through a store-owned `commit_*_audited` holding one lock across a write-ahead, fsync'd audit append and the collection write. A committed change can never be unaudited, and audit order matches commit order under concurrent writers.
- **Path**: derived per config directory so distinct gateway instances do not share governance state.
- **Error hygiene**: responses no longer leak filesystem paths; detail is logged server-side.
- Deferred with follow-ups: `verify_log` HMAC authentication (MIK-6700); read API reflecting persisted store rows (MIK-6701).

A confirmation review pass verifying these fixes is recorded on the ticket before merge.

### Validation
`cargo test --all-features` green; `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt --check` clean. 27 control-plane tests including audited-commit + route allow/deny/503.

Advances MIK-6673. Depends on MIK-6685 (merged).
