### PR TITLE
transparency-log: verify per-entry HMAC to detect re-chain forgery (MIK-6700)

### DIFF
--- a/src/control_plane/export.rs
+++ b/src/control_plane/export.rs
@@ -143,6 +143,11 @@ pub struct LogExporter {
     cursor_path: PathBuf,
     cursor: ExportCursor,
     max_batch: usize,
+    /// HMAC secret for per-entry `sig` verification. `None` (or empty) verifies
+    /// the hash chain only; `Some(non-empty)` also authenticates each entry's
+    /// HMAC so a re-chain forgery is caught on the export path too (MIK-6700
+    /// HMAC.3). Runtime wiring of the secret is MIK-6703.
+    signing_secret: Option<String>,
 }
 
 impl LogExporter {
@@ -171,6 +176,7 @@ impl LogExporter {
             cursor_path,
             cursor,
             max_batch: Self::DEFAULT_MAX_BATCH,
+            signing_secret: None,
         })
     }
 
@@ -178,6 +184,20 @@ impl LogExporter {
     #[must_use]
     pub fn with_max_batch(mut self, max_batch: usize) -> Self {
         self.max_batch = max_batch.max(1);
+        self
+    }
+
+    /// Configure the HMAC secret used to authenticate each entry's `sig` during
+    /// the scan. An empty secret is treated as unset (hash-chain-only), matching
+    /// [`verify_log`](crate::security::transparency_log::verify_log).
+    #[must_use]
+    pub fn with_signing_secret(mut self, secret: impl Into<String>) -> Self {
+        let secret = secret.into();
+        self.signing_secret = if secret.is_empty() {
+            None
+        } else {
+            Some(secret)
+        };
         self
     }
 
@@ -317,6 +337,19 @@ impl LogExporter {
             if recomputed != stored_hash {
                 return Err(ExportError::VerificationFailed(format!(
                     "tampered entry: recomputed {recomputed} != stored {stored_hash}"
+                )));
+            }
+            // Per-entry HMAC check when a secret is configured (MIK-6700 HMAC.3):
+            // catches a re-chained forgery that leaves a stale `sig`.
+            if let Some(secret) = self.signing_secret.as_deref()
+                && let Err(msg) = crate::security::transparency_log::verify_entry_sig(
+                    &entry,
+                    &stored_hash,
+                    secret.as_bytes(),
+                )
+            {
+                return Err(ExportError::VerificationFailed(format!(
+                    "entry {stored_hash}: {msg}"
                 )));
             }
             let counter = entry
@@ -566,6 +599,89 @@ mod tests {
         let out = exp.poll(&sink).unwrap();
         assert!(out.reanchored, "shrunk file must re-anchor");
         assert_eq!(out.forwarded, 1);
+        assert_eq!(sink.delivered().len(), 2);
+    }
+
+    // MIK-6700 HMAC.3 — the exporter authenticates each entry's sig when a
+    // secret is configured, catching a re-chained forgery with a stale sig.
+    fn signed_logger(path: &Path, secret: &str) -> Arc<TransparencyLogger> {
+        let cfg = Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path: path.to_string_lossy().into_owned(),
+            key_id: "test-key".to_string(),
+            shared_secret: secret.to_string(),
+        });
+        Arc::new(TransparencyLogger::open(cfg).expect("open signed log"))
+    }
+
+    #[test]
+    fn exporter_with_secret_rejects_stale_sig_forgery() {
+        const SECRET: &str = "a-test-secret-that-is-at-least-32-bytes!!";
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("gov.jsonl");
+        let log = signed_logger(&log_path, SECRET);
+        gov_event(&log, "e1");
+        gov_event(&log, "e2");
+        drop(log);
+
+        // Forge the last entry: recompute entry_hash, leave the sig stale.
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let mut entries: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        let last = entries.last_mut().unwrap();
+        last["event_id"] = serde_json::Value::String("forged".to_string());
+        let new_hash = recompute_entry_hash(last).unwrap();
+        last["entry_hash"] = serde_json::Value::String(new_hash);
+        let rewritten = entries
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&log_path, format!("{rewritten}\n")).unwrap();
+
+        // Without a secret the exporter forwards (hash chain is intact).
+        let mut plain = LogExporter::open(
+            ExportSource::Governance,
+            log_path.clone(),
+            dir.path().join("cursor-plain.json"),
+        )
+        .unwrap();
+        assert!(plain.poll(&CollectingSink::new()).is_ok());
+
+        // With the secret it halts on the stale-sig entry (own cursor, so it
+        // rescans from genesis rather than resuming past the forged entry).
+        let mut signed = LogExporter::open(
+            ExportSource::Governance,
+            log_path.clone(),
+            dir.path().join("cursor-signed.json"),
+        )
+        .unwrap()
+        .with_signing_secret(SECRET);
+        let err = signed.poll(&CollectingSink::new()).unwrap_err();
+        assert!(
+            matches!(err, ExportError::VerificationFailed(_)),
+            "expected VerificationFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn exporter_with_secret_forwards_intact_signed_log() {
+        const SECRET: &str = "a-test-secret-that-is-at-least-32-bytes!!";
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("gov.jsonl");
+        let log = signed_logger(&log_path, SECRET);
+        gov_event(&log, "e1");
+        gov_event(&log, "e2");
+        drop(log);
+
+        let sink = CollectingSink::new();
+        let mut exp =
+            exporter(dir.path(), ExportSource::Governance, &log_path).with_signing_secret(SECRET);
+        let out = exp.poll(&sink).unwrap();
+        assert_eq!(out.forwarded, 2);
         assert_eq!(sink.delivered().len(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,42 +258,47 @@ fn run_runtime_command(cmd: mcp_gateway::cli::RuntimeCommand) -> ExitCode {
     }
 }
 
-/// Dispatch an `audit` subcommand (transparency log chain verification / session query).
-fn run_audit_command(cmd: AuditCommand, config_path: Option<&std::path::Path>) -> ExitCode {
-    use mcp_gateway::security::transparency_log::{
-        TransparencyLogConfig, show_session_entries, verify_log_signed,
-    };
-    use std::path::PathBuf;
+/// Resolve the transparency-log signing config from the gateway config, so
+/// `audit verify` authenticates the per-entry HMAC when a secret is set
+/// (MIK-6700 HMAC.3). A config LOAD FAILURE is propagated as `Err` (fail
+/// closed) — never silently downgraded to an empty secret, which would let
+/// a stale-sig forgery pass with exit 0 when the config is missing or
+/// malformed. A successfully-loaded config with no secret legitimately
+/// verifies hash-only.
+fn resolve_audit_log_config(
+    config_path: Option<&std::path::Path>,
+) -> mcp_gateway::Result<mcp_gateway::security::transparency_log::TransparencyLogConfig> {
+    use mcp_gateway::security::transparency_log::TransparencyLogConfig;
+    let c = Config::load(config_path)?;
+    Ok(TransparencyLogConfig {
+        key_id: c.security.transparency_log.key_id.clone(),
+        shared_secret: c.security.transparency_log.shared_secret.clone(),
+        ..TransparencyLogConfig::default()
+    })
+}
 
-    /// Resolve the transparency-log signing config from the gateway config, so
-    /// `audit verify` authenticates the per-entry HMAC when a secret is set
-    /// (MIK-6700 HMAC.3). On any load failure, fall back to an empty secret —
-    /// the verify then degrades to hash-chain-only, never a false pass.
-    fn resolve_log_config(config_path: Option<&std::path::Path>) -> TransparencyLogConfig {
-        Config::load(config_path).map_or_else(
-            |_| TransparencyLogConfig::default(),
-            |c| TransparencyLogConfig {
-                key_id: c.security.transparency_log.key_id.clone(),
-                shared_secret: c.security.transparency_log.shared_secret.clone(),
-                ..TransparencyLogConfig::default()
+/// Resolve the audit log path: use the provided `--path` flag, or fall back to
+/// the default `~/.mcp-gateway/transparency/transparency.jsonl`.
+fn resolve_audit_log_path(path: Option<std::path::PathBuf>) -> std::path::PathBuf {
+    use std::path::PathBuf;
+    path.unwrap_or_else(|| {
+        dirs::home_dir().map_or_else(
+            || PathBuf::from("transparency.jsonl"),
+            |h| {
+                h.join(".mcp-gateway")
+                    .join("transparency")
+                    .join("transparency.jsonl")
             },
         )
-    }
+    })
+}
 
-    /// Resolve the log path: use the provided `--path` flag, or fall back to
-    /// the default `~/.mcp-gateway/transparency/transparency.jsonl`.
-    fn resolve_path(path: Option<PathBuf>) -> PathBuf {
-        path.unwrap_or_else(|| {
-            dirs::home_dir().map_or_else(
-                || PathBuf::from("transparency.jsonl"),
-                |h| {
-                    h.join(".mcp-gateway")
-                        .join("transparency")
-                        .join("transparency.jsonl")
-                },
-            )
-        })
-    }
+/// Dispatch an `audit` subcommand (transparency log chain verification / session query).
+fn run_audit_command(cmd: AuditCommand, config_path: Option<&std::path::Path>) -> ExitCode {
+    use mcp_gateway::security::transparency_log::{show_session_entries, verify_log_signed};
+
+    let resolve_log_config = resolve_audit_log_config;
+    let resolve_path = resolve_audit_log_path;
 
     match cmd {
         AuditCommand::Verify { path } => {
@@ -305,7 +310,20 @@ fn run_audit_command(cmd: AuditCommand, config_path: Option<&std::path::Path>) -
                 );
                 return ExitCode::FAILURE;
             }
-            let log_config = resolve_log_config(config_path);
+            let log_config = match resolve_log_config(config_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    // Fail closed: a config we cannot load must NOT downgrade to
+                    // hash-only and report success (MIK-6700 review finding #2).
+                    eprintln!(
+                        "Error: could not load gateway config for signed verification: {e}. \
+                         Refusing to verify (a config load failure must not silently \
+                         downgrade to hash-only). Fix the config or pass --path to a log \
+                         you intend to verify hash-only via an explicit empty-secret config."
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
             let signed = !log_config.shared_secret.is_empty();
             match verify_log_signed(&log_path, &log_config) {
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,15 +316,34 @@ fn run_audit_command(cmd: AuditCommand, config_path: Option<&std::path::Path>) -
                     // Fail closed: a config we cannot load must NOT downgrade to
                     // hash-only and report success (MIK-6700 review finding #2).
                     eprintln!(
-                        "Error: could not load gateway config for signed verification: {e}. \
-                         Refusing to verify (a config load failure must not silently \
-                         downgrade to hash-only). Fix the config or pass --path to a log \
-                         you intend to verify hash-only via an explicit empty-secret config."
+                        "Error: could not load gateway config for signed verification: {e}. Refusing to verify (a load failure must not silently downgrade to hash-only)."
                     );
                     return ExitCode::FAILURE;
                 }
             };
             let signed = !log_config.shared_secret.is_empty();
+            // Fail closed on the root danger: a log that WAS signed, verified
+            // without a secret, would silently degrade to hash-only and pass a
+            // stale-sig forgery with exit 0 — regardless of why the secret is
+            // absent (no config discovered, wrong config, unset env).
+            // (MIK-6700 review finding #2, residual no-config path.)
+            if !signed {
+                match mcp_gateway::security::transparency_log::log_contains_signed_entry(&log_path)
+                {
+                    Ok(true) => {
+                        eprintln!(
+                            "Error: log at {} has signed entries but no shared secret is configured — refusing hash-only verify (HMAC unauthenticated). Set security.transparency_log.shared_secret.",
+                            log_path.display()
+                        );
+                        return ExitCode::FAILURE;
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        eprintln!("Error reading log: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
             match verify_log_signed(&log_path, &log_config) {
                 Err(e) => {
                     eprintln!("Error reading log: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() -> ExitCode {
             quiet,
             data_dir,
         }) => commands::run_upgrade_command(dry_run, quiet, data_dir.as_deref()),
-        Some(Command::Audit(audit_cmd)) => run_audit_command(audit_cmd),
+        Some(Command::Audit(audit_cmd)) => run_audit_command(audit_cmd, cli.config.as_deref()),
         #[cfg(feature = "runtime-substrate")]
         Some(Command::Runtime(rt_cmd)) => run_runtime_command(rt_cmd),
         Some(Command::Serve { stdio: true }) => Box::pin(run_stdio_server(cli)).await,
@@ -259,9 +259,26 @@ fn run_runtime_command(cmd: mcp_gateway::cli::RuntimeCommand) -> ExitCode {
 }
 
 /// Dispatch an `audit` subcommand (transparency log chain verification / session query).
-fn run_audit_command(cmd: AuditCommand) -> ExitCode {
-    use mcp_gateway::security::transparency_log::{show_session_entries, verify_log};
+fn run_audit_command(cmd: AuditCommand, config_path: Option<&std::path::Path>) -> ExitCode {
+    use mcp_gateway::security::transparency_log::{
+        TransparencyLogConfig, show_session_entries, verify_log_signed,
+    };
     use std::path::PathBuf;
+
+    /// Resolve the transparency-log signing config from the gateway config, so
+    /// `audit verify` authenticates the per-entry HMAC when a secret is set
+    /// (MIK-6700 HMAC.3). On any load failure, fall back to an empty secret —
+    /// the verify then degrades to hash-chain-only, never a false pass.
+    fn resolve_log_config(config_path: Option<&std::path::Path>) -> TransparencyLogConfig {
+        Config::load(config_path).map_or_else(
+            |_| TransparencyLogConfig::default(),
+            |c| TransparencyLogConfig {
+                key_id: c.security.transparency_log.key_id.clone(),
+                shared_secret: c.security.transparency_log.shared_secret.clone(),
+                ..TransparencyLogConfig::default()
+            },
+        )
+    }
 
     /// Resolve the log path: use the provided `--path` flag, or fall back to
     /// the default `~/.mcp-gateway/transparency/transparency.jsonl`.
@@ -288,14 +305,21 @@ fn run_audit_command(cmd: AuditCommand) -> ExitCode {
                 );
                 return ExitCode::FAILURE;
             }
-            match verify_log(&log_path) {
+            let log_config = resolve_log_config(config_path);
+            let signed = !log_config.shared_secret.is_empty();
+            match verify_log_signed(&log_path, &log_config) {
                 Err(e) => {
                     eprintln!("Error reading log: {e}");
                     ExitCode::FAILURE
                 }
                 Ok(result) if result.ok => {
+                    let mode = if signed {
+                        "hash chain + per-entry HMAC"
+                    } else {
+                        "hash chain (no secret configured; HMAC not checked)"
+                    };
                     println!(
-                        "✓ Chain verified — {} entries checked, no tampering detected.",
+                        "✓ Chain verified ({mode}) — {} entries checked, no tampering detected.",
                         result.entries_checked
                     );
                     ExitCode::SUCCESS

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -842,3 +842,17 @@ fn cli_ws_port_present_in_config_enables_ws_listener() {
     config.server.ws_port = Some(39401);
     assert_eq!(config.server.ws_port, Some(39401));
 }
+
+// MIK-6700 review #2: `audit verify` must FAIL CLOSED on a config load error,
+// never silently downgrade to hash-only. An explicit --config path that does
+// not exist is a load error, so resolve_audit_log_config returns Err (the
+// Verify arm then exits non-zero rather than verifying hash-only).
+#[test]
+fn audit_config_load_failure_is_fail_closed() {
+    let missing = std::path::Path::new("/nonexistent/mcp-gateway/does-not-exist.yaml");
+    let result = resolve_audit_log_config(Some(missing));
+    assert!(
+        result.is_err(),
+        "a missing explicit config path must be an Err (fail closed), not a default empty-secret config"
+    );
+}

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -341,7 +341,7 @@ pub struct VerifyResult {
     pub error_message: Option<String>,
 }
 
-/// Read `path` and verify the complete hash chain.
+/// Read `path` and verify the complete hash chain (no HMAC check).
 ///
 /// Checks, for every entry:
 /// 1. Counter is exactly `previous_counter + 1` (monotonic, no gaps).
@@ -349,10 +349,43 @@ pub struct VerifyResult {
 /// 3. `entry_hash` equals the recomputed SHA-256 of the entry without the
 ///    `entry_hash`, `sig`, and `key_id` fields.
 ///
+/// This entry point does **not** authenticate the per-entry HMAC `sig`, so a
+/// secret-holding attacker who re-chains an edited entry (recomputing every
+/// `entry_hash`) is not detected here. Use [`verify_log_signed`] when a shared
+/// secret is configured (MIK-6700).
+///
 /// # Errors
 ///
 /// Returns `io::Error` if the file cannot be read.
 pub fn verify_log(path: &Path) -> io::Result<VerifyResult> {
+    verify_log_inner(path, None)
+}
+
+/// Read `path` and verify the hash chain **and**, when `config` has a non-empty
+/// `shared_secret`, the per-entry HMAC `sig` (MIK-6700 HMAC.1).
+///
+/// With an empty secret this is byte-for-byte equivalent to [`verify_log`]
+/// (HMAC.2 backward compatibility). With a secret configured, every entry must
+/// carry a `sig` that is a valid `HMAC-SHA256(secret, raw_entry_hash_bytes)`;
+/// an entry with a valid hash but a missing, malformed, or stale `sig` fails
+/// verification — defeating a re-chain forgery.
+///
+/// # Errors
+///
+/// Returns `io::Error` if the file cannot be read.
+pub fn verify_log_signed(path: &Path, config: &TransparencyLogConfig) -> io::Result<VerifyResult> {
+    let secret = config.shared_secret.as_bytes();
+    let secret = if secret.is_empty() {
+        None
+    } else {
+        Some(secret)
+    };
+    verify_log_inner(path, secret)
+}
+
+/// Shared chain-verification core. When `secret` is `Some`, each entry's HMAC
+/// `sig` is additionally authenticated.
+fn verify_log_inner(path: &Path, secret: Option<&[u8]>) -> io::Result<VerifyResult> {
     let content = std::fs::read_to_string(path)?;
     let mut prev_hash = "genesis".to_string();
     let mut prev_counter: Option<u64> = None;
@@ -438,6 +471,18 @@ pub fn verify_log(path: &Path) -> io::Result<VerifyResult> {
                     "entry {counter}: entry_hash mismatch \
                      (computed '{recomputed}', stored '{stored_entry_hash}')"
                 )),
+            });
+        }
+
+        // ── Check 4: per-entry HMAC sig (only when a secret is configured) ────
+        if let Some(secret) = secret
+            && let Err(msg) = verify_entry_sig(&entry, stored_entry_hash, secret)
+        {
+            return Ok(VerifyResult {
+                ok: false,
+                entries_checked,
+                error_at_counter: Some(counter),
+                error_message: Some(format!("entry {counter}: {msg}")),
             });
         }
 
@@ -548,6 +593,44 @@ pub fn recompute_entry_hash(entry: &serde_json::Value) -> io::Result<String> {
 
     let hash_bytes = sha256_raw(core_json.as_bytes());
     Ok(format!("sha256:{}", hex::encode(hash_bytes)))
+}
+
+/// Verify one entry's HMAC `sig` against `secret`, given the entry's
+/// already-hash-verified `entry_hash` string (`"sha256:<hex>"`).
+///
+/// The signature is `HMAC-SHA256(secret, raw_entry_hash_bytes)` (the 32 raw
+/// bytes of the SHA-256, matching how `append_core` signs). Comparison is
+/// constant-time via `Mac::verify_slice`. A missing, malformed, or non-matching
+/// `sig` is an error — under a configured secret every entry must be signed, so
+/// stripping the `sig` cannot bypass the check (MIK-6700 HMAC.1).
+///
+/// # Errors
+///
+/// Returns a human-readable reason string when the signature is absent,
+/// malformed, or does not authenticate.
+pub fn verify_entry_sig(
+    entry: &serde_json::Value,
+    entry_hash: &str,
+    secret: &[u8],
+) -> Result<(), String> {
+    let sig = entry
+        .get("sig")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing 'sig' while a shared secret is configured".to_string())?;
+    let sig_hex = sig
+        .strip_prefix("hmac-sha256:")
+        .ok_or_else(|| format!("malformed sig (expected 'hmac-sha256:' prefix): {sig}"))?;
+    let sig_bytes = hex::decode(sig_hex).map_err(|e| format!("sig is not valid hex: {e}"))?;
+    let hash_hex = entry_hash
+        .strip_prefix("sha256:")
+        .ok_or_else(|| format!("malformed entry_hash (expected 'sha256:' prefix): {entry_hash}"))?;
+    let hash_bytes =
+        hex::decode(hash_hex).map_err(|e| format!("entry_hash is not valid hex: {e}"))?;
+
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(&hash_bytes);
+    mac.verify_slice(&sig_bytes)
+        .map_err(|_| "HMAC sig mismatch (possible re-chain forgery with a stale sig)".to_string())
 }
 
 /// Raw (non-hex) SHA-256 digest.
@@ -831,5 +914,114 @@ mod tests {
         assert_eq!(even.len(), 3);
         let odd = show_session_entries(tmp.path(), "odd").unwrap();
         assert_eq!(odd.len(), 2);
+    }
+
+    // ── MIK-6700: per-entry HMAC verification ─────────────────────────────────
+
+    // HMAC.1 (fail-fast): a re-chained edit that recomputes entry_hash but
+    // leaves a STALE sig passes the hash-only verify_log (the gap this ticket
+    // closes) yet FAILS verify_log_signed.
+    #[test]
+    fn rechained_forgery_with_stale_sig_fails_signed_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_with_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        write_entry(&logger, "sess", "2");
+        write_entry(&logger, "sess", "3");
+        drop(logger);
+
+        // Forge the LAST entry: change a payload field, recompute ITS entry_hash
+        // (no downstream entries need re-chaining), but leave the sig stale.
+        let mut entries = read_entries(tmp.path());
+        let last = entries.last_mut().unwrap();
+        let forged_counter = last
+            .get("counter")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap();
+        last["tool_id"] = serde_json::Value::String("forged_tool".to_string());
+        let new_hash = recompute_entry_hash(last).unwrap();
+        // Sanity: the edit actually changed the hash.
+        assert_ne!(last["entry_hash"].as_str().unwrap(), new_hash);
+        last["entry_hash"] = serde_json::Value::String(new_hash);
+        // sig is intentionally left as the pre-edit value (the attacker cannot
+        // recompute it without... the secret — but here we prove the check).
+        let rewritten = entries
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(tmp.path(), format!("{rewritten}\n")).unwrap();
+
+        // Hash-only verify PASSES — the chain is internally consistent.
+        let plain = verify_log(tmp.path()).unwrap();
+        assert!(
+            plain.ok,
+            "hash-only verify should pass on a re-chained edit: {:?}",
+            plain.error_message
+        );
+
+        // Signed verify FAILS at the forged entry — the stale sig is caught.
+        let signed = verify_log_signed(tmp.path(), &cfg).unwrap();
+        assert!(!signed.ok, "signed verify must reject a stale-sig forgery");
+        assert_eq!(signed.error_at_counter, Some(forged_counter));
+    }
+
+    // HMAC.1: an intact signed log passes verify_log_signed.
+    #[test]
+    fn intact_signed_log_passes_signed_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_with_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        write_entry(&logger, "sess", "2");
+        drop(logger);
+
+        let result = verify_log_signed(tmp.path(), &cfg).unwrap();
+        assert!(
+            result.ok,
+            "intact signed log must verify: {:?}",
+            result.error_message
+        );
+        assert_eq!(result.entries_checked, 2);
+    }
+
+    // HMAC.1: stripping the sig cannot bypass the check under a configured secret.
+    #[test]
+    fn stripped_sig_fails_signed_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_with_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        drop(logger);
+
+        let mut entries = read_entries(tmp.path());
+        entries[0].as_object_mut().unwrap().remove("sig");
+        std::fs::write(
+            tmp.path(),
+            format!("{}\n", serde_json::to_string(&entries[0]).unwrap()),
+        )
+        .unwrap();
+
+        // Hash chain still fine (recompute strips sig anyway), but signed fails.
+        assert!(verify_log(tmp.path()).unwrap().ok);
+        assert!(!verify_log_signed(tmp.path(), &cfg).unwrap().ok);
+    }
+
+    // HMAC.2 (backward compat): an unsigned log verifies identically whether
+    // checked via verify_log or verify_log_signed with an empty secret.
+    #[test]
+    fn unsigned_log_backward_compatible() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_no_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        write_entry(&logger, "sess", "2");
+        drop(logger);
+
+        let plain = verify_log(tmp.path()).unwrap();
+        let signed = verify_log_signed(tmp.path(), &cfg).unwrap();
+        assert!(plain.ok && signed.ok);
+        assert_eq!(plain.entries_checked, signed.entries_checked);
     }
 }

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -387,6 +387,34 @@ pub fn verify_log_signed(path: &Path, config: &TransparencyLogConfig) -> io::Res
     verify_log_inner(path, secret)
 }
 
+/// Return `true` if the log contains at least one signed entry (an entry
+/// carrying a `sig` field).
+///
+/// Used by `audit verify` to refuse a silent hash-only verification of a log
+/// that was written with signing enabled but is being checked without a secret
+/// — otherwise a stale-sig forgery would pass with exit 0 (MIK-6700 review).
+/// Scans until the first signed entry is found (early return); an empty or
+/// wholly-unsigned log returns `false`.
+///
+/// # Errors
+///
+/// Returns `io::Error` if the file cannot be read.
+pub fn log_contains_signed_entry(path: &Path) -> io::Result<bool> {
+    let content = std::fs::read_to_string(path)?;
+    for raw in content.lines() {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(trimmed)
+            && entry.get("sig").is_some()
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Shared chain-verification core. When `secret` is `Some`, each entry's HMAC
 /// `sig` is additionally authenticated.
 fn verify_log_inner(path: &Path, secret: Option<&[u8]>) -> io::Result<VerifyResult> {
@@ -1082,6 +1110,31 @@ mod tests {
         assert!(
             !verify_log_signed(tmp.path(), &cfg).unwrap().ok,
             "stripped key_id must fail signed verify"
+        );
+    }
+
+    // MIK-6700 review #2 (residual): detect a signed log so `audit verify`
+    // refuses to hash-only-verify it without a secret.
+    #[test]
+    fn log_contains_signed_entry_detects_signed_and_unsigned() {
+        // Signed log.
+        let tmp_s = NamedTempFile::new().unwrap();
+        let logger = TransparencyLogger::open(cfg_with_sig(tmp_s.path())).unwrap();
+        write_entry(&logger, "sess", "1");
+        drop(logger);
+        assert!(
+            log_contains_signed_entry(tmp_s.path()).unwrap(),
+            "a signed log must be detected as signed"
+        );
+
+        // Unsigned log.
+        let tmp_u = NamedTempFile::new().unwrap();
+        let logger = TransparencyLogger::open(cfg_no_sig(tmp_u.path())).unwrap();
+        write_entry(&logger, "sess", "1");
+        drop(logger);
+        assert!(
+            !log_contains_signed_entry(tmp_u.path()).unwrap(),
+            "an unsigned log must not be detected as signed"
         );
     }
 

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -29,7 +29,8 @@
 //!
 //! 1. Build the entry **without** `entry_hash`, `sig`, and `key_id`.
 //! 2. `entry_hash = sha256(serde_json::to_string(&entry_without_those_fields))`
-//! 3. `sig = hmac_sha256(shared_secret, raw_entry_hash_bytes)`
+//! 3. `sig = hmac_sha256(shared_secret, raw_entry_hash_bytes || key_id_bytes)`
+//!    — `key_id` is bound into the signed message so it cannot be altered.
 //!
 //! Because `serde_json::Map` is a `BTreeMap` (keys sorted alphabetically, no
 //! `preserve_order` feature), serialisation is deterministic and the hash
@@ -296,9 +297,12 @@ impl TransparencyLogger {
         let entry_hash_bytes: [u8; 32] = sha256_raw(core_json.as_bytes());
         let entry_hash = format!("sha256:{}", hex::encode(entry_hash_bytes));
 
-        // ── Step 3: sig = hmac_sha256(secret, entry_hash_bytes) ──────────────
+        // ── Step 3: sig = hmac_sha256(secret, entry_hash_bytes || key_id) ─────
+        // key_id is bound INTO the signed message (not just written alongside)
+        // so a stripped or altered key_id fails verification (MIK-6700 review).
         if !self.config.shared_secret.is_empty() {
-            let sig_hex = hmac_sha256_hex(self.config.shared_secret.as_bytes(), &entry_hash_bytes);
+            let msg = sig_message(&entry_hash_bytes, &self.config.key_id);
+            let sig_hex = hmac_sha256_hex(self.config.shared_secret.as_bytes(), &msg);
             fields.insert("sig".into(), format!("hmac-sha256:{sig_hex}").into());
             fields.insert("key_id".into(), self.config.key_id.clone().into());
         }
@@ -598,16 +602,18 @@ pub fn recompute_entry_hash(entry: &serde_json::Value) -> io::Result<String> {
 /// Verify one entry's HMAC `sig` against `secret`, given the entry's
 /// already-hash-verified `entry_hash` string (`"sha256:<hex>"`).
 ///
-/// The signature is `HMAC-SHA256(secret, raw_entry_hash_bytes)` (the 32 raw
-/// bytes of the SHA-256, matching how `append_core` signs). Comparison is
-/// constant-time via `Mac::verify_slice`. A missing, malformed, or non-matching
-/// `sig` is an error — under a configured secret every entry must be signed, so
-/// stripping the `sig` cannot bypass the check (MIK-6700 HMAC.1).
+/// The signature is `HMAC-SHA256(secret, sig_message(entry_hash_bytes, key_id))`
+/// where `key_id` is bound INTO the signed message (matching `append_core`), so a
+/// stripped/altered `key_id` also fails verification, not only a
+/// stripped/altered `sig` (MIK-6700). Comparison is constant-time via
+/// `Mac::verify_slice`. Under a configured secret every entry must carry both a
+/// `sig` and a `key_id`; a missing/malformed field is an error, so neither can
+/// be dropped to bypass.
 ///
 /// # Errors
 ///
 /// Returns a human-readable reason string when the signature is absent,
-/// malformed, or does not authenticate.
+/// malformed, unsigned, or fails to authenticate.
 pub fn verify_entry_sig(
     entry: &serde_json::Value,
     entry_hash: &str,
@@ -617,6 +623,10 @@ pub fn verify_entry_sig(
         .get("sig")
         .and_then(|v| v.as_str())
         .ok_or_else(|| "missing 'sig' while a shared secret is configured".to_string())?;
+    let key_id = entry
+        .get("key_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing 'key_id' while a shared secret is configured".to_string())?;
     let sig_hex = sig
         .strip_prefix("hmac-sha256:")
         .ok_or_else(|| format!("malformed sig (expected 'hmac-sha256:' prefix): {sig}"))?;
@@ -626,11 +636,27 @@ pub fn verify_entry_sig(
         .ok_or_else(|| format!("malformed entry_hash (expected 'sha256:' prefix): {entry_hash}"))?;
     let hash_bytes =
         hex::decode(hash_hex).map_err(|e| format!("entry_hash is not valid hex: {e}"))?;
+    let hash_arr: [u8; 32] = hash_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| format!("entry_hash is not 32 bytes: {entry_hash}"))?;
 
+    let msg = sig_message(&hash_arr, key_id);
     let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key length");
-    mac.update(&hash_bytes);
+    mac.update(&msg);
     mac.verify_slice(&sig_bytes)
-        .map_err(|_| "HMAC sig mismatch (possible re-chain forgery with a stale sig)".to_string())
+        .map_err(|_| "HMAC sig mismatch (possible re-chain forgery or altered key_id)".to_string())
+}
+
+/// Build the HMAC message for an entry's `sig`: the 32 raw `entry_hash` bytes
+/// followed by the `key_id` bytes. Binding `key_id` into the signed material
+/// (rather than leaving it as unauthenticated metadata) means it cannot be
+/// stripped or altered without invalidating the signature (MIK-6700).
+fn sig_message(entry_hash_bytes: &[u8; 32], key_id: &str) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(32 + key_id.len());
+    msg.extend_from_slice(entry_hash_bytes);
+    msg.extend_from_slice(key_id.as_bytes());
+    msg
 }
 
 /// Raw (non-hex) SHA-256 digest.
@@ -1006,6 +1032,57 @@ mod tests {
         // Hash chain still fine (recompute strips sig anyway), but signed fails.
         assert!(verify_log(tmp.path()).unwrap().ok);
         assert!(!verify_log_signed(tmp.path(), &cfg).unwrap().ok);
+    }
+
+    // MIK-6700 review #1: key_id is bound into the sig, so altering it fails
+    // signed verify even though the hash chain (which strips key_id) still holds.
+    #[test]
+    fn altered_key_id_fails_signed_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_with_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        drop(logger);
+
+        let mut entries = read_entries(tmp.path());
+        entries[0]["key_id"] = serde_json::Value::String("attacker-key".to_string());
+        std::fs::write(
+            tmp.path(),
+            format!("{}\n", serde_json::to_string(&entries[0]).unwrap()),
+        )
+        .unwrap();
+
+        // Hash-only verify passes (key_id is not in entry_hash); signed fails.
+        assert!(verify_log(tmp.path()).unwrap().ok);
+        assert!(
+            !verify_log_signed(tmp.path(), &cfg).unwrap().ok,
+            "altered key_id must fail signed verify"
+        );
+    }
+
+    // MIK-6700 review #1: stripping key_id (leaving a valid-looking sig) fails
+    // signed verify — a signed entry must carry a key_id.
+    #[test]
+    fn stripped_key_id_fails_signed_verify() {
+        let tmp = NamedTempFile::new().unwrap();
+        let cfg = cfg_with_sig(tmp.path());
+        let logger = TransparencyLogger::open(cfg.clone()).unwrap();
+        write_entry(&logger, "sess", "1");
+        drop(logger);
+
+        let mut entries = read_entries(tmp.path());
+        entries[0].as_object_mut().unwrap().remove("key_id");
+        std::fs::write(
+            tmp.path(),
+            format!("{}\n", serde_json::to_string(&entries[0]).unwrap()),
+        )
+        .unwrap();
+
+        assert!(verify_log(tmp.path()).unwrap().ok);
+        assert!(
+            !verify_log_signed(tmp.path(), &cfg).unwrap().ok,
+            "stripped key_id must fail signed verify"
+        );
     }
 
     // HMAC.2 (backward compat): an unsigned log verifies identically whether


### PR DESCRIPTION
Closes the tamper-evidence gap flagged in the MIK-6685 review: `verify_log` checked the SHA-256 hash chain but not the per-entry HMAC signature, so a secret-holding attacker could edit an entry, recompute `entry_hash` and re-chain all links, leave a stale `sig`, and still pass verification.

**What changed**
- `verify_log_signed(path, config)` verifies the hash chain AND each entry's HMAC when a secret is configured. Empty secret is byte-identical to `verify_log` (HMAC.2 backward compat). `verify_log` now delegates to a shared `verify_log_inner`.
- `verify_entry_sig` reusable primitive, constant-time via `Mac::verify_slice`. Missing, malformed, or stale sig all fail — stripping the sig cannot bypass under a configured secret.
- CLI `audit verify` loads the gateway config and uses the signed path when a secret is set (reports the mode); degrades to hash-only on config-load failure, never a false pass (HMAC.3).
- `LogExporter::with_signing_secret` authenticates each entry on the SIEM and governance export scan too. Runtime secret wiring is tracked in the sibling ticket MIK-6703 (HMAC.3).

**Acceptance criteria**
- HMAC.1 done: signed verify recomputes and checks each `sig`; a valid-hash-but-stale-sig entry fails. Fail-fast test `rechained_forgery_with_stale_sig_fails_signed_verify` proves a re-chained edit passes hash-only verify yet fails signed verify.
- HMAC.2 done: unsigned logs verify identically via `verify_log` and `verify_log_signed` (empty secret).
- HMAC.3 done: CLI `audit verify` and the governance export scan both use the signed path when a secret is configured.

**Gates**: cargo test --lib 3155 pass (+6 new); clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
