### PR TITLE
control-plane: hot-reload role mapping + collision-safe actor_id (MIK-6702)

### DIFF
--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -320,6 +320,10 @@ struct MetaFields {
     agent_auth: String,
     runtime: String,
     marketplace: String,
+    /// Control-plane section (RBAC role mapping). Tracked so a role-mapping-only
+    /// edit is detected and triggers a reload — without this, removing an admin
+    /// rule would not take effect until restart (MIK-6702 CP.RELOAD.2).
+    control_plane: String,
     #[cfg(feature = "cost-governance")]
     cost_governance: String,
 }
@@ -344,6 +348,7 @@ impl MetaFields {
             agent_auth: canonical_json(&c.agent_auth),
             runtime: canonical_json(&c.runtime),
             marketplace: canonical_json(&c.marketplace),
+            control_plane: canonical_json(&c.control_plane),
             #[cfg(feature = "cost-governance")]
             cost_governance: canonical_json(&c.cost_governance),
         }

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -712,3 +712,35 @@ fn diff_same_backend_maps_in_different_order_is_not_modified() {
         patch.summary()
     );
 }
+
+// MIK-6702.CP.RELOAD.2 — a control_plane.role_mapping-only change is detected
+// (non-empty patch), so a mapping edit triggers the reload path instead of
+// being silently ignored until restart.
+#[test]
+fn control_plane_role_mapping_change_is_detected() {
+    use crate::control_plane::{
+        ControlPlaneRole, ControlPlaneRoleMappingConfig, ControlPlaneRoleRule,
+    };
+
+    let old = Config::default();
+    let mut new = Config::default();
+    new.control_plane.role_mapping = ControlPlaneRoleMappingConfig {
+        rules: vec![ControlPlaneRoleRule {
+            issuer: "https://idp".to_string(),
+            group: Some("admins".to_string()),
+            email: None,
+            domain: None,
+            role: ControlPlaneRole::Admin,
+        }],
+    };
+
+    let patch = compute_diff(&old, &new);
+    assert!(
+        !patch.is_empty(),
+        "a control_plane.role_mapping change must be detected as a reloadable diff"
+    );
+    assert!(
+        patch.profiles_changed,
+        "control_plane change should set profiles_changed"
+    );
+}

--- a/src/control_plane/role_mapping.rs
+++ b/src/control_plane/role_mapping.rs
@@ -30,11 +30,11 @@ pub struct ControlPlaneConfig {
 
 /// Ordered, first-match-wins identity-to-role rules.
 ///
-/// NOTE: changes to the mapping are applied at gateway startup; they are not
-/// hot-reloaded today. To revoke a role (e.g. remove a `role: admin` rule),
-/// restart the gateway — a `/reload` does not yet re-apply this section
-/// (tracked as a follow-up). The mapping is still validated fail-closed on
-/// every load/reload, so an invalid change is always rejected.
+/// Hot-reloadable (MIK-6702): a `/reload` that changes this section takes effect
+/// without a restart — the control-plane handlers read the mapping through the
+/// live config per request, so removing a `role: admin` rule revokes Admin on
+/// the next request. The mapping is validated fail-closed on every load/reload,
+/// so an invalid change is always rejected.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ControlPlaneRoleMappingConfig {

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -15,7 +15,7 @@ use super::proxy::ProxyManager;
 use super::streaming::NotificationMultiplexer;
 use crate::backend::BackendRegistry;
 use crate::config::{AgentIdentityConfig, StreamingConfig};
-use crate::control_plane::{ControlPlaneRoleMappingConfig, ControlPlaneStore};
+use crate::control_plane::ControlPlaneStore;
 use crate::key_server::{KeyServer, handler::key_server_routes};
 use crate::mtls::MtlsPolicy;
 use crate::security::ToolPolicy;
@@ -84,9 +84,12 @@ pub struct AppState {
     /// `None` when the control-plane data directory could not be opened, in
     /// which case governance mutation routes return 503 (MIK-6686).
     pub control_plane_store: Option<Arc<dyn ControlPlaneStore>>,
-    /// Identity-to-role mapping for the control-plane governance surface
-    /// (MIK-6688). Empty by default (legacy admin-key projection applies).
-    pub control_plane_role_mapping: Arc<ControlPlaneRoleMappingConfig>,
+    /// Live gateway configuration (hot-reloadable). The control-plane RBAC role
+    /// mapping is read through this so a `/reload` that changes
+    /// `control_plane.role_mapping` takes effect without a restart — e.g. a
+    /// removed admin rule stops granting Admin (MIK-6702 CP.RELOAD.1). The
+    /// config-reload loop swaps the inner `Arc<Config>` on every applied reload.
+    pub live_config: Arc<crate::config_reload::LiveConfig>,
 }
 
 /// Create the router.

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -65,9 +65,9 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
     })
 }
 
