### PR TITLE
control-plane: OIDC identity to role mapping, issuer-scoped (MIK-6688)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -94,6 +94,9 @@ pub struct Config {
     /// Plugin marketplace and local plugin directory.
     #[serde(default)]
     pub marketplace: MarketplaceConfig,
+    /// Enterprise control-plane governance (identity-to-role mapping, MIK-6688).
+    #[serde(default)]
+    pub control_plane: crate::control_plane::ControlPlaneConfig,
     /// Cost governance — per-tool budget enforcement and alerting.
     #[cfg(feature = "cost-governance")]
     #[serde(default)]
@@ -298,6 +301,7 @@ impl Config {
         self.validate_required_env_references()?;
         self.runtime.validate()?;
         self.validate_backend_runtime_profiles()?;
+        self.control_plane.role_mapping.validate()?;
         Ok(())
     }
 

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -6,8 +6,10 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod role_mapping;
 pub mod store;
 
+pub use role_mapping::{ControlPlaneConfig, ControlPlaneRoleMappingConfig, ControlPlaneRoleRule};
 pub use store::{
     AuditFilter, ControlPlaneStore, FileControlPlaneStore, InMemoryControlPlaneStore, StoreError,
     StoreResult,

--- a/src/control_plane/role_mapping.rs
+++ b/src/control_plane/role_mapping.rs
@@ -68,10 +68,12 @@ impl ControlPlaneRoleRule {
         if identity.issuer != self.issuer {
             return false;
         }
-        if let Some(group) = &self.group
-            && !identity.groups.iter().any(|g| g == group)
-        {
-            return false;
+        if let Some(group) = &self.group {
+            // Symmetric with email/domain: an empty rule group, or an empty
+            // identity group entry, must never match.
+            if group.is_empty() || !identity.groups.iter().any(|g| !g.is_empty() && g == group) {
+                return false;
+            }
         }
         if let Some(email) = &self.email {
             // An empty rule email (or a missing identity email) must never
@@ -354,6 +356,18 @@ mod tests {
         };
         let no_email = identity("https://idp.corp", "", &[]);
         assert!(!sneaky.matches(&no_email));
+
+        // Group parity: an empty rule group never matches, and an identity group
+        // entry that is empty cannot satisfy a group rule.
+        let sneaky_group = ControlPlaneRoleRule {
+            issuer: "https://idp.corp".to_string(),
+            group: Some(String::new()),
+            email: None,
+            domain: None,
+            role: ControlPlaneRole::Admin,
+        };
+        let empty_group_member = identity("https://idp.corp", "a@corp", &[""]);
+        assert!(!sneaky_group.matches(&empty_group_member));
     }
 
     // Email + domain discriminators, still issuer-scoped.

--- a/src/control_plane/role_mapping.rs
+++ b/src/control_plane/role_mapping.rs
@@ -1,0 +1,320 @@
+//! Map a verified identity (OIDC/SCIM) to a control-plane role (MIK-6688).
+//!
+//! Mirrors the key-server policy engine (issuer/email/domain/group match,
+//! first-match-wins) but with one hard rule: **every rule is issuer-scoped**.
+//! A group (or email/domain) match is only honoured together with the exact
+//! issuer, so a group name minted by one identity provider cannot map into a
+//! privileged role via a different provider (cross-IdP collision).
+//!
+//! Fallbacks (resolved by the caller, not here):
+//! - verified identity present but no rule matches -> `Auditor` (least privilege);
+//! - no verified identity / no mapping configured  -> legacy admin-key behaviour.
+//!
+//! Admin is grantable only by an explicit `role: admin` rule; there is no
+//! implicit path to Admin. Invalid config fails closed at load/reload.
+
+use serde::{Deserialize, Serialize};
+
+use crate::key_server::oidc::VerifiedIdentity;
+use crate::{Error, Result};
+
+use super::ControlPlaneRole;
+
+/// Control-plane configuration section.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ControlPlaneConfig {
+    /// Identity-to-role mapping for the governance surface.
+    pub role_mapping: ControlPlaneRoleMappingConfig,
+}
+
+/// Ordered, first-match-wins identity-to-role rules.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ControlPlaneRoleMappingConfig {
+    /// Rules evaluated in declaration order; the first match wins.
+    pub rules: Vec<ControlPlaneRoleRule>,
+}
+
+/// One issuer-scoped identity-to-role rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlPlaneRoleRule {
+    /// Exact OIDC issuer URL. **Required** — the rule only fires for this
+    /// issuer, which blocks cross-provider group-name collisions.
+    pub issuer: String,
+    /// Optional group membership discriminator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    /// Optional exact email discriminator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Optional email-domain discriminator (e.g. `"company.com"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// Role granted when the rule matches.
+    pub role: ControlPlaneRole,
+}
+
+impl ControlPlaneRoleRule {
+    /// True when `identity` satisfies this rule: the issuer must match exactly
+    /// AND every present discriminator must match.
+    fn matches(&self, identity: &VerifiedIdentity) -> bool {
+        if identity.issuer != self.issuer {
+            return false;
+        }
+        if let Some(group) = &self.group
+            && !identity.groups.iter().any(|g| g == group)
+        {
+            return false;
+        }
+        if let Some(email) = &self.email
+            && &identity.email != email
+        {
+            return false;
+        }
+        if let Some(domain) = &self.domain {
+            let email_domain = identity.email.split('@').next_back().unwrap_or("");
+            if email_domain != domain {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl ControlPlaneRoleMappingConfig {
+    /// Validate the mapping, failing closed on any unusable rule.
+    ///
+    /// Each rule must carry a non-empty issuer AND at least one discriminator
+    /// (group/email/domain). A rule with no discriminator would map every
+    /// identity from an issuer to a role — too broad to allow implicitly,
+    /// especially for Admin.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigValidation`] describing the first offending rule.
+    pub fn validate(&self) -> Result<()> {
+        for (i, rule) in self.rules.iter().enumerate() {
+            if rule.issuer.trim().is_empty() {
+                return Err(Error::ConfigValidation(format!(
+                    "control_plane.role_mapping rule {i} must set a non-empty issuer \
+                     (issuer-scoped rules block cross-provider role escalation)"
+                )));
+            }
+            let has_discriminator =
+                rule.group.is_some() || rule.email.is_some() || rule.domain.is_some();
+            if !has_discriminator {
+                return Err(Error::ConfigValidation(format!(
+                    "control_plane.role_mapping rule {i} (issuer '{}') must set at least one of \
+                     group/email/domain; an issuer-only rule maps every identity to '{:?}'",
+                    rule.issuer, rule.role
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve the role for `identity` using first-match-wins. Returns `None`
+    /// when no rule matches (the caller applies the least-privilege fallback).
+    #[must_use]
+    pub fn resolve_role(&self, identity: &VerifiedIdentity) -> Option<ControlPlaneRole> {
+        self.rules
+            .iter()
+            .find(|rule| rule.matches(identity))
+            .map(|rule| rule.role)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(issuer: &str, email: &str, groups: &[&str]) -> VerifiedIdentity {
+        VerifiedIdentity {
+            subject: "sub-1".to_string(),
+            email: email.to_string(),
+            name: None,
+            groups: groups.iter().map(|g| (*g).to_string()).collect(),
+            issuer: issuer.to_string(),
+        }
+    }
+
+    fn rule(
+        issuer: &str,
+        group: Option<&str>,
+        email: Option<&str>,
+        domain: Option<&str>,
+        role: ControlPlaneRole,
+    ) -> ControlPlaneRoleRule {
+        ControlPlaneRoleRule {
+            issuer: issuer.to_string(),
+            group: group.map(str::to_string),
+            email: email.map(str::to_string),
+            domain: domain.map(str::to_string),
+            role,
+        }
+    }
+
+    // MIK-6688.ROLE.1 — issuer-scoped group rule maps to a specific role.
+    #[test]
+    fn issuer_scoped_group_maps_to_role() {
+        let m = ControlPlaneRoleMappingConfig {
+            rules: vec![
+                rule(
+                    "https://idp.corp",
+                    Some("sec-review"),
+                    None,
+                    None,
+                    ControlPlaneRole::SecurityReviewer,
+                ),
+                rule(
+                    "https://idp.corp",
+                    Some("devs"),
+                    None,
+                    None,
+                    ControlPlaneRole::Developer,
+                ),
+                rule(
+                    "https://idp.corp",
+                    Some("cp-admins"),
+                    None,
+                    None,
+                    ControlPlaneRole::Admin,
+                ),
+            ],
+        };
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "a@corp", &["sec-review"])),
+            Some(ControlPlaneRole::SecurityReviewer)
+        );
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "a@corp", &["cp-admins"])),
+            Some(ControlPlaneRole::Admin)
+        );
+    }
+
+    // MIK-6688.ROLE.2 — no matching rule -> None (caller defaults to Auditor).
+    // First-match-wins order is honoured.
+    #[test]
+    fn no_match_returns_none_and_first_match_wins() {
+        let m = ControlPlaneRoleMappingConfig {
+            rules: vec![
+                rule(
+                    "https://idp.corp",
+                    Some("multi"),
+                    None,
+                    None,
+                    ControlPlaneRole::Developer,
+                ),
+                rule(
+                    "https://idp.corp",
+                    Some("multi"),
+                    None,
+                    None,
+                    ControlPlaneRole::Admin,
+                ),
+            ],
+        };
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "a@corp", &["other"])),
+            None
+        );
+        // Identity in "multi" matches both rules; the first (Developer) wins.
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "a@corp", &["multi"])),
+            Some(ControlPlaneRole::Developer)
+        );
+    }
+
+    // MIK-6688.ROLE.4 — the same group name from a DIFFERENT issuer does not match.
+    #[test]
+    fn cross_idp_group_collision_is_blocked() {
+        let m = ControlPlaneRoleMappingConfig {
+            rules: vec![rule(
+                "https://trusted.idp",
+                Some("cp-admins"),
+                None,
+                None,
+                ControlPlaneRole::Admin,
+            )],
+        };
+        // Same group name, attacker-controlled issuer -> no match.
+        assert_eq!(
+            m.resolve_role(&identity("https://evil.idp", "a@evil", &["cp-admins"])),
+            None
+        );
+        // Correct issuer -> match.
+        assert_eq!(
+            m.resolve_role(&identity("https://trusted.idp", "a@corp", &["cp-admins"])),
+            Some(ControlPlaneRole::Admin)
+        );
+    }
+
+    // MIK-6688.ROLE.5 — invalid config fails closed: issuer-less and
+    // discriminator-less rules are rejected.
+    #[test]
+    fn invalid_config_fails_closed() {
+        let no_issuer = ControlPlaneRoleMappingConfig {
+            rules: vec![rule("", Some("g"), None, None, ControlPlaneRole::Auditor)],
+        };
+        assert!(no_issuer.validate().is_err());
+
+        let no_discriminator = ControlPlaneRoleMappingConfig {
+            rules: vec![rule(
+                "https://idp.corp",
+                None,
+                None,
+                None,
+                ControlPlaneRole::Admin,
+            )],
+        };
+        assert!(no_discriminator.validate().is_err());
+
+        let ok = ControlPlaneRoleMappingConfig {
+            rules: vec![rule(
+                "https://idp.corp",
+                None,
+                None,
+                Some("corp"),
+                ControlPlaneRole::Developer,
+            )],
+        };
+        assert!(ok.validate().is_ok());
+    }
+
+    // Email + domain discriminators, still issuer-scoped.
+    #[test]
+    fn email_and_domain_discriminators() {
+        let m = ControlPlaneRoleMappingConfig {
+            rules: vec![
+                rule(
+                    "https://idp.corp",
+                    None,
+                    Some("boss@corp.com"),
+                    None,
+                    ControlPlaneRole::Admin,
+                ),
+                rule(
+                    "https://idp.corp",
+                    None,
+                    None,
+                    Some("corp.com"),
+                    ControlPlaneRole::Developer,
+                ),
+            ],
+        };
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "boss@corp.com", &[])),
+            Some(ControlPlaneRole::Admin)
+        );
+        assert_eq!(
+            m.resolve_role(&identity("https://idp.corp", "staff@corp.com", &[])),
+            Some(ControlPlaneRole::Developer)
+        );
+        // Right domain, wrong issuer -> no match.
+        assert_eq!(
+            m.resolve_role(&identity("https://other.idp", "staff@corp.com", &[])),
+            None
+        );
+    }
+}

