### PR TITLE
control-plane: actionable decision queue via mutation+audit path (MIK-6687)

### DIFF
--- a/src/control_plane/store.rs
+++ b/src/control_plane/store.rs
@@ -37,8 +37,8 @@ use std::sync::{Arc, Mutex};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::control_plane::{
-    ControlPlaneAction, ControlPlaneAuditEvent, ControlPlaneGrant, ControlPlanePolicy,
-    ControlPlaneRollbackPlan,
+    ControlPlaneAction, ControlPlaneAuditEvent, ControlPlaneGrant, ControlPlaneGrantStatus,
+    ControlPlanePolicy, ControlPlaneRollbackPlan,
 };
 use crate::security::TransparencyLogger;
 
@@ -236,6 +236,47 @@ pub trait ControlPlaneStore: Send + Sync {
     ) -> StoreResult<()> {
         self.append_audit(event)?;
         self.put_policy(policy)
+    }
+
+    /// Apply a status change to one grant as an audited unit WITHOUT overwriting
+    /// its other fields. Returns `false` when no grant with `grant_id` exists
+    /// (so callers can 404 without writing an audit record). Durable backends
+    /// override to re-read the row under the lock, so a concurrent edit to other
+    /// fields is not lost — unlike [`Self::commit_grant_audited`], which
+    /// replaces the whole row with the caller's copy.
+    ///
+    /// # Errors
+    /// Errors on an I/O failure, a serialisation failure, a corrupt collection.
+    fn set_grant_status_audited(
+        &self,
+        grant_id: &str,
+        status: ControlPlaneGrantStatus,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<bool> {
+        let Some(mut grant) = self.get_grant(grant_id)? else {
+            return Ok(false);
+        };
+        grant.status = status;
+        self.commit_grant_audited(grant, event)?;
+        Ok(true)
+    }
+
+    /// Policy counterpart of [`Self::set_grant_status_audited`] (sets `enforced`).
+    ///
+    /// # Errors
+    /// Errors on an I/O failure, a serialisation failure, a corrupt collection.
+    fn set_policy_enforced_audited(
+        &self,
+        policy_id: &str,
+        enforced: bool,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<bool> {
+        let Some(mut policy) = self.get_policy(policy_id)? else {
+            return Ok(false);
+        };
+        policy.enforced = enforced;
+        self.commit_policy_audited(policy, event)?;
+        Ok(true)
     }
 }
 
@@ -518,10 +559,10 @@ impl FileControlPlaneStore {
 
     /// Optimistic read-modify-write against a collection: load, apply `mutate`,
     /// then compare-and-swap; retry from a fresh read if a stale write loses.
-    fn mutate<T, F>(&self, file: &Path, mutate: F) -> StoreResult<()>
+    fn mutate<T, F>(&self, file: &Path, mut mutate: F) -> StoreResult<()>
     where
         T: Serialize + DeserializeOwned,
-        F: Fn(&mut Vec<T>),
+        F: FnMut(&mut Vec<T>),
     {
         loop {
             let mut current = Self::load::<T>(file)?;
@@ -639,6 +680,60 @@ impl ControlPlaneStore for FileControlPlaneStore {
                 items.push(policy.clone());
             }
         })
+    }
+
+    fn set_grant_status_audited(
+        &self,
+        grant_id: &str,
+        status: ControlPlaneGrantStatus,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<bool> {
+        let _lock = ExclusiveFileLock::acquire(&self.dir.join(".audit.lock"))?;
+        // Existence check under the lock, so a missing target 404s without
+        // writing a spurious audit record.
+        if !Self::load::<ControlPlaneGrant>(&self.grants_file())?
+            .items
+            .iter()
+            .any(|g| g.grant_id == grant_id)
+        {
+            return Ok(false);
+        }
+        self.append_audit_locked(event)?;
+        // Re-read + mutate ONLY the status field on the current row, so a
+        // concurrent edit to other fields is preserved (no stale-clone stomp).
+        let mut applied = false;
+        self.mutate::<ControlPlaneGrant, _>(&self.grants_file(), |items| {
+            if let Some(g) = items.iter_mut().find(|g| g.grant_id == grant_id) {
+                g.status = status;
+                applied = true;
+            }
+        })?;
+        Ok(applied)
+    }
+
+    fn set_policy_enforced_audited(
+        &self,
+        policy_id: &str,
+        enforced: bool,
+        event: &ControlPlaneAuditEvent,
+    ) -> StoreResult<bool> {
+        let _lock = ExclusiveFileLock::acquire(&self.dir.join(".audit.lock"))?;
+        if !Self::load::<ControlPlanePolicy>(&self.policies_file())?
+            .items
+            .iter()
+            .any(|p| p.policy_id == policy_id)
+        {
+            return Ok(false);
+        }
+        self.append_audit_locked(event)?;
+        let mut applied = false;
+        self.mutate::<ControlPlanePolicy, _>(&self.policies_file(), |items| {
+            if let Some(p) = items.iter_mut().find(|p| p.policy_id == policy_id) {
+                p.enforced = enforced;
+                applied = true;
+            }
+        })?;
+        Ok(applied)
     }
 
     fn read_audit(&self, filter: &AuditFilter) -> StoreResult<Vec<ControlPlaneAuditEvent>> {
@@ -1252,5 +1347,47 @@ mod tests {
             "audit chain must verify: {:?}",
             result.error_message
         );
+    }
+
+    // MIK-6687.CP.3 — set_grant_status_audited flips ONLY the status and
+    // preserves other fields (no stale-clone lost update), audits the change,
+    // and returns false (no audit) for a missing target.
+    #[test]
+    fn set_grant_status_audited_is_field_only_and_audited() {
+        let dir = tempfile::tempdir().unwrap();
+        let logger = governance_logger(dir.path());
+        let store =
+            FileControlPlaneStore::open(dir.path().join("store"), Arc::clone(&logger)).unwrap();
+
+        // Seed g1, then a concurrent edit changes a NON-status field.
+        store
+            .put_grant(grant("g1", ControlPlaneGrantStatus::Requested))
+            .unwrap();
+        let mut edited = grant("g1", ControlPlaneGrantStatus::Requested);
+        edited.subject_id = "user-CHANGED".to_string();
+        store.put_grant(edited).unwrap();
+
+        // A decision flips status; the concurrent field edit must survive.
+        let ev = audit_event("d1", "alice", ControlPlaneAction::MutateGrant);
+        assert!(
+            store
+                .set_grant_status_audited("g1", ControlPlaneGrantStatus::Approved, &ev)
+                .unwrap()
+        );
+        let g = store.get_grant("g1").unwrap().unwrap();
+        assert_eq!(g.status, ControlPlaneGrantStatus::Approved);
+        assert_eq!(
+            g.subject_id, "user-CHANGED",
+            "non-status field must be preserved"
+        );
+        assert_eq!(store.read_audit(&AuditFilter::new(10)).unwrap().len(), 1);
+
+        // Missing target -> false, and NO extra audit entry is written.
+        assert!(
+            !store
+                .set_grant_status_audited("absent", ControlPlaneGrantStatus::Revoked, &ev)
+                .unwrap()
+        );
+        assert_eq!(store.read_audit(&AuditFilter::new(10)).unwrap().len(), 1);
     }
 }

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -16,12 +16,13 @@ use super::super::router::AppState;
 use super::errors::auth_required;
 use crate::control_plane::{
     ControlPlaneAction, ControlPlaneActor, ControlPlaneAuditEvent, ControlPlaneAuthorization,
-    ControlPlaneDecisionQueue, ControlPlaneDomainCoverage, ControlPlaneFeature, ControlPlaneGrant,
-    ControlPlaneGrantStatus, ControlPlaneHealth, ControlPlaneLicenseTier, ControlPlaneMutation,
-    ControlPlanePolicy, ControlPlaneRbac, ControlPlaneReadOnlyView, ControlPlaneRole,
-    ControlPlaneRoleMappingConfig, ControlPlaneRollbackPlan, ControlPlaneRuntimeHealth,
-    ControlPlaneServer, ControlPlaneServerStatus, ControlPlaneSnapshot, ControlPlaneStore,
-    ControlPlaneTool, ControlPlaneTrustCard, ControlPlaneUser,
+    ControlPlaneDecisionQueue, ControlPlaneDecisionTargetKind, ControlPlaneDomainCoverage,
+    ControlPlaneFeature, ControlPlaneGrant, ControlPlaneGrantStatus, ControlPlaneHealth,
+    ControlPlaneLicenseTier, ControlPlaneMutation, ControlPlanePolicy, ControlPlaneRbac,
+    ControlPlaneReadOnlyView, ControlPlaneRole, ControlPlaneRoleMappingConfig,
+    ControlPlaneRollbackPlan, ControlPlaneRuntimeHealth, ControlPlaneServer,
+    ControlPlaneServerStatus, ControlPlaneSnapshot, ControlPlaneStore, ControlPlaneTool,
+    ControlPlaneTrustCard, ControlPlaneUser,
 };
 use crate::discovery::AutoDiscovery;
 use crate::discovery::shadow::{
@@ -39,6 +40,7 @@ pub fn control_plane_router() -> Router<Arc<AppState>> {
         .route("/ui/api/control-plane", get(control_plane_snapshot))
         .route("/ui/api/control-plane/grants", post(mutate_grant))
         .route("/ui/api/control-plane/policies", post(mutate_policy))
+        .route("/ui/api/control-plane/decisions", post(resolve_decision))
 }
 
 async fn control_plane_snapshot(
@@ -153,6 +155,140 @@ async fn mutate_policy(
         req.rollback,
         |store, event| store.commit_policy_audited(req.policy.clone(), event),
     )
+}
+
+/// Approve/deny decision on a queued item.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum Decision {
+    Approve,
+    Deny,
+}
+
+/// Request body for resolving a decision-queue item.
+#[derive(Debug, Deserialize)]
+struct DecisionRequest {
+    /// Kind of the queued item (only `grant`/`policy` are actionable today).
+    target_kind: ControlPlaneDecisionTargetKind,
+    /// Id of the grant/policy the decision resolves.
+    target_id: String,
+    /// Approve or deny.
+    decision: Decision,
+    /// Reason (ticket id) for the audit trail.
+    reason: String,
+    /// Rollback plan recorded with the audit event.
+    rollback: ControlPlaneRollbackPlan,
+}
+
+/// POST a decision on a queued item: load the target grant/policy, apply the
+/// approve/deny effect, and route it through the SAME `validate_for_actor` +
+/// audited-commit path as a direct mutation (MIK-6687). Items whose kind has no
+/// durable store target (server/trust-evaluation/runtime-health) are not
+/// actionable here yet and return 422.
+async fn resolve_decision(
+    State(state): State<Arc<AppState>>,
+    client: Option<Extension<AuthenticatedClient>>,
+    identity: Option<Extension<VerifiedIdentity>>,
+    Json(req): Json<DecisionRequest>,
+) -> axum::response::Response {
+    let actor = actor_from_client(
+        client.map(|Extension(c)| c).as_ref(),
+        identity.map(|Extension(id)| id).as_ref(),
+        &state.control_plane_role_mapping,
+    );
+    resolve_decision_core(state.control_plane_store.as_ref(), &actor, req)
+}
+
+/// Sync core of [`resolve_decision`] (testable without a router): load the
+/// target grant/policy, apply the approve/deny effect, and route it through the
+/// SAME `validate_for_actor` + audited-commit path as a direct mutation. Items
+/// whose kind has no durable store target return 422.
+fn resolve_decision_core(
+    store: Option<&Arc<dyn ControlPlaneStore>>,
+    actor: &ControlPlaneActor,
+    req: DecisionRequest,
+) -> axum::response::Response {
+    let Some(store) = store else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(MutationResponse {
+                ok: false,
+                reason_code: "CONTROL_STORE_UNAVAILABLE".to_string(),
+                reason: "Control-plane store is not configured".to_string(),
+            }),
+        )
+            .into_response();
+    };
+    let approve = req.decision == Decision::Approve;
+    let verb = if approve { "approve" } else { "deny" };
+
+    match req.target_kind {
+        ControlPlaneDecisionTargetKind::Grant => {
+            let mut grant = match store.get_grant(&req.target_id) {
+                Ok(Some(g)) => g,
+                Ok(None) => return decision_not_found("grant", &req.target_id),
+                Err(e) => return internal_error("CONTROL_STORE_READ_FAILED", &e),
+            };
+            grant.status = if approve {
+                ControlPlaneGrantStatus::Approved
+            } else {
+                ControlPlaneGrantStatus::Revoked
+            };
+            apply_mutation(
+                Some(store),
+                actor,
+                ControlPlaneAction::MutateGrant,
+                req.target_id.clone(),
+                format!("{verb} grant {}", req.target_id),
+                req.reason,
+                req.rollback,
+                |s, event| s.commit_grant_audited(grant.clone(), event),
+            )
+        }
+        ControlPlaneDecisionTargetKind::Policy => {
+            let mut policy = match store.get_policy(&req.target_id) {
+                Ok(Some(p)) => p,
+                Ok(None) => return decision_not_found("policy", &req.target_id),
+                Err(e) => return internal_error("CONTROL_STORE_READ_FAILED", &e),
+            };
+            policy.enforced = approve;
+            apply_mutation(
+                Some(store),
+                actor,
+                ControlPlaneAction::MutatePolicy,
+                req.target_id.clone(),
+                format!("{verb} policy {}", req.target_id),
+                req.reason,
+                req.rollback,
+                |s, event| s.commit_policy_audited(policy.clone(), event),
+            )
+        }
+        // Server enablement / trust-evaluation / runtime-health have no durable
+        // CP.1 store target yet; not resolvable through this endpoint.
+        other => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(MutationResponse {
+                ok: false,
+                reason_code: "CONTROL_DECISION_KIND_UNSUPPORTED".to_string(),
+                reason: format!(
+                    "decision target kind {other:?} is not actionable via this endpoint"
+                ),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+fn decision_not_found(kind: &str, id: &str) -> axum::response::Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(MutationResponse {
+            ok: false,
+            reason_code: "CONTROL_DECISION_TARGET_NOT_FOUND".to_string(),
+            reason: format!("no {kind} '{id}' in the control-plane store"),
+        }),
+    )
+        .into_response()
 }
 
 /// Shared mutation path: build the audited mutation, authorize it with
@@ -773,9 +909,9 @@ mod grant_projection_tests {
 mod mutation_tests {
     use super::apply_mutation;
     use crate::control_plane::{
-        AuditFilter, ControlPlaneAction, ControlPlaneActor, ControlPlaneGrant,
-        ControlPlaneGrantStatus, ControlPlaneRole, ControlPlaneRollbackPlan, ControlPlaneStore,
-        InMemoryControlPlaneStore,
+        AuditFilter, ControlPlaneAction, ControlPlaneActor, ControlPlaneDecisionTargetKind,
+        ControlPlaneGrant, ControlPlaneGrantStatus, ControlPlaneRole, ControlPlaneRollbackPlan,
+        ControlPlaneStore, InMemoryControlPlaneStore,
     };
     use axum::http::StatusCode;
     use std::sync::Arc;
@@ -863,6 +999,110 @@ mod mutation_tests {
             |_s, _event| Ok(()),
         );
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    // MIK-6687.CP.3 — an admin decision on a queued grant flips its status
+    // through the audited-commit path (approve -> Approved, deny -> Revoked).
+    #[test]
+    fn decision_resolves_grant_through_audited_path() {
+        use super::{Decision, DecisionRequest, resolve_decision_core};
+        let store: Arc<dyn ControlPlaneStore> = Arc::new(InMemoryControlPlaneStore::new());
+        let mut g = grant();
+        g.status = ControlPlaneGrantStatus::Requested;
+        store.put_grant(g).unwrap();
+
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::Grant,
+                target_id: "grant-1".to_string(),
+                decision: Decision::Approve,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            store.get_grant("grant-1").unwrap().unwrap().status,
+            ControlPlaneGrantStatus::Approved
+        );
+        assert_eq!(store.read_audit(&AuditFilter::new(10)).unwrap().len(), 1);
+
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::Grant,
+                target_id: "grant-1".to_string(),
+                decision: Decision::Deny,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            store.get_grant("grant-1").unwrap().unwrap().status,
+            ControlPlaneGrantStatus::Revoked
+        );
+    }
+
+    // MIK-6687.CP.3 — decision guards: non-admin denied (no state change), a
+    // missing target returns 404, an unsupported kind returns 422.
+    #[test]
+    fn decision_guards_rbac_missing_and_unsupported() {
+        use super::{Decision, DecisionRequest, resolve_decision_core};
+        let store: Arc<dyn ControlPlaneStore> = Arc::new(InMemoryControlPlaneStore::new());
+        let mut g = grant();
+        g.status = ControlPlaneGrantStatus::Requested;
+        store.put_grant(g).unwrap();
+
+        // Auditor is denied; grant stays Requested; no audit entry.
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Auditor),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::Grant,
+                target_id: "grant-1".to_string(),
+                decision: Decision::Approve,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            store.get_grant("grant-1").unwrap().unwrap().status,
+            ControlPlaneGrantStatus::Requested
+        );
+        assert!(store.read_audit(&AuditFilter::new(10)).unwrap().is_empty());
+
+        // Missing target -> 404.
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::Policy,
+                target_id: "absent".to_string(),
+                decision: Decision::Approve,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // Unsupported kind -> 422.
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::RuntimeHealth,
+                target_id: "srv-1".to_string(),
+                decision: Decision::Approve,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 }
 

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -199,10 +199,11 @@ async fn resolve_decision(
     resolve_decision_core(state.control_plane_store.as_ref(), &actor, req)
 }
 