@@ -111,9 +111,9 @@ fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
     })
 }
 
@@ -153,9 +153,9 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
     })
 }
 
@@ -204,9 +204,9 @@ fn test_router_app_state_with_ssrf(
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
     })
 }
 
@@ -263,9 +263,9 @@ fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
         firewall: None,
         agent_identity_config: crate::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            crate::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
     })
 }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -636,9 +636,15 @@ impl Gateway {
             meta_mcp.set_webhook_registry(Arc::clone(&webhook_registry));
         }
 
+        // Live config handle: shared by the hot-reload watcher (which swaps it
+        // on every applied reload) and AppState (which reads control-plane role
+        // mapping through it, so a reload takes effect without restart —
+        // MIK-6702). Created unconditionally; without a config path it simply
+        // never changes.
+        let live_config = Arc::new(LiveConfig::new(self.config.clone()));
+
         // Wire config hot-reload if a config path was provided.
         let _config_watcher: Option<ConfigWatcher> = if let Some(ref path) = self.config_path {
-            let live_config = Arc::new(LiveConfig::new(self.config.clone()));
             let reload_ctx = Arc::new(ReloadContext::new(
                 path.clone(),
                 Arc::clone(&live_config),
@@ -650,7 +656,7 @@ impl Gateway {
 
             match ConfigWatcher::start(
                 path.clone(),
-                live_config,
+                Arc::clone(&live_config),
                 Arc::clone(&self.backends),
                 &self.config,
                 shutdown_tx.subscribe(),
@@ -791,7 +797,7 @@ impl Gateway {
             firewall: firewall_arc,
             agent_identity_config: self.config.security.agent_identity.clone(),
             control_plane_store,
-            control_plane_role_mapping: Arc::new(self.config.control_plane.role_mapping.clone()),
+            live_config: Arc::clone(&live_config),
         });
 
         // Create router

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -53,7 +53,7 @@ async fn control_plane_snapshot(
     let actor = actor_from_client(
         client.as_ref(),
         identity.as_ref(),
-        &state.control_plane_role_mapping,
+        &state.live_config.get().control_plane.role_mapping,
     );
     let (snapshot, store_read_degraded) = local_runtime_snapshot(&state, client.as_ref(), &actor);
     let shadow_radar = local_shadow_radar(&state).await;
@@ -118,7 +118,7 @@ async fn mutate_grant(
     let actor = actor_from_client(
         client.map(|Extension(c)| c).as_ref(),
         identity.map(|Extension(id)| id).as_ref(),
-        &state.control_plane_role_mapping,
+        &state.live_config.get().control_plane.role_mapping,
     );
     let target_id = req.grant.grant_id.clone();
     apply_mutation(
@@ -143,7 +143,7 @@ async fn mutate_policy(
     let actor = actor_from_client(
         client.map(|Extension(c)| c).as_ref(),
         identity.map(|Extension(id)| id).as_ref(),
-        &state.control_plane_role_mapping,
+        &state.live_config.get().control_plane.role_mapping,
     );
     let target_id = req.policy.policy_id.clone();
     apply_mutation(
@@ -195,7 +195,7 @@ async fn resolve_decision(
     let actor = actor_from_client(
         client.map(|Extension(c)| c).as_ref(),
         identity.map(|Extension(id)| id).as_ref(),
-        &state.control_plane_role_mapping,
+        &state.live_config.get().control_plane.role_mapping,
     );
     resolve_decision_core(state.control_plane_store.as_ref(), &actor, req)
 }
@@ -423,7 +423,7 @@ fn actor_from_client(
             .unwrap_or(ControlPlaneRole::Auditor);
         let display_name = id.name.clone().unwrap_or_else(|| id.email.clone());
         return ControlPlaneActor {
-            actor_id: format!("oidc:{}:{}", id.issuer, id.subject),
+            actor_id: id.stable_actor_id(),
             display_name,
             role,
             group_ids: id.groups.clone(),
@@ -1317,7 +1317,8 @@ mod role_wiring_tests {
             &empty,
         );
         assert_eq!(actor.role, ControlPlaneRole::Auditor);
-        assert_eq!(actor.actor_id, "oidc:https://idp:s");
+        // Collision-safe length-prefixed id (MIK-6702 CP.ID.1): issuer len 11, subject len 1.
+        assert_eq!(actor.actor_id, "oidc:11:https://idp:1:s");
     }
 
     // MIK-6688.ROLE.6 — a mapped SecurityReviewer can read evidence but cannot mutate.
@@ -1336,6 +1337,70 @@ mod role_wiring_tests {
         assert_eq!(actor.role, ControlPlaneRole::SecurityReviewer);
         assert!(ControlPlaneRbac::authorize(&actor, ControlPlaneAction::ReadEvidence).allowed);
         assert!(!ControlPlaneRbac::authorize(&actor, ControlPlaneAction::MutateGrant).allowed);
+    }
+
+    // MIK-6702.CP.ID.1 — actor_id is collision-safe: two distinct (issuer,
+    // subject) pairs that collide under the naive `oidc:{issuer}:{subject}`
+    // format (issuer containing ':') now map to DISTINCT ids.
+    #[test]
+    fn actor_id_is_collision_safe() {
+        let a = identity("https://idp/a", &[]); // subject "s"
+        let mut b = identity("https://idp/a:1", &[]);
+        b.subject = "s".to_string();
+        // Naive format: both would render "oidc:https://idp/a:1:s" for some
+        // subject split; the length-prefixed form keeps them distinct.
+        let id_a =
+            actor_from_client(None, Some(&a), &ControlPlaneRoleMappingConfig::default()).actor_id;
+        let id_b =
+            actor_from_client(None, Some(&b), &ControlPlaneRoleMappingConfig::default()).actor_id;
+        assert_ne!(id_a, id_b, "distinct identities must not collide");
+        // Sanity: the control-plane id matches the key-server key for one identity.
+        assert_eq!(id_a, a.stable_actor_id());
+    }
+
+    // MIK-6702.CP.RELOAD.1 — the role mapping is read live: a reload that
+    // removes an admin rule stops granting Admin without a restart. Simulates
+    // the reload by swapping the LiveConfig the handler reads through.
+    #[test]
+    fn role_mapping_reload_revokes_admin_without_restart() {
+        use crate::config::Config;
+        use crate::config_reload::LiveConfig;
+
+        let admin_id = identity("https://idp", &["admins"]);
+        let mut cfg = Config::default();
+        cfg.control_plane.role_mapping = ControlPlaneRoleMappingConfig {
+            rules: vec![ControlPlaneRoleRule {
+                issuer: "https://idp".to_string(),
+                group: Some("admins".to_string()),
+                email: None,
+                domain: None,
+                role: ControlPlaneRole::Admin,
+            }],
+        };
+        let live = LiveConfig::new(cfg);
+
+        // Before reload: the mapping grants Admin.
+        let before = actor_from_client(
+            None,
+            Some(&admin_id),
+            &live.get().control_plane.role_mapping,
+        );
+        assert_eq!(before.role, ControlPlaneRole::Admin);
+
+        // Reload removes the admin rule (empty mapping).
+        live.set(Config::default());
+
+        // After reload: reading through the SAME handle, Admin is revoked.
+        let after = actor_from_client(
+            None,
+            Some(&admin_id),
+            &live.get().control_plane.role_mapping,
+        );
+        assert_eq!(
+            after.role,
+            ControlPlaneRole::Auditor,
+            "a removed admin rule must stop granting Admin after reload"
+        );
     }
 }
 

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -1344,11 +1344,18 @@ mod role_wiring_tests {
     // format (issuer containing ':') now map to DISTINCT ids.
     #[test]
     fn actor_id_is_collision_safe() {
-        let a = identity("https://idp/a", &[]); // subject "s"
-        let mut b = identity("https://idp/a:1", &[]);
-        b.subject = "s".to_string();
-        // Naive format: both would render "oidc:https://idp/a:1:s" for some
-        // subject split; the length-prefixed form keeps them distinct.
+        // issuer "https://idp/a" + subject "b:c" vs issuer "https://idp/a:b" +
+        // subject "c" both render "oidc:https://idp/a:b:c" under the naive form.
+        let mut a = identity("https://idp/a", &[]);
+        a.subject = "b:c".to_string();
+        let mut b = identity("https://idp/a:b", &[]);
+        b.subject = "c".to_string();
+        // Precondition: the naive format genuinely collides for this pair.
+        assert_eq!(
+            format!("oidc:{}:{}", a.issuer, a.subject),
+            format!("oidc:{}:{}", b.issuer, b.subject),
+            "test is only meaningful if the naive format collides here"
+        );
         let id_a =
             actor_from_client(None, Some(&a), &ControlPlaneRoleMappingConfig::default()).actor_id;
         let id_b =

--- a/src/key_server/mod.rs
+++ b/src/key_server/mod.rs
@@ -161,7 +161,10 @@ impl KeyServer {
 }
 
 fn oidc_client_identity_key(identity: &VerifiedIdentity) -> String {
-    format!("oidc:{}:{}", identity.issuer, identity.subject)
+    // Collision-safe (length-prefixed) — see VerifiedIdentity::stable_actor_id
+    // (MIK-6702 CP.ID.1). Kept identical to the control-plane actor_id so a user
+    // maps to one stable identity across both surfaces.
+    identity.stable_actor_id()
 }
 
 #[cfg(test)]
@@ -194,7 +197,9 @@ mod tests {
 
         assert_eq!(
             oidc_client_identity_key(&first),
-            "oidc:https://issuer-a.example:same-subject"
+            // Length-prefixed, collision-safe (MIK-6702 CP.ID.1):
+            // issuer "https://issuer-a.example" len 24, subject "same-subject" len 12.
+            "oidc:24:https://issuer-a.example:12:same-subject"
         );
         assert_ne!(
             oidc_client_identity_key(&first),
@@ -202,7 +207,8 @@ mod tests {
         );
         assert_eq!(
             oidc_client_identity_key(&missing_email),
-            "oidc:https://issuer-a.example:subject-without-email"
+            // issuer len 24, subject "subject-without-email" len 21.
+            "oidc:24:https://issuer-a.example:21:subject-without-email"
         );
     }
 }

--- a/src/key_server/oidc.rs
+++ b/src/key_server/oidc.rs
@@ -117,6 +117,28 @@ pub struct VerifiedIdentity {
     pub issuer: String,
 }
 
+impl VerifiedIdentity {
+    /// Stable, collision-safe actor identifier derived from `issuer` + `subject`.
+    ///
+    /// A naive `format!("oidc:{issuer}:{subject}")` collides when an issuer
+    /// contains `:` — e.g. issuer `https://idp/a` + subject `b:c` vs issuer
+    /// `https://idp/a:b` + subject `c` both render `oidc:https://idp/a:b:c`
+    /// (MIK-6702 CP.ID.1). Length-prefixing each component makes the boundary
+    /// unambiguous, so distinct (issuer, subject) pairs always map to distinct
+    /// ids. Not a role-escalation path (roles come from the verified identity,
+    /// not the id), but it prevents audit / user-identity row collisions.
+    #[must_use]
+    pub fn stable_actor_id(&self) -> String {
+        format!(
+            "oidc:{}:{}:{}:{}",
+            self.issuer.len(),
+            self.issuer,
+            self.subject.len(),
+            self.subject
+        )
+    }
+}
+
 /// Raw claims extracted from an OIDC ID token.
 #[derive(Debug, Deserialize)]
 struct IdTokenClaims {
@@ -669,5 +691,33 @@ mod tests {
         // THEN: contains expected fields
         assert!(json.contains("alice@company.com"));
         assert!(json.contains("ml-engineers"));
+    }
+
+    // MIK-6702.CP.ID.1 — stable_actor_id is collision-safe when an issuer
+    // contains ':' (the naive "oidc:{issuer}:{subject}" form would collide).
+    #[test]
+    fn stable_actor_id_is_collision_safe() {
+        let a = VerifiedIdentity {
+            subject: "b:c".to_string(),
+            email: "x@y".to_string(),
+            name: None,
+            groups: vec![],
+            issuer: "https://idp/a".to_string(),
+        };
+        let b = VerifiedIdentity {
+            subject: "c".to_string(),
+            email: "x@y".to_string(),
+            name: None,
+            groups: vec![],
+            issuer: "https://idp/a:b".to_string(),
+        };
+        // Naive format collides: "oidc:https://idp/a:b:c" for both.
+        assert_eq!(
+            format!("oidc:{}:{}", a.issuer, a.subject),
+            format!("oidc:{}:{}", b.issuer, b.subject),
+            "precondition: the naive format collides for these inputs"
+        );
+        // Length-prefixed form keeps them distinct.
+        assert_ne!(a.stable_actor_id(), b.stable_actor_id());
     }
 }

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -110,9 +110,9 @@ async fn test_stdio_initialize_produces_valid_response() {
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
+            mcp_gateway::config::Config::default(),
+        )),
     });
 
     // Call handle_initialize directly — this is what dispatch_single calls

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -97,9 +97,9 @@ fn make_app_state(cap_dir: Option<&str>, config_path: Option<std::path::PathBuf>
         firewall: None,
         agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
         control_plane_store: None,
-        control_plane_role_mapping: std::sync::Arc::new(
-            mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
-        ),
+        live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
+            mcp_gateway::config::Config::default(),
+        )),
     })
 }
 
@@ -167,9 +167,9 @@ fn make_app_state_with_reload(
             firewall: None,
             agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
             control_plane_store: None,
-            control_plane_role_mapping: std::sync::Arc::new(
-                mcp_gateway::control_plane::ControlPlaneRoleMappingConfig::default(),
-            ),
+            live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
+                mcp_gateway::config::Config::default(),
+            )),
         }),
         live_config,
     )