--- a/src/control_plane/role_mapping.rs
+++ b/src/control_plane/role_mapping.rs
@@ -29,6 +29,12 @@ pub struct ControlPlaneConfig {
 }
 
 /// Ordered, first-match-wins identity-to-role rules.
+///
+/// NOTE: changes to the mapping are applied at gateway startup; they are not
+/// hot-reloaded today. To revoke a role (e.g. remove a `role: admin` rule),
+/// restart the gateway — a `/reload` does not yet re-apply this section
+/// (tracked as a follow-up). The mapping is still validated fail-closed on
+/// every load/reload, so an invalid change is always rejected.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ControlPlaneRoleMappingConfig {
@@ -67,14 +73,17 @@ impl ControlPlaneRoleRule {
         {
             return false;
         }
-        if let Some(email) = &self.email
-            && &identity.email != email
-        {
-            return false;
+        if let Some(email) = &self.email {
+            // An empty rule email (or a missing identity email) must never
+            // match: a token with no `email` claim resolves to "" and must not
+            // satisfy an email discriminator.
+            if email.is_empty() || identity.email.is_empty() || &identity.email != email {
+                return false;
+            }
         }
         if let Some(domain) = &self.domain {
             let email_domain = identity.email.split('@').next_back().unwrap_or("");
-            if email_domain != domain {
+            if domain.is_empty() || email_domain.is_empty() || email_domain != domain {
                 return false;
             }
         }
@@ -100,6 +109,24 @@ impl ControlPlaneRoleMappingConfig {
                     "control_plane.role_mapping rule {i} must set a non-empty issuer \
                      (issuer-scoped rules block cross-provider role escalation)"
                 )));
+            }
+            // A discriminator that is present but empty/whitespace is rejected:
+            // an empty `email`/`domain` would otherwise match a token that has
+            // no email claim (email == ""), silently widening the rule.
+            for (field, value) in [
+                ("group", &rule.group),
+                ("email", &rule.email),
+                ("domain", &rule.domain),
+            ] {
+                if let Some(v) = value
+                    && v.trim().is_empty()
+                {
+                    return Err(Error::ConfigValidation(format!(
+                        "control_plane.role_mapping rule {i} (issuer '{}') has an empty '{field}' \
+                         discriminator; omit it or give it a non-empty value",
+                        rule.issuer
+                    )));
+                }
             }
             let has_discriminator =
                 rule.group.is_some() || rule.email.is_some() || rule.domain.is_some();