-/// Sync core of [`resolve_decision`] (testable without a router): load the
-/// target grant/policy, apply the approve/deny effect, and route it through the
-/// SAME `validate_for_actor` + audited-commit path as a direct mutation. Items
-/// whose kind has no durable store target return 422.
+/// Sync core of [`resolve_decision`] (testable without a router). Authorizes
+/// FIRST (before any store read, so 403-vs-404 cannot leak target existence),
+/// then applies a field-only, audited status change through the store's
+/// re-read-under-lock primitive (no stale-clone lost update). Kinds without a
+/// durable store target return 422.
 fn resolve_decision_core(
     store: Option<&Arc<dyn ControlPlaneStore>>,
     actor: &ControlPlaneActor,
@@ -219,63 +220,85 @@ fn resolve_decision_core(
         )
             .into_response();
     };
+
+    // Map kind -> action; reject unsupported kinds with a static 422 (no
+    // resource lookup, so no information leak).
+    let (action, kind_label) = match req.target_kind {
+        ControlPlaneDecisionTargetKind::Grant => (ControlPlaneAction::MutateGrant, "grant"),
+        ControlPlaneDecisionTargetKind::Policy => (ControlPlaneAction::MutatePolicy, "policy"),
+        other => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(MutationResponse {
+                    ok: false,
+                    reason_code: "CONTROL_DECISION_KIND_UNSUPPORTED".to_string(),
+                    reason: format!(
+                        "decision target kind {other:?} is not actionable via this endpoint"
+                    ),
+                }),
+            )
+                .into_response();
+        }
+    };
     let approve = req.decision == Decision::Approve;
     let verb = if approve { "approve" } else { "deny" };
 