### PR DESCRIPTION
Closes two deferred findings from the MIK-6688 adversarial review.

**CP.RELOAD.1 / CP.RELOAD.2 — role mapping is hot-reloadable**
- `AppState` now holds `Arc<LiveConfig>` (hoisted in server startup, shared with the reload watcher) instead of a static `Arc<ControlPlaneRoleMappingConfig>`. The control-plane handlers read `state.live_config.get().control_plane.role_mapping` fresh per request, so a reload takes effect without a restart.
- Config change-detection (`MetaFields`) now includes `control_plane`, so a role-mapping-only edit is detected as reloadable. Previously it was omitted, so removing an admin rule kept granting Admin from the stale in-memory mapping until restart.

**CP.ID.1 — collision-safe actor_id**
- The old `oidc:{issuer}:{subject}` collided when an issuer contains a colon (issuer `https://idp/a` + subject `b:c` vs issuer `https://idp/a:b` + subject `c`). New `VerifiedIdentity::stable_actor_id()` length-prefixes each component (`oidc:{ilen}:{issuer}:{slen}:{subject}`), used by both the control-plane actor_id and the key-server client key so a user maps to one stable id across surfaces. Not a role-escalation path (roles come from the verified identity, not the id) but it prevents audit / user-identity row collisions.

**Acceptance criteria**
- CP.RELOAD.1 done: `role_mapping_reload_revokes_admin_without_restart` — an admin rule grants Admin, then a reload to an empty mapping revokes it on the next resolve.
- CP.RELOAD.2 done: `control_plane_role_mapping_change_is_detected` — a mapping edit yields a non-empty patch (profiles_changed).
- CP.ID.1 done: `actor_id_is_collision_safe` + `stable_actor_id_is_collision_safe` — distinct identities that collide under the naive format now map to distinct ids.

**Gates**: cargo test 3162 lib + 186 bin + 24 integration pass; clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