@@ -280,6 +307,53 @@ mod tests {
             )],
         };
         assert!(ok.validate().is_ok());
+    }
+
+    // MIK-6688.ROLE.5 — an empty discriminator is rejected: an empty email/domain
+    // would otherwise match a token with a missing email claim (email == "").
+    #[test]
+    fn empty_discriminator_rejected_and_missing_email_never_matches() {
+        for bad in [
+            rule(
+                "https://idp.corp",
+                None,
+                Some(""),
+                None,
+                ControlPlaneRole::Admin,
+            ),
+            rule(
+                "https://idp.corp",
+                None,
+                None,
+                Some("  "),
+                ControlPlaneRole::Admin,
+            ),
+            rule(
+                "https://idp.corp",
+                Some(""),
+                None,
+                None,
+                ControlPlaneRole::Admin,
+            ),
+        ] {
+            let m = ControlPlaneRoleMappingConfig { rules: vec![bad] };
+            assert!(
+                m.validate().is_err(),
+                "empty discriminator must be rejected"
+            );
+        }
+
+        // Defense in depth: even if an empty-email rule existed, a token with no
+        // email claim must not match it.
+        let sneaky = ControlPlaneRoleRule {
+            issuer: "https://idp.corp".to_string(),
+            group: None,
+            email: Some(String::new()),
+            domain: None,
+            role: ControlPlaneRole::Admin,
+        };
+        let no_email = identity("https://idp.corp", "", &[]);
+        assert!(!sneaky.matches(&no_email));
     }
 
     // Email + domain discriminators, still issuer-scoped.

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -15,7 +15,7 @@ use super::proxy::ProxyManager;
 use super::streaming::NotificationMultiplexer;
 use crate::backend::BackendRegistry;
 use crate::config::{AgentIdentityConfig, StreamingConfig};