-    match req.target_kind {
+    // Build the audited mutation and authorize BEFORE touching the store, so a
+    // non-admin cannot use 403-vs-404 as an existence oracle.
+    let event = ControlPlaneAuditEvent {
+        event_id: format!("cpa-{}-{}", Utc::now().timestamp_millis(), req.target_id),
+        actor_id: actor.actor_id.clone(),
+        action,
+        target_id: req.target_id.clone(),
+        reason: req.reason,
+        rollback: req.rollback,
+    };
+    let mutation = ControlPlaneMutation {
+        action,
+        target_id: req.target_id.clone(),
+        summary: format!("{verb} {kind_label} {}", req.target_id),
+        audit_event: Some(event.clone()),
+    };
+    let report = mutation.validate_for_actor(actor);
+    if !report.allowed {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(MutationResponse {
+                ok: false,
+                reason_code: report.reason_code,
+                reason: report.reason,
+            }),
+        )
+            .into_response();
+    }
+
+    // Apply the field-only, audited status change (re-read under the store lock).
+    let applied = match req.target_kind {
         ControlPlaneDecisionTargetKind::Grant => {
-            let mut grant = match store.get_grant(&req.target_id) {
-                Ok(Some(g)) => g,
-                Ok(None) => return decision_not_found("grant", &req.target_id),
-                Err(e) => return internal_error("CONTROL_STORE_READ_FAILED", &e),
-            };
-            grant.status = if approve {
+            let status = if approve {
                 ControlPlaneGrantStatus::Approved
             } else {
                 ControlPlaneGrantStatus::Revoked
             };
-            apply_mutation(
-                Some(store),
-                actor,
-                ControlPlaneAction::MutateGrant,
-                req.target_id.clone(),
-                format!("{verb} grant {}", req.target_id),
-                req.reason,
-                req.rollback,
-                |s, event| s.commit_grant_audited(grant.clone(), event),
-            )
+            store.set_grant_status_audited(&req.target_id, status, &event)
         }
         ControlPlaneDecisionTargetKind::Policy => {
-            let mut policy = match store.get_policy(&req.target_id) {
-                Ok(Some(p)) => p,
-                Ok(None) => return decision_not_found("policy", &req.target_id),
-                Err(e) => return internal_error("CONTROL_STORE_READ_FAILED", &e),
-            };
-            policy.enforced = approve;
-            apply_mutation(
-                Some(store),
-                actor,
-                ControlPlaneAction::MutatePolicy,
-                req.target_id.clone(),
-                format!("{verb} policy {}", req.target_id),
-                req.reason,
-                req.rollback,
-                |s, event| s.commit_policy_audited(policy.clone(), event),
-            )
+            store.set_policy_enforced_audited(&req.target_id, approve, &event)
         }
-        // Server enablement / trust-evaluation / runtime-health have no durable
-        // CP.1 store target yet; not resolvable through this endpoint.
-        other => (
-            StatusCode::UNPROCESSABLE_ENTITY,
+        _ => unreachable!("non grant/policy kinds returned 422 above"),
+    };
+    match applied {
+        Ok(true) => (
+            StatusCode::OK,
             Json(MutationResponse {
-                ok: false,
-                reason_code: "CONTROL_DECISION_KIND_UNSUPPORTED".to_string(),
-                reason: format!(
-                    "decision target kind {other:?} is not actionable via this endpoint"
-                ),
+                ok: true,
+                reason_code: report.reason_code,
+                reason: report.reason,
             }),
         )
             .into_response(),
+        Ok(false) => decision_not_found(kind_label, &req.target_id),
+        Err(e) => internal_error("CONTROL_STORE_WRITE_FAILED", &e),
     }
 }
 
@@ -1045,6 +1068,37 @@ mod mutation_tests {
             store.get_grant("grant-1").unwrap().unwrap().status,
             ControlPlaneGrantStatus::Revoked
         );
+        // Deny is also audited: two decisions -> two audit entries.
+        assert_eq!(store.read_audit(&AuditFilter::new(10)).unwrap().len(), 2);
+    }
+
+    // MIK-6687.CP.3 — a policy decision flips `enforced` through the audited path.
+    #[test]
+    fn decision_resolves_policy_through_audited_path() {
+        use super::{Decision, DecisionRequest, resolve_decision_core};
+        let store: Arc<dyn ControlPlaneStore> = Arc::new(InMemoryControlPlaneStore::new());
+        store
+            .put_policy(crate::control_plane::ControlPlanePolicy {
+                policy_id: "pol-1".to_string(),
+                name: "p".to_string(),
+                enforced: false,
+            })
+            .unwrap();
+
+        let resp = resolve_decision_core(
+            Some(&store),
+            &actor(ControlPlaneRole::Admin),
+            DecisionRequest {
+                target_kind: ControlPlaneDecisionTargetKind::Policy,
+                target_id: "pol-1".to_string(),
+                decision: Decision::Approve,
+                reason: "MIK-1".to_string(),
+                rollback: rollback(),
+            },
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(store.get_policy("pol-1").unwrap().unwrap().enforced);
+        assert_eq!(store.read_audit(&AuditFilter::new(10)).unwrap().len(), 1);
     }
 
     // MIK-6687.CP.3 — decision guards: non-admin denied (no state change), a


### PR DESCRIPTION
## MIK-6687 (CP.3) — actionable decision queue

Makes control-plane decision-queue items resolvable: `POST /ui/api/control-plane/decisions` loads the target grant/policy by id, applies approve/deny, and routes the change through the **same** `validate_for_actor` + audited-commit path as a direct mutation (reuses CP.2 / MIK-6686). Part of epic MIK-6673.

### What landed
- `POST /ui/api/control-plane/decisions` — body: `{target_kind, target_id, decision: approve|deny, reason, rollback}`.
  - Grant: approve → Approved, deny → Revoked. Policy: `enforced = approve`.
  - Both approve **and** deny are audited (write-ahead audit + single-lock commit via `commit_grant_audited`/`commit_policy_audited`).
  - RBAC gates every decision (non-admin → 403, no state change, no audit entry).
  - Missing target → 404; a kind with no durable CP.1 store target (server / trust-evaluation / runtime-health) → 422 (not silently dropped).
- Sync core `resolve_decision_core` is unit-tested without a router.

### AC (MIK-6687.CP.3)
- Decision-queue items become actionable via handlers consuming `required_action`, routed through the mutation validator + audit path — done (grant/policy; kinds without a store target explicitly 422).

### Validation
`cargo test --lib` green (3137); `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt --check` clean. Tests: approve/deny flip + audit, RBAC deny, 404, 422.

A GPT adversarial review (DoD §12) runs against this change; confirmed findings incorporated before merge, verdict recorded on the ticket.

Advances MIK-6673. Depends on MIK-6685 + MIK-6686 (merged).
