### PR TITLE
helm: air-gap export and import proof (MIK-6699)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,33 @@ jobs:
       - name: Sign + verify chart and image by digest, assert SBOM
         run: scripts/dev/helm-supply-chain-smoke.sh
 
+  helm-airgap:
+    name: Helm air-gap export/import
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+      airgap:
+        image: registry:2
+        ports:
+          - 5001:5000
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - name: Install cosign
+        # ponytail: floating major tag until pinned to a SHA (follow-up).
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.5.2
+      - name: Install syft (SBOM)
+        uses: anchore/sbom-action/download-syft@v0
+      - name: Validate air-gap smoke script
+        run: bash -n scripts/dev/helm-airgap-smoke.sh
+      - name: Export to bundle, import to isolated registry, verify + install offline
+        run: scripts/dev/helm-airgap-smoke.sh
+
   k8s-kind-rollback:
     name: K8s kind apply+upgrade+rollback
     runs-on: ubuntu-latest
@@ -243,7 +270,7 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, test, fmt, audit, public-claims, public-repo-hygiene, service-template-smoke, usability-smoke, helm-chart-smoke, helm-oci-roundtrip, helm-supply-chain]
+    needs: [check, test, fmt, audit, public-claims, public-repo-hygiene, service-template-smoke, usability-smoke, helm-chart-smoke, helm-oci-roundtrip, helm-supply-chain, helm-airgap]
     permissions:
       contents: read
       packages: write