-use crate::control_plane::ControlPlaneStore;
+use crate::control_plane::{ControlPlaneRoleMappingConfig, ControlPlaneStore};
 use crate::key_server::{KeyServer, handler::key_server_routes};
 use crate::mtls::MtlsPolicy;
 use crate::security::ToolPolicy;
@@ -84,6 +84,9 @@ pub struct AppState {
     /// `None` when the control-plane data directory could not be opened, in
     /// which case governance mutation routes return 503 (MIK-6686).
     pub control_plane_store: Option<Arc<dyn ControlPlaneStore>>,
+    /// Identity-to-role mapping for the control-plane governance surface
+    /// (MIK-6688). Empty by default (legacy admin-key projection applies).
+    pub control_plane_role_mapping: Arc<ControlPlaneRoleMappingConfig>,
 }
 
 /// Create the router.

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -65,6 +65,9 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 
@@ -108,6 +111,9 @@ fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 
@@ -147,6 +153,9 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 
@@ -195,6 +204,9 @@ fn test_router_app_state_with_ssrf(
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 
@@ -251,6 +263,9 @@ fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -791,6 +791,7 @@ impl Gateway {
             firewall: firewall_arc,
             agent_identity_config: self.config.security.agent_identity.clone(),
             control_plane_store,
+            control_plane_role_mapping: Arc::new(self.config.control_plane.role_mapping.clone()),
         });
 
         // Create router

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -19,9 +19,9 @@ use crate::control_plane::{
     ControlPlaneDecisionQueue, ControlPlaneDomainCoverage, ControlPlaneFeature, ControlPlaneGrant,
     ControlPlaneGrantStatus, ControlPlaneHealth, ControlPlaneLicenseTier, ControlPlaneMutation,
     ControlPlanePolicy, ControlPlaneRbac, ControlPlaneReadOnlyView, ControlPlaneRole,
-    ControlPlaneRollbackPlan, ControlPlaneRuntimeHealth, ControlPlaneServer,
-    ControlPlaneServerStatus, ControlPlaneSnapshot, ControlPlaneStore, ControlPlaneTool,
-    ControlPlaneTrustCard, ControlPlaneUser,
+    ControlPlaneRoleMappingConfig, ControlPlaneRollbackPlan, ControlPlaneRuntimeHealth,
+    ControlPlaneServer, ControlPlaneServerStatus, ControlPlaneSnapshot, ControlPlaneStore,
+    ControlPlaneTool, ControlPlaneTrustCard, ControlPlaneUser,
 };
 use crate::discovery::AutoDiscovery;
 use crate::discovery::shadow::{
@@ -29,6 +29,7 @@ use crate::discovery::shadow::{
     ShadowEnterpriseBoundary, ShadowScanReport, ShadowScanSummary,
 };
 use crate::hashing::canonical_json_sha256;
+use crate::key_server::oidc::VerifiedIdentity;
 use crate::trust::TrustCard;
 
 /// Build the control-plane API router: a read-only snapshot plus governance
@@ -43,9 +44,15 @@ pub fn control_plane_router() -> Router<Arc<AppState>> {
 async fn control_plane_snapshot(
     State(state): State<Arc<AppState>>,
     client: Option<Extension<AuthenticatedClient>>,
+    identity: Option<Extension<VerifiedIdentity>>,
 ) -> impl IntoResponse {
     let client = client.map(|Extension(client)| client);
-    let actor = actor_from_client(client.as_ref());
+    let identity = identity.map(|Extension(id)| id);
+    let actor = actor_from_client(
+        client.as_ref(),
+        identity.as_ref(),
+        &state.control_plane_role_mapping,
+    );
     let snapshot = local_runtime_snapshot(&state, client.as_ref(), &actor);
     let shadow_radar = local_shadow_radar(&state).await;
 
@@ -102,9 +109,14 @@ struct MutationResponse {
 async fn mutate_grant(
     State(state): State<Arc<AppState>>,
     client: Option<Extension<AuthenticatedClient>>,
+    identity: Option<Extension<VerifiedIdentity>>,
     Json(req): Json<GrantMutationRequest>,
 ) -> impl IntoResponse {
-    let actor = actor_from_client(client.map(|Extension(c)| c).as_ref());
+    let actor = actor_from_client(
+        client.map(|Extension(c)| c).as_ref(),
+        identity.map(|Extension(id)| id).as_ref(),
+        &state.control_plane_role_mapping,
+    );
     let target_id = req.grant.grant_id.clone();
     apply_mutation(
         state.control_plane_store.as_ref(),
@@ -122,9 +134,14 @@ async fn mutate_grant(
 async fn mutate_policy(
     State(state): State<Arc<AppState>>,
     client: Option<Extension<AuthenticatedClient>>,
+    identity: Option<Extension<VerifiedIdentity>>,
     Json(req): Json<PolicyMutationRequest>,
 ) -> impl IntoResponse {
-    let actor = actor_from_client(client.map(|Extension(c)| c).as_ref());
+    let actor = actor_from_client(
+        client.map(|Extension(c)| c).as_ref(),
+        identity.map(|Extension(id)| id).as_ref(),
+        &state.control_plane_role_mapping,
+    );
     let target_id = req.policy.policy_id.clone();
     apply_mutation(
         state.control_plane_store.as_ref(),
@@ -229,7 +246,30 @@ fn internal_error(code: &str, err: &crate::control_plane::StoreError) -> axum::r
         .into_response()
 }
 
-fn actor_from_client(client: Option<&AuthenticatedClient>) -> ControlPlaneActor {
+/// Resolve the control-plane actor.
+///
+/// When a verified identity is present, the role comes from the issuer-scoped
+/// role mapping (MIK-6688); an identity that matches no rule gets `Auditor`
+/// (least privilege). With no verified identity, the legacy admin-key
+/// projection applies (admin key -> Admin, else Auditor) — backward compatible.
+fn actor_from_client(
+    client: Option<&AuthenticatedClient>,
+    identity: Option<&VerifiedIdentity>,
+    role_mapping: &ControlPlaneRoleMappingConfig,
+) -> ControlPlaneActor {
+    if let Some(id) = identity {
+        let role = role_mapping
+            .resolve_role(id)
+            .unwrap_or(ControlPlaneRole::Auditor);
+        let display_name = id.name.clone().unwrap_or_else(|| id.email.clone());
+        return ControlPlaneActor {
+            actor_id: format!("oidc:{}:{}", id.issuer, id.subject),
+            display_name,
+            role,
+            group_ids: id.groups.clone(),
+        };
+    }
+
     let (name, role, group_id) = match client {
         Some(client) if client.admin => (
             client.name.clone(),
@@ -823,5 +863,87 @@ mod mutation_tests {
             |_s, _event| Ok(()),
         );
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}
+
+#[cfg(test)]
+mod role_wiring_tests {
+    use super::actor_from_client;
+    use crate::control_plane::{
+        ControlPlaneAction, ControlPlaneRbac, ControlPlaneRole, ControlPlaneRoleMappingConfig,
+        ControlPlaneRoleRule,
+    };
+    use crate::gateway::auth::AuthenticatedClient;
+    use crate::key_server::oidc::VerifiedIdentity;
+
+    fn client(admin: bool) -> AuthenticatedClient {
+        AuthenticatedClient {
+            name: "c".to_string(),
+            rate_limit: 0,
+            backends: Vec::new(),
+            allowed_tools: None,
+            denied_tools: None,
+            admin,
+        }
+    }
+
+    fn identity(issuer: &str, groups: &[&str]) -> VerifiedIdentity {
+        VerifiedIdentity {
+            subject: "s".to_string(),
+            email: "a@corp".to_string(),
+            name: None,
+            groups: groups.iter().map(|g| (*g).to_string()).collect(),
+            issuer: issuer.to_string(),
+        }
+    }
+
+    // MIK-6688.ROLE.3 — no verified identity -> legacy admin-key projection.
+    #[test]
+    fn no_identity_uses_legacy_admin_key_projection() {
+        let empty = ControlPlaneRoleMappingConfig::default();
+        assert_eq!(
+            actor_from_client(Some(&client(true)), None, &empty).role,
+            ControlPlaneRole::Admin
+        );
+        assert_eq!(
+            actor_from_client(Some(&client(false)), None, &empty).role,
+            ControlPlaneRole::Auditor
+        );
+        assert_eq!(
+            actor_from_client(None, None, &empty).role,
+            ControlPlaneRole::Auditor
+        );
+    }
+
+    // MIK-6688.ROLE.2 — a verified identity with no matching rule is Auditor,
+    // even when an admin API key is also present (identity path wins).
+    #[test]
+    fn verified_identity_without_rule_is_auditor_not_admin() {
+        let empty = ControlPlaneRoleMappingConfig::default();
+        let actor = actor_from_client(
+            Some(&client(true)),
+            Some(&identity("https://idp", &["x"])),
+            &empty,
+        );
+        assert_eq!(actor.role, ControlPlaneRole::Auditor);
+        assert_eq!(actor.actor_id, "oidc:https://idp:s");
+    }
+
+    // MIK-6688.ROLE.6 — a mapped SecurityReviewer can read evidence but cannot mutate.
+    #[test]
+    fn mapped_security_reviewer_reads_but_cannot_mutate() {
+        let mapping = ControlPlaneRoleMappingConfig {
+            rules: vec![ControlPlaneRoleRule {
+                issuer: "https://idp".to_string(),
+                group: Some("sec".to_string()),
+                email: None,
+                domain: None,
+                role: ControlPlaneRole::SecurityReviewer,
+            }],
+        };
+        let actor = actor_from_client(None, Some(&identity("https://idp", &["sec"])), &mapping);
+        assert_eq!(actor.role, ControlPlaneRole::SecurityReviewer);
+        assert!(ControlPlaneRbac::authorize(&actor, ControlPlaneAction::ReadEvidence).allowed);
+        assert!(!ControlPlaneRbac::authorize(&actor, ControlPlaneAction::MutateGrant).allowed);
     }
 }

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -110,6 +110,9 @@ async fn test_stdio_initialize_produces_valid_response() {
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     });
 
     // Call handle_initialize directly — this is what dispatch_single calls

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -97,6 +97,9 @@ fn make_app_state(cap_dir: Option<&str>, config_path: Option<std::path::PathBuf>
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
         control_plane_store: None,
+        control_plane_role_mapping: std::sync::Arc::new(
+            mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
+        ),
     })
 }
 
@@ -164,6 +167,9 @@ fn make_app_state_with_reload(
             firewall: None,
             agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
             control_plane_store: None,
+            control_plane_role_mapping: std::sync::Arc::new(
+                mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
+            ),
         }),
         live_config,
     )


### PR DESCRIPTION
## MIK-6688 (CP.4) — OIDC identity → control-plane role, issuer-scoped

Sources the control-plane actor's role from verified identity instead of the hardcoded admin-bool → Admin/Auditor projection. Reuses the merged MIK-6648 OIDC `VerifiedIdentity` (subject/email/groups/issuer). Part of epic MIK-6673.

### What landed
- New `control_plane.role_mapping` config: an ordered, first-match-wins rule list. Each rule is **issuer-scoped** (issuer required) and matches on group/email/domain, so a group name minted by one identity provider cannot map into a privileged role via a different provider (cross-provider collision blocked).
- Resolver + fail-closed validation: a rule with no issuer, or with no group/email/domain discriminator, is rejected at config load/reload. Admin is grantable only by an explicit `role: admin` rule.
- `actor_from_client` consumes the verified identity + mapping:
  - identity present, rule matches → mapped role
  - identity present, no rule → Auditor (least privilege)
  - no identity → legacy admin-key projection (backward compatible)
- RBAC authorizes per mapped role (SecurityReviewer reads evidence, cannot mutate) — verified end to end.

### AC (MIK-6688.ROLE.1–6)
- ROLE.1 issuer-scoped group→role — done
- ROLE.2 no-match → Auditor, first-match-wins — done
- ROLE.3 no identity → legacy behavior (backward compatible) — done
- ROLE.4 cross-provider group-name collision blocked — done
- ROLE.5 invalid config fails closed at load/reload — done
- ROLE.6 RBAC authorizes per mapped role — done

### Validation
`cargo test --lib` green (3134 passed); `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt --check` clean. Resolver unit tests + actor/RBAC wiring tests.

A GPT adversarial review (DoD §12) runs against this change; confirmed findings will be incorporated before merge, with the verdict recorded on the ticket.

Advances MIK-6673. Depends on MIK-6648 (merged).