--- a/scripts/dev/helm-airgap-smoke.sh
+++ b/scripts/dev/helm-airgap-smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Helm air-gap proof (MIK-6699 / HELM.7): export the signed image + signed chart
+# + SBOM attestation to offline media, import them into a SEPARATE registry that
+# never talked to the source, then verify signatures and install the chart
+# entirely from that offline registry.
+#
+# Self-contained + deterministic: builds its own scratch image (no external
+# pulls), uses two local registries as "connected" (5000) and "air-gapped"
+# (5001), and an ephemeral cosign key with the transparency log disabled. The
+# offline transport is cosign save/load (which carries signatures + attestations)
+# plus the chart tgz — so the air-gap install proves the whole supply chain
+# survived the crossing.
+set -euo pipefail
+
+SRC="${SRC_REGISTRY:-localhost:5000}"
+AIR="${AIRGAP_REGISTRY:-localhost:5001}"
+HELM="${HELM:-helm}"
+COSIGN="${COSIGN:-cosign}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART="$ROOT_DIR/deploy/helm/mcp-gateway"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+
+export COSIGN_PASSWORD=""
+"$COSIGN" generate-key-pair
+SIGN=(--yes --key cosign.key --tlog-upload=false --allow-insecure-registry)
+VERIFY=(--key cosign.pub --insecure-ignore-tlog --allow-insecure-registry)
+
+# ── Build + sign + SBOM-attest a scratch image on the SOURCE registry ──────────
+mkdir -p img
+printf 'airgap-marker\n' > img/marker
+printf 'FROM scratch\nCOPY marker /marker\n' > img/Dockerfile
+docker build -q -t "$SRC/mcp-gateway-airgap:v1" img >/dev/null
+docker push "$SRC/mcp-gateway-airgap:v1" >/dev/null
+IMG_DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "$SRC/mcp-gateway-airgap:v1" | cut -d@ -f2)"
+[ -n "$IMG_DIGEST" ] || { echo "FAIL: source image digest not resolved" >&2; exit 1; }
+SRC_IMG="$SRC/mcp-gateway-airgap@$IMG_DIGEST"
+
+export SYFT_REGISTRY_INSECURE_USE_HTTP=true
+syft "registry:$SRC_IMG" -o spdx-json > sbom.spdx.json
+[ -s sbom.spdx.json ] || { echo "FAIL: SBOM empty" >&2; exit 1; }
+
+"$COSIGN" sign "${SIGN[@]}" "$SRC_IMG"
+"$COSIGN" attest --yes --key cosign.key --predicate sbom.spdx.json --type spdxjson \
+  --allow-insecure-registry "$SRC_IMG"
+
+# ── Package + push + sign the chart on the SOURCE registry ─────────────────────
+"$HELM" package "$CHART" -d "$work" >/dev/null
+ver="$(grep -E '^version:' "$CHART/Chart.yaml" | awk '{print $2}')"
+push_out="$("$HELM" push "$work/mcp-gateway-$ver.tgz" "oci://$SRC/charts" --plain-http 2>&1)"
+CHART_DIGEST="$(printf '%s\n' "$push_out" | grep -oE 'sha256:[0-9a-f]{64}' | head -1)"
+[ -n "$CHART_DIGEST" ] || { echo "FAIL: source chart digest not resolved" >&2; exit 1; }
+SRC_CHART="$SRC/charts/mcp-gateway@$CHART_DIGEST"
+"$COSIGN" sign "${SIGN[@]}" "$SRC_CHART"
+
+# ── EXPORT to offline media (carries the image, its signature + attestation) ───
+echo "== cosign save image + chart to an offline bundle =="
+"$COSIGN" save "$SRC_IMG" --dir bundle/image
+"$COSIGN" save "$SRC_CHART" --dir bundle/chart
+[ -d bundle/image ] && [ -d bundle/chart ] || { echo "FAIL: offline bundle not created" >&2; exit 1; }
+
+# ── IMPORT into the AIR-GAPPED registry (only the bundle crosses the gap) ───────
+echo "== cosign load into the air-gapped registry =="
+"$COSIGN" load --dir bundle/image --registry "$AIR" --allow-insecure-registry >/dev/null 2>&1 \
+  || "$COSIGN" load --dir bundle/image --registry "$AIR" >/dev/null
+"$COSIGN" load --dir bundle/chart --registry "$AIR" --allow-insecure-registry >/dev/null 2>&1 \
+  || "$COSIGN" load --dir bundle/chart --registry "$AIR" >/dev/null
+
+AIR_IMG="$AIR/mcp-gateway-airgap@$IMG_DIGEST"
+AIR_CHART="$AIR/charts/mcp-gateway@$CHART_DIGEST"
+
+# ── OFFLINE verify: signatures + SBOM attestation from the air-gapped registry ─
+echo "== verify signatures + SBOM attestation from the air-gapped registry =="
+"$COSIGN" verify "${VERIFY[@]}" "$AIR_IMG" >/dev/null \
+  || { echo "FAIL: image signature did not verify from air-gapped registry" >&2; exit 1; }
+"$COSIGN" verify-attestation "${VERIFY[@]}" --type spdxjson "$AIR_IMG" >/dev/null \
+  || { echo "FAIL: SBOM attestation did not verify from air-gapped registry" >&2; exit 1; }
+"$COSIGN" verify "${VERIFY[@]}" "$AIR_CHART" >/dev/null \
+  || { echo "FAIL: chart signature did not verify from air-gapped registry" >&2; exit 1; }
+
+# ── OFFLINE install: pull + render the chart from the air-gapped registry ──────
+echo "== pull + render the chart from the air-gapped registry (offline install) =="
+mkdir -p pulled
+"$HELM" pull "oci://$AIR/charts/mcp-gateway" --version "$ver" -d pulled --plain-http
+[ -f "pulled/mcp-gateway-$ver.tgz" ] || { echo "FAIL: chart not pulled from air-gapped registry" >&2; exit 1; }
+"$HELM" template t "pulled/mcp-gateway-$ver.tgz" \
+  --set image.registry="$AIR" \
+  --set image.repository="mcp-gateway-airgap" \
+  --set image.digest="$IMG_DIGEST" \
+  | tee rendered.yaml | grep -q '^kind: Deployment' \
+  || { echo "FAIL: air-gapped chart did not render a Deployment" >&2; exit 1; }
+
+# The rendered manifest must reference ONLY the air-gapped registry, never source.
+grep -q "$AIR/mcp-gateway-airgap@$IMG_DIGEST" rendered.yaml \
+  || { echo "FAIL: rendered image does not point at the air-gapped digest" >&2; exit 1; }
+! grep -q "$SRC/" rendered.yaml \
+  || { echo "FAIL: rendered manifest still references the SOURCE registry" >&2; exit 1; }
+
+echo "air-gap smoke passed: exported to bundle, imported to isolated registry, verified sigs + SBOM, installed offline"

--- a/scripts/dev/helm-airgap-smoke.sh
+++ b/scripts/dev/helm-airgap-smoke.sh
@@ -43,8 +43,8 @@ syft "registry:$SRC_IMG" -o spdx-json > sbom.spdx.json
 [ -s sbom.spdx.json ] || { echo "FAIL: SBOM empty" >&2; exit 1; }
 
 "$COSIGN" sign "${SIGN[@]}" "$SRC_IMG"
-"$COSIGN" attest --yes --key cosign.key --predicate sbom.spdx.json --type spdxjson \
-  --allow-insecure-registry "$SRC_IMG"
+"$COSIGN" attest --yes --key cosign.key --tlog-upload=false --predicate sbom.spdx.json \
+  --type spdxjson --allow-insecure-registry "$SRC_IMG"
 
 # ── Package + push + sign the chart on the SOURCE registry ─────────────────────
 "$HELM" package "$CHART" -d "$work" >/dev/null
@@ -62,11 +62,12 @@ echo "== cosign save image + chart to an offline bundle =="
 [ -d bundle/image ] && [ -d bundle/chart ] || { echo "FAIL: offline bundle not created" >&2; exit 1; }
 
 # ── IMPORT into the AIR-GAPPED registry (only the bundle crosses the gap) ───────
+# `cosign load` takes the destination image ref as a positional arg (no
+# --registry flag); the manifest digest is preserved, so the saved signature +
+# attestation round-trip to the air-gapped registry.
 echo "== cosign load into the air-gapped registry =="
-"$COSIGN" load --dir bundle/image --registry "$AIR" --allow-insecure-registry >/dev/null 2>&1 \
-  || "$COSIGN" load --dir bundle/image --registry "$AIR" >/dev/null
-"$COSIGN" load --dir bundle/chart --registry "$AIR" --allow-insecure-registry >/dev/null 2>&1 \
-  || "$COSIGN" load --dir bundle/chart --registry "$AIR" >/dev/null
+"$COSIGN" load --dir bundle/image --allow-insecure-registry "$AIR/mcp-gateway-airgap:v1"
+"$COSIGN" load --dir bundle/chart --allow-insecure-registry "$AIR/charts/mcp-gateway:$ver"
 
 AIR_IMG="$AIR/mcp-gateway-airgap@$IMG_DIGEST"
 AIR_CHART="$AIR/charts/mcp-gateway@$CHART_DIGEST"
@@ -92,10 +93,18 @@ mkdir -p pulled
   | tee rendered.yaml | grep -q '^kind: Deployment' \
   || { echo "FAIL: air-gapped chart did not render a Deployment" >&2; exit 1; }
 
-# The rendered manifest must reference ONLY the air-gapped registry, never source.
+# EVERY image ref in the rendered manifest must resolve to the air-gapped
+# registry — not just "source absent" (which a new upstream initContainer would
+# slip past).
+mapfile -t IMAGE_REFS < <(grep -oE 'image: *"?[^"]+' rendered.yaml | sed -E 's/image: *"?//')
+[ "${#IMAGE_REFS[@]}" -ge 1 ] || { echo "FAIL: no image refs in rendered manifest" >&2; exit 1; }
+for ref in "${IMAGE_REFS[@]}"; do
+  case "$ref" in
+    "$AIR"/*) : ;; # air-gapped registry — good
+    *) echo "FAIL: rendered image '$ref' is not from the air-gapped registry ($AIR)" >&2; exit 1 ;;
+  esac
+done
 grep -q "$AIR/mcp-gateway-airgap@$IMG_DIGEST" rendered.yaml \
   || { echo "FAIL: rendered image does not point at the air-gapped digest" >&2; exit 1; }
-! grep -q "$SRC/" rendered.yaml \
-  || { echo "FAIL: rendered manifest still references the SOURCE registry" >&2; exit 1; }
 
 echo "air-gap smoke passed: exported to bundle, imported to isolated registry, verified sigs + SBOM, installed offline"

--- a/scripts/dev/helm-supply-chain-smoke.sh
+++ b/scripts/dev/helm-supply-chain-smoke.sh
@@ -67,9 +67,10 @@ grep -q '"spdxVersion"' sbom.spdx.json \
   || { echo "FAIL: SBOM lacks an spdxVersion marker (not valid SPDX)" >&2; exit 1; }
 
 echo "== cosign attest the SBOM to the signed digest, then verify the attestation =="
-# `attest` gets its own args (no --tlog-upload on attest across cosign majors).
-"$COSIGN" attest --yes --key cosign.key --predicate sbom.spdx.json --type spdxjson \
-  --allow-insecure-registry "$SIGNED_REF"
+# cosign-release is pinned to v2.5.2, which supports --tlog-upload on attest;
+# keep the transparency-log upload off so the smoke needs no Rekor egress.
+"$COSIGN" attest --yes --key cosign.key --tlog-upload=false --predicate sbom.spdx.json \
+  --type spdxjson --allow-insecure-registry "$SIGNED_REF"
 "$COSIGN" verify-attestation "${VERIFY_ARGS[@]}" --type spdxjson "$SIGNED_REF" >/dev/null \
   || { echo "FAIL: SBOM attestation did not verify" >&2; exit 1; }
 


### PR DESCRIPTION
AC HELM.7 — prove the signed release survives an offline crossing.

New `helm-airgap` CI job (two registry:2 services: source 5000, air-gapped 5001) runs `scripts/dev/helm-airgap-smoke.sh`:
- Build scratch image, cosign-sign + SBOM-attest, package+sign chart on the source registry.
- `cosign save` image + chart (carrying signatures + attestation) to an offline bundle dir.
- `cosign load` them into the separate air-gapped registry — only the bundle crosses.
- Verify image signature + SBOM attestation + chart signature FROM the air-gapped registry.
- `helm pull` + `helm template` from the air-gapped registry; assert the rendered manifest references ONLY the air-gapped digest and NEVER the source.

Tag `docker` job now also `needs` helm-airgap. CI YAML validated; smoke bash -n clean.

Follow-up: SHA-pin the two new actions. Completes the Helm supply-chain slices; advances epic MIK-6691. Depends on MIK-6697 + MIK-6698 (merged).

A GPT adversarial review runs; confirmed findings incorporated before merge.