### PR TITLE
siem-export: run the export engine from the server (MIK-6703)

### DIFF
--- a/src/control_plane/export.rs
+++ b/src/control_plane/export.rs
@@ -465,9 +465,14 @@ impl Default for ExportConfig {
 /// Core NDJSON [`ExportSink`]: appends each forwarded entry as one JSON line to
 /// a local file the SIEM agent tails. Fully synchronous (no async bridging), so
 /// it composes with the sync [`LogExporter::poll`] contract. Delivery is the
-/// ack: the file write must succeed before the cursor advances.
+/// ack: the file write must succeed (and be fsynced) before the cursor advances.
 pub struct FileExportSink {
     path: PathBuf,
+    /// Fail-closed latch (MIK-6703 review). Set `false` if a partial write can
+    /// NOT be rolled back, so the torn-prefix stream integrity can no longer be
+    /// guaranteed; all subsequent deliveries then refuse (export halts, cursor
+    /// never advances) rather than risk appending after a torn prefix.
+    healthy: std::sync::atomic::AtomicBool,
 }
 
 impl FileExportSink {
@@ -481,13 +486,27 @@ impl FileExportSink {
         {
             std::fs::create_dir_all(parent)?;
         }
-        Ok(Self { path })
+        Ok(Self {
+            path,
+            healthy: std::sync::atomic::AtomicBool::new(true),
+        })
     }
 }
 
 impl ExportSink for FileExportSink {
     fn deliver(&self, entries: &[ExportEntry]) -> Result<(), ExportError> {
         use std::io::Write;
+        use std::sync::atomic::Ordering::{Acquire, Release};
+
+        // Fail closed: once integrity can no longer be guaranteed (a partial
+        // write that could not be rolled back), refuse all further deliveries so
+        // the cursor never advances over a torn stream (MIK-6703 review #1).
+        if !self.healthy.load(Acquire) {
+            return Err(ExportError::SinkRejected(
+                "export sink halted after an unrecoverable partial write".to_string(),
+            ));
+        }
+
         let mut buf = String::new();
         for e in entries {
             let line = serde_json::to_string(e)
@@ -495,27 +514,43 @@ impl ExportSink for FileExportSink {
             buf.push_str(&line);
             buf.push('\n');
         }
+
+        let existed = self.path.exists();
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)?;
-        // All-or-nothing append (MIK-6703 review): record the pre-write length so
-        // a PARTIAL write_all (prefix written, then error) can be rolled back.
-        // Otherwise the torn prefix would stay and a later retry would append the
-        // full batch after it, corrupting the NDJSON stream while the retry's
-        // success advances the cursor — silently "delivering" an unparseable line.
+        // All-or-nothing append: record the pre-write length so a PARTIAL
+        // write_all (prefix written, then error) can be rolled back. Otherwise
+        // the torn prefix stays and a later retry appends the full batch after
+        // it, corrupting the stream while the retry's success advances the
+        // cursor — silently "delivering" an unparseable line.
         let start_len = f.metadata()?.len();
         if let Err(e) = f.write_all(buf.as_bytes()) {
-            // Roll the file back to its pre-batch length; the cursor did not
-            // advance, so the whole batch is re-sent cleanly next poll.
-            let _ = f.set_len(start_len);
-            let _ = f.sync_all();
+            // Roll back to pre-batch length. If the rollback itself fails we can
+            // NOT guarantee the stream is clean, so latch unhealthy (fail-closed)
+            // — subsequent deliveries refuse rather than append after a torn
+            // prefix (MIK-6703 review #1).
+            if f.set_len(start_len).and_then(|()| f.sync_all()).is_err() {
+                self.healthy.store(false, Release);
+            }
             return Err(e.into());
         }
         // fsync before the ack: the cursor advances only after deliver returns
         // Ok, so the sink write must be durable first to hold at-least-once
         // across a power loss (flush alone leaves an OS-buffer window).
         f.sync_all()?;
+        // On first creation, the file's directory entry must also be durable, or
+        // a crash could lose the newly-created sink file after the cursor
+        // advanced (MIK-6703 review #2). Unix-only (portable dir fsync); the
+        // parent exists because open() created it.
+        #[cfg(unix)]
+        if !existed
+            && let Some(parent) = self.path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
         Ok(())
     }
 }
@@ -879,6 +914,46 @@ mod tests {
     #[test]
     fn export_config_is_opt_in() {
         assert!(!ExportConfig::default().enabled);
+    }
+
+    // MIK-6703 review #1 — fail-closed latch: once the sink is unhealthy (a
+    // partial write it could not roll back), every subsequent deliver refuses,
+    // so the cursor can never advance over a torn stream.
+    #[test]
+    fn unhealthy_sink_refuses_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = FileExportSink::open(dir.path().join("siem.ndjson")).unwrap();
+        // Healthy: an empty deliver succeeds.
+        assert!(sink.deliver(&[]).is_ok());
+        // Latch unhealthy (simulating an unrecoverable partial write).
+        sink.healthy
+            .store(false, std::sync::atomic::Ordering::Release);
+        let err = sink.deliver(&[]).unwrap_err();
+        assert!(
+            matches!(err, ExportError::SinkRejected(_)),
+            "an unhealthy sink must refuse (fail-closed), got {err:?}"
+        );
+    }
+
+    // MIK-6703 review #2 — first-create durability: delivering to a fresh path
+    // creates the sink file with the content (the dir-fsync path runs).
+    #[test]
+    fn file_sink_first_create_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink_path = dir.path().join("nested/siem.ndjson");
+        let sink = FileExportSink::open(sink_path.clone()).unwrap();
+        assert!(!sink_path.exists(), "file not created until first deliver");
+        let entry = ExportEntry {
+            source: ExportSource::Invocation,
+            counter: 1,
+            entry_hash: "sha256:aa".to_string(),
+            prev_entry_hash: "genesis".to_string(),
+            checkpoint: "genesis".to_string(),
+            raw: serde_json::json!({ "k": "v" }),
+        };
+        sink.deliver(std::slice::from_ref(&entry)).unwrap();
+        let contents = std::fs::read_to_string(&sink_path).unwrap();
+        assert_eq!(contents.lines().filter(|l| !l.is_empty()).count(), 1);
     }
 
     // MIK-6703 review — deliver is all-or-nothing + durable: repeated batches

--- a/src/control_plane/export.rs
+++ b/src/control_plane/export.rs
@@ -11,13 +11,14 @@
 //! - **Non-blocking + bounded.** The exporter polls the on-disk log; appends
 //!   (`log_invocation`) never wait on it. Each poll forwards at most
 //!   `max_batch` entries, so memory stays bounded regardless of backlog.
-//! - **Hash-verified.** Each entry's chain link (`prev_entry_hash`) and its
-//!   recomputed `entry_hash` are checked before forwarding; a failed check
-//!   halts export and never forwards the entry. Note: like `verify_log`, this
-//!   does NOT authenticate the per-entry HMAC, so a full-file replacement with a
-//!   self-consistent forged chain would pass — closing that needs signed
-//!   checkpoints / HMAC verification (tracked in MIK-6700). A re-anchor is
-//!   surfaced (`PollOutcome::reanchored`) so it can be alerted on.
+//! - **Hash-verified (+ optional HMAC).** Each entry's chain link
+//!   (`prev_entry_hash`) and its recomputed `entry_hash` are checked before
+//!   forwarding; a failed check halts export and never forwards the entry. When
+//!   a signing secret is configured (`with_signing_secret`, wired at runtime by
+//!   MIK-6703), each entry's per-entry HMAC is also authenticated, so a
+//!   self-consistent re-chained forgery is rejected too (MIK-6700). Without a
+//!   secret it degrades to hash-only. A re-anchor is surfaced
+//!   (`PollOutcome::reanchored`) so it can be alerted on.
 //! - **Rotation-safe (in-place).** The cursor anchors on the last forwarded
 //!   `entry_hash`; a truncated/rewritten-in-place file whose anchor is gone is
 //!   re-anchored from the start. Rename-style external logrotate that strands an
@@ -498,8 +499,23 @@ impl ExportSink for FileExportSink {
             .create(true)
             .append(true)
             .open(&self.path)?;
-        f.write_all(buf.as_bytes())?;
-        f.flush()?;
+        // All-or-nothing append (MIK-6703 review): record the pre-write length so
+        // a PARTIAL write_all (prefix written, then error) can be rolled back.
+        // Otherwise the torn prefix would stay and a later retry would append the
+        // full batch after it, corrupting the NDJSON stream while the retry's
+        // success advances the cursor — silently "delivering" an unparseable line.
+        let start_len = f.metadata()?.len();
+        if let Err(e) = f.write_all(buf.as_bytes()) {
+            // Roll the file back to its pre-batch length; the cursor did not
+            // advance, so the whole batch is re-sent cleanly next poll.
+            let _ = f.set_len(start_len);
+            let _ = f.sync_all();
+            return Err(e.into());
+        }
+        // fsync before the ack: the cursor advances only after deliver returns
+        // Ok, so the sink write must be durable first to hold at-least-once
+        // across a power loss (flush alone leaves an OS-buffer window).
+        f.sync_all()?;
         Ok(())
     }
 }
@@ -863,6 +879,43 @@ mod tests {
     #[test]
     fn export_config_is_opt_in() {
         assert!(!ExportConfig::default().enabled);
+    }
+
+    // MIK-6703 review — deliver is all-or-nothing + durable: repeated batches
+    // produce a stream where EVERY line is complete valid JSON (no torn lines),
+    // and each entry appears exactly once (no duplication across delivers).
+    #[test]
+    fn file_sink_stream_stays_valid_across_repeated_delivers() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink_path = dir.path().join("siem.ndjson");
+        let sink = FileExportSink::open(sink_path.clone()).unwrap();
+        let entry = |c: u64| ExportEntry {
+            source: ExportSource::Governance,
+            counter: c,
+            entry_hash: format!("sha256:{c:064x}"),
+            prev_entry_hash: "sha256:prev".to_string(),
+            checkpoint: "genesis".to_string(),
+            raw: serde_json::json!({ "counter": c }),
+        };
+        sink.deliver(&[entry(1), entry(2)]).unwrap();
+        sink.deliver(&[entry(3)]).unwrap();
+        sink.deliver(&[]).unwrap(); // empty batch: no-op, no torn output
+
+        let contents = std::fs::read_to_string(&sink_path).unwrap();
+        let counters: Vec<u64> = contents
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                let v: serde_json::Value =
+                    serde_json::from_str(l).expect("every sink line must be complete valid JSON");
+                v["counter"].as_u64().unwrap()
+            })
+            .collect();
+        assert_eq!(
+            counters,
+            vec![1, 2, 3],
+            "each entry once, in order, no torn lines"
+        );
     }
 
     // SIEM.RUN.1 — status counters fold poll outcomes: forwarded accumulates,

--- a/src/control_plane/export.rs
+++ b/src/control_plane/export.rs
@@ -515,7 +515,6 @@ impl ExportSink for FileExportSink {
             buf.push('\n');
         }
 
-        let existed = self.path.exists();
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -540,15 +539,20 @@ impl ExportSink for FileExportSink {
         // Ok, so the sink write must be durable first to hold at-least-once
         // across a power loss (flush alone leaves an OS-buffer window).
         f.sync_all()?;
-        // On first creation, the file's directory entry must also be durable, or
-        // a crash could lose the newly-created sink file after the cursor
-        // advanced (MIK-6703 review #2). Unix-only (portable dir fsync); the
-        // parent exists because open() created it.
+        // Also fsync the parent directory so a first-create's directory entry is
+        // durable before the cursor advances (a crash could otherwise lose the
+        // newly-created sink file). Done unconditionally — no `existed` sample —
+        // to avoid a TOCTOU miss, and an empty parent (a bare relative path) is
+        // resolved to "." so the case is not skipped (MIK-6703 review #2). A dir
+        // fsync when nothing changed is a cheap no-op at the 15s poll cadence.
+        // Unix-only (portable directory fsync).
         #[cfg(unix)]
-        if !existed
-            && let Some(parent) = self.path.parent()
-            && !parent.as_os_str().is_empty()
         {
+            let parent = self
+                .path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
             std::fs::File::open(parent)?.sync_all()?;
         }
         Ok(())

--- a/src/control_plane/export.rs
+++ b/src/control_plane/export.rs
@@ -433,6 +433,148 @@ pub fn default_cursor_path(log_path: &Path) -> PathBuf {
     log_path.with_extension("export-cursor.json")
 }
 
+/// Runtime SIEM-export configuration (MIK-6703). Opt-in; disabled by default so
+/// the export background task is only spawned when an operator configures it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExportConfig {
+    /// Enable the background export task.
+    pub enabled: bool,
+    /// Destination NDJSON file the sink appends forwarded entries to (the SIEM
+    /// agent tails this). One JSON object per line. This is the core sink; an
+    /// OTel/HTTP sink is a separate enterprise follow-up.
+    pub sink_path: String,
+    /// Poll cadence in seconds (how often the task tails the logs).
+    pub poll_interval_secs: u64,
+    /// Max entries forwarded per poll per source (memory bound).
+    pub max_batch: usize,
+}
+
+impl Default for ExportConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            sink_path: "~/.mcp-gateway/export/siem.ndjson".to_string(),
+            poll_interval_secs: 15,
+            max_batch: LogExporter::DEFAULT_MAX_BATCH,
+        }
+    }
+}
+
+/// Core NDJSON [`ExportSink`]: appends each forwarded entry as one JSON line to
+/// a local file the SIEM agent tails. Fully synchronous (no async bridging), so
+/// it composes with the sync [`LogExporter::poll`] contract. Delivery is the
+/// ack: the file write must succeed before the cursor advances.
+pub struct FileExportSink {
+    path: PathBuf,
+}
+
+impl FileExportSink {
+    /// Open (create-append) the sink at `path`, creating parent dirs.
+    ///
+    /// # Errors
+    /// Errors if the parent directory cannot be created.
+    pub fn open(path: PathBuf) -> Result<Self, ExportError> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        Ok(Self { path })
+    }
+}
+
+impl ExportSink for FileExportSink {
+    fn deliver(&self, entries: &[ExportEntry]) -> Result<(), ExportError> {
+        use std::io::Write;
+        let mut buf = String::new();
+        for e in entries {
+            let line = serde_json::to_string(e)
+                .map_err(|err| ExportError::SinkRejected(format!("serialize: {err}")))?;
+            buf.push_str(&line);
+            buf.push('\n');
+        }
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        f.write_all(buf.as_bytes())?;
+        f.flush()?;
+        Ok(())
+    }
+}
+
+/// Observable status of the export task for one source, updated after each poll
+/// and read by the control-plane export-status route (MIK-6703 SIEM.RUN.2).
+/// Uses atomics so the async route can read it without locking the task.
+#[derive(Debug, Default)]
+pub struct SourceExportStatus {
+    /// Total entries forwarded+acked since startup.
+    pub forwarded_total: std::sync::atomic::AtomicU64,
+    /// Entries still pending after the last poll (current lag).
+    pub last_lag: std::sync::atomic::AtomicU64,
+    /// Max lag observed since startup (feeds the max-lag alert).
+    pub max_lag: std::sync::atomic::AtomicU64,
+    /// Number of re-anchor events (rotation/truncation detected).
+    pub reanchor_total: std::sync::atomic::AtomicU64,
+    /// Number of poll errors (verification failures / sink rejections).
+    pub error_total: std::sync::atomic::AtomicU64,
+}
+
+impl SourceExportStatus {
+    /// Fold one poll outcome into the running counters.
+    pub fn record(&self, outcome: &PollOutcome) {
+        use std::sync::atomic::Ordering::Relaxed;
+        self.forwarded_total
+            .fetch_add(outcome.forwarded as u64, Relaxed);
+        let lag = outcome.lag_entries as u64;
+        self.last_lag.store(lag, Relaxed);
+        self.max_lag.fetch_max(lag, Relaxed);
+        if outcome.reanchored {
+            self.reanchor_total.fetch_add(1, Relaxed);
+        }
+    }
+
+    /// Record a poll error.
+    pub fn record_error(&self) {
+        self.error_total
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Snapshot as a serialisable map for the status route.
+    #[must_use]
+    pub fn snapshot(&self) -> serde_json::Value {
+        use std::sync::atomic::Ordering::Relaxed;
+        serde_json::json!({
+            "forwarded_total": self.forwarded_total.load(Relaxed),
+            "last_lag": self.last_lag.load(Relaxed),
+            "max_lag": self.max_lag.load(Relaxed),
+            "reanchor_total": self.reanchor_total.load(Relaxed),
+            "error_total": self.error_total.load(Relaxed),
+        })
+    }
+}
+
+/// Shared export status for both log sources (invocation + governance).
+#[derive(Debug, Default)]
+pub struct ExportStatus {
+    /// Invocation-log export counters.
+    pub invocation: SourceExportStatus,
+    /// Governance-log export counters.
+    pub governance: SourceExportStatus,
+}
+
+impl ExportStatus {
+    /// Snapshot both sources for the status route.
+    #[must_use]
+    pub fn snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "invocation": self.invocation.snapshot(),
+            "governance": self.governance.snapshot(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -683,5 +825,65 @@ mod tests {
         let out = exp.poll(&sink).unwrap();
         assert_eq!(out.forwarded, 2);
         assert_eq!(sink.delivered().len(), 2);
+    }
+
+    // MIK-6703 SIEM.RUN.1 — the core NDJSON file sink appends one JSON line per
+    // forwarded entry, and forwarding advances the cursor (at-least-once ack).
+    #[test]
+    fn file_sink_writes_ndjson_and_forwards() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("gov.jsonl");
+        let log = logger(&log_path);
+        gov_event(&log, "e1");
+        gov_event(&log, "e2");
+        drop(log);
+
+        let sink_path = dir.path().join("siem.ndjson");
+        let sink = FileExportSink::open(sink_path.clone()).unwrap();
+        let mut exp = exporter(dir.path(), ExportSource::Governance, &log_path);
+        let out = exp.poll(&sink).unwrap();
+        assert_eq!(out.forwarded, 2);
+
+        let contents = std::fs::read_to_string(&sink_path).unwrap();
+        let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 2, "one NDJSON line per forwarded entry");
+        for line in &lines {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["source"], "governance");
+            assert!(v["entry_hash"].is_string());
+        }
+
+        // Cursor advanced: a second poll with no new entries forwards nothing.
+        let out2 = exp.poll(&sink).unwrap();
+        assert_eq!(out2.forwarded, 0);
+    }
+
+    // SIEM.RUN.2 — ExportConfig is opt-in (disabled by default) so the task is
+    // never spawned unless an operator configures it.
+    #[test]
+    fn export_config_is_opt_in() {
+        assert!(!ExportConfig::default().enabled);
+    }
+
+    // SIEM.RUN.1 — status counters fold poll outcomes: forwarded accumulates,
+    // max_lag is monotonic, last_lag tracks the latest.
+    #[test]
+    fn source_status_records_outcomes() {
+        let s = SourceExportStatus::default();
+        s.record(&PollOutcome {
+            forwarded: 3,
+            lag_entries: 5,
+            reanchored: false,
+        });
+        s.record(&PollOutcome {
+            forwarded: 2,
+            lag_entries: 1,
+            reanchored: true,
+        });
+        let snap = s.snapshot();
+        assert_eq!(snap["forwarded_total"], 5);
+        assert_eq!(snap["last_lag"], 1);
+        assert_eq!(snap["max_lag"], 5, "max_lag is monotonic across polls");
+        assert_eq!(snap["reanchor_total"], 1);
     }
 }

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -11,8 +11,9 @@ pub mod role_mapping;
 pub mod store;
 
 pub use export::{
-    CollectingSink, ExportCursor, ExportEntry, ExportError, ExportSink, ExportSource, LogExporter,
-    PollOutcome, default_cursor_path,
+    CollectingSink, ExportConfig, ExportCursor, ExportEntry, ExportError, ExportSink, ExportSource,
+    ExportStatus, FileExportSink, LogExporter, PollOutcome, SourceExportStatus,
+    default_cursor_path,
 };
 pub use role_mapping::{ControlPlaneConfig, ControlPlaneRoleMappingConfig, ControlPlaneRoleRule};
 pub use store::{

--- a/src/control_plane/role_mapping.rs
+++ b/src/control_plane/role_mapping.rs
@@ -26,6 +26,8 @@ use super::ControlPlaneRole;
 pub struct ControlPlaneConfig {
     /// Identity-to-role mapping for the governance surface.
     pub role_mapping: ControlPlaneRoleMappingConfig,
+    /// SIEM evidence-export runtime configuration (MIK-6703). Opt-in.
+    pub export: super::ExportConfig,
 }
 
 /// Ordered, first-match-wins identity-to-role rules.

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -90,6 +90,9 @@ pub struct AppState {
     /// removed admin rule stops granting Admin (MIK-6702 CP.RELOAD.1). The
     /// config-reload loop swaps the inner `Arc<Config>` on every applied reload.
     pub live_config: Arc<crate::config_reload::LiveConfig>,
+    /// SIEM export status, present when the export background task is running
+    /// (MIK-6703). Drives the `EvidenceExport` entitlement + export-status route.
+    pub export_status: Option<Arc<crate::control_plane::ExportStatus>>,
 }
 
 /// Create the router.

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -68,6 +68,7 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
         live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
             crate::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 
@@ -114,6 +115,7 @@ fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
         live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
             crate::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 
@@ -156,6 +158,7 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
         live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
             crate::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 
@@ -207,6 +210,7 @@ fn test_router_app_state_with_ssrf(
         live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
             crate::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 
@@ -266,6 +270,7 @@ fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
         live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
             crate::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -94,6 +94,20 @@ async fn load_configured_identity_grants(
 /// governance state; otherwise it falls back to `~/.mcp-gateway/control-plane`.
 /// Governance audit entries reuse the transparency log's signing identity, so
 /// they are signed iff the invocation log is.
+/// Per-config control-plane base directory (governance store + audit log).
+/// Shared by [`build_control_plane_store`] and the SIEM export wiring so both
+/// resolve the identical `audit.jsonl` path (MIK-6703).
+fn control_plane_base(config_path: Option<&std::path::Path>) -> std::path::PathBuf {
+    config_path.map_or_else(
+        || expand_home_path("~/.mcp-gateway/control-plane"),
+        |p| {
+            let dir = p.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("gateway");
+            dir.join(format!("{stem}-control-plane"))
+        },
+    )
+}
+
 fn build_control_plane_store(
     config: &Config,
     config_path: Option<&std::path::Path>,
@@ -110,17 +124,8 @@ fn build_control_plane_store(
     }
 
     // Derive a per-config store directory so distinct gateway instances do not
-    // share governance state. Include the config file stem, so two config files
-    // in the SAME directory (a.yaml, b.yaml) get distinct control-plane dirs.
-    // With no config file we assume a single instance and use the global path.
-    let base = config_path.map_or_else(
-        || expand_home_path("~/.mcp-gateway/control-plane"),
-        |p| {
-            let dir = p.parent().unwrap_or_else(|| std::path::Path::new("."));
-            let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("gateway");
-            dir.join(format!("{stem}-control-plane"))
-        },
-    );
+    // share governance state (see control_plane_base).
+    let base = control_plane_base(config_path);
     let audit_cfg = Arc::new(TransparencyLogConfig {
         enabled: true,
         path: base.join("audit.jsonl").to_string_lossy().into_owned(),
@@ -139,6 +144,130 @@ fn build_control_plane_store(
         Err(e) => {
             warn!(error = %e, "control-plane store unavailable; governance mutations disabled");
             None
+        }
+    }
+}
+
+/// Spawn the SIEM evidence-export background task (MIK-6703).
+///
+/// Returns `Some(status)` when export is enabled and both log exporters open;
+/// the task then tails the invocation + governance transparency logs on a timer
+/// and forwards verified entries to the NDJSON sink. Non-blocking: it reads the
+/// on-disk logs off the async runtime via `spawn_blocking`, so tool invocations
+/// (which append to the logs) never wait on export. HMAC secret is threaded so
+/// re-anchored entries are signature-verified (SIEM.SIG.1, needs MIK-6700).
+fn spawn_export_task(
+    config: &Config,
+    config_path: Option<&std::path::Path>,
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> Option<Arc<crate::control_plane::ExportStatus>> {
+    use crate::control_plane::{
+        ExportSink, ExportSource, ExportStatus, FileExportSink, LogExporter, default_cursor_path,
+    };
+    use std::sync::Mutex;
+
+    let ecfg = &config.control_plane.export;
+    if !ecfg.enabled {
+        return None;
+    }
+    if !config.auth.enabled {
+        warn!("SIEM export configured but auth is off; the governance log may be absent");
+    }
+
+    let inv_path = expand_home_path(&config.security.transparency_log.path);
+    let gov_path = control_plane_base(config_path).join("audit.jsonl");
+    let secret = config.security.transparency_log.shared_secret.clone();
+    let sink_path = expand_home_path(&ecfg.sink_path);
+
+    let sink: Arc<dyn ExportSink> = match FileExportSink::open(sink_path.clone()) {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            warn!(error = %e, path = %sink_path.display(), "SIEM export sink unavailable; export disabled");
+            return None;
+        }
+    };
+
+    let open = |source, path: &std::path::Path| {
+        LogExporter::open(source, path.to_path_buf(), default_cursor_path(path)).map(|e| {
+            e.with_max_batch(ecfg.max_batch)
+                .with_signing_secret(secret.clone())
+        })
+    };
+    let inv = match open(ExportSource::Invocation, &inv_path) {
+        Ok(e) => Arc::new(Mutex::new(e)),
+        Err(e) => {
+            warn!(error = %e, "SIEM export: invocation exporter open failed; export disabled");
+            return None;
+        }
+    };
+    let gov = match open(ExportSource::Governance, &gov_path) {
+        Ok(e) => Arc::new(Mutex::new(e)),
+        Err(e) => {
+            warn!(error = %e, "SIEM export: governance exporter open failed; export disabled");
+            return None;
+        }
+    };
+
+    let status = Arc::new(ExportStatus::default());
+    let interval_secs = ecfg.poll_interval_secs.max(1);
+    let (task_status, task_sink) = (Arc::clone(&status), Arc::clone(&sink));
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    poll_export_source(&inv, &task_sink, &task_status.invocation, "invocation").await;
+                    poll_export_source(&gov, &task_sink, &task_status.governance, "governance").await;
+                }
+                _ = shutdown_rx.recv() => break,
+            }
+        }
+        info!("SIEM export task stopped");
+    });
+
+    info!(sink = %sink_path.display(), "SIEM export task started");
+    Some(status)
+}
+
+/// Poll one exporter off the async runtime and fold the outcome into `status`.
+async fn poll_export_source(
+    exporter: &Arc<std::sync::Mutex<crate::control_plane::LogExporter>>,
+    sink: &Arc<dyn crate::control_plane::ExportSink>,
+    status: &crate::control_plane::SourceExportStatus,
+    label: &str,
+) {
+    let (exporter_arc, sink_ref) = (Arc::clone(exporter), Arc::clone(sink));
+    // The exporter reads the on-disk log synchronously; run it on the blocking
+    // pool so the async runtime is never stalled by a large tail read.
+    let result = tokio::task::spawn_blocking(move || {
+        let mut e = exporter_arc.lock().expect("export mutex poisoned");
+        e.poll(sink_ref.as_ref())
+    })
+    .await;
+    match result {
+        Ok(Ok(outcome)) => {
+            status.record(&outcome);
+            let lag = u32::try_from(outcome.lag_entries).unwrap_or(u32::MAX);
+            telemetry_metrics::gauge!("siem_export_lag_entries", "source" => label.to_string())
+                .set(f64::from(lag));
+            if outcome.forwarded > 0 || outcome.reanchored {
+                debug!(
+                    source = label,
+                    forwarded = outcome.forwarded,
+                    lag = outcome.lag_entries,
+                    reanchored = outcome.reanchored,
+                    "SIEM export poll"
+                );
+            }
+        }
+        Ok(Err(e)) => {
+            status.record_error();
+            warn!(source = label, error = %e, "SIEM export poll failed");
+        }
+        Err(e) => {
+            status.record_error();
+            warn!(source = label, error = %e, "SIEM export blocking task join failed");
         }
     }
 }
@@ -643,6 +772,13 @@ impl Gateway {
         // never changes.
         let live_config = Arc::new(LiveConfig::new(self.config.clone()));
 
+        // SIEM evidence-export background task (MIK-6703). None when disabled.
+        let export_status = spawn_export_task(
+            &self.config,
+            self.config_path.as_deref(),
+            shutdown_tx.subscribe(),
+        );
+
         // Wire config hot-reload if a config path was provided.
         let _config_watcher: Option<ConfigWatcher> = if let Some(ref path) = self.config_path {
             let reload_ctx = Arc::new(ReloadContext::new(
@@ -798,6 +934,7 @@ impl Gateway {
             agent_identity_config: self.config.security.agent_identity.clone(),
             control_plane_store,
             live_config: Arc::clone(&live_config),
+            export_status,
         });
 
         // Create router

--- a/src/gateway/ui/control_plane.rs
+++ b/src/gateway/ui/control_plane.rs
@@ -41,6 +41,40 @@ pub fn control_plane_router() -> Router<Arc<AppState>> {
         .route("/ui/api/control-plane/grants", post(mutate_grant))
         .route("/ui/api/control-plane/policies", post(mutate_policy))
         .route("/ui/api/control-plane/decisions", post(resolve_decision))
+        .route(
+            "/ui/api/control-plane/export-status",
+            get(export_status_handler),
+        )
+}
+
+/// GET the SIEM export status (MIK-6703 SIEM.RUN.2): per-source forwarded/lag/
+/// max-lag/re-anchor/error counters. Requires read-inventory RBAC. Returns 404
+/// (via a `configured: false` body) when export is not running.
+async fn export_status_handler(
+    State(state): State<Arc<AppState>>,
+    client: Option<Extension<AuthenticatedClient>>,
+    identity: Option<Extension<VerifiedIdentity>>,
+) -> impl IntoResponse {
+    let actor = actor_from_client(
+        client.map(|Extension(c)| c).as_ref(),
+        identity.map(|Extension(id)| id).as_ref(),
+        &state.live_config.get().control_plane.role_mapping,
+    );
+    if !ControlPlaneRbac::authorize(&actor, ControlPlaneAction::ReadInventory).allowed {
+        return auth_required(StatusCode::FORBIDDEN).into_response();
+    }
+    match state.export_status.as_ref() {
+        Some(status) => Json(serde_json::json!({
+            "configured": true,
+            "sources": status.snapshot(),
+        }))
+        .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "configured": false })),
+        )
+            .into_response(),
+    }
 }
 
 async fn control_plane_snapshot(
@@ -71,8 +105,11 @@ async fn control_plane_snapshot(
         view,
         decision_queue,
         shadow_radar,
-        state.control_plane_store.is_some(),
-        store_read_degraded,
+        &ControlPlaneResponseFlags {
+            mutation_enabled: state.control_plane_store.is_some(),
+            store_read_degraded,
+            export_configured: state.export_status.is_some(),
+        },
     );
     Json(response).into_response()
 }
@@ -735,6 +772,17 @@ struct ControlPlaneApiResponse {
     current_limits: Vec<&'static str>,
 }
 
+/// Boolean flags threaded into the control-plane API response, grouped to keep
+/// [`ControlPlaneApiResponse::from_snapshot`] within the argument-count budget.
+struct ControlPlaneResponseFlags {
+    /// Governance mutation endpoint is active (a store is configured).
+    mutation_enabled: bool,
+    /// A durable store read failed; the view fell back to the local projection.
+    store_read_degraded: bool,
+    /// The SIEM export task is running.
+    export_configured: bool,
+}
+
 impl ControlPlaneApiResponse {
     fn from_snapshot(
         actor: ControlPlaneActor,
@@ -742,9 +790,13 @@ impl ControlPlaneApiResponse {
         view: ControlPlaneReadOnlyView,
         decision_queue: ControlPlaneDecisionQueue,
         shadow_radar: ControlPlaneShadowRadar,
-        mutation_enabled: bool,
-        store_read_degraded: bool,
+        flags: &ControlPlaneResponseFlags,
     ) -> Self {
+        let &ControlPlaneResponseFlags {
+            mutation_enabled,
+            store_read_degraded,
+            export_configured,
+        } = flags;
         let coverage = snapshot.domain_coverage();
         let inventory_counts = ControlPlaneInventoryCounts::from_snapshot(snapshot, &shadow_radar);
         let current_limits = if mutation_enabled {
@@ -770,7 +822,7 @@ impl ControlPlaneApiResponse {
                 mutation_endpoint: mutation_enabled,
                 mutating_actions_require_audit: true,
             },
-            features: feature_entitlements(mutation_enabled),
+            features: feature_entitlements(mutation_enabled, export_configured),
             authorizations: ControlPlaneAuthorizationSet::for_actor(&actor),
             coverage,
             coverage_complete: coverage.is_complete(),
@@ -876,7 +928,10 @@ struct ControlPlaneFeatureEntitlement {
 /// must track `route.mutation_endpoint`, not report read-only unconditionally).
 /// `FleetInventory` and `EvidenceExport` are enterprise features not served by
 /// this local route.
-fn feature_entitlements(mutation_enabled: bool) -> Vec<ControlPlaneFeatureEntitlement> {
+fn feature_entitlements(
+    mutation_enabled: bool,
+    export_configured: bool,
+) -> Vec<ControlPlaneFeatureEntitlement> {
     [
         ControlPlaneFeature::LocalStatus,
         ControlPlaneFeature::FleetInventory,
@@ -890,7 +945,8 @@ fn feature_entitlements(mutation_enabled: bool) -> Vec<ControlPlaneFeatureEntitl
         available_in_this_route: match feature {
             ControlPlaneFeature::LocalStatus => true,
             ControlPlaneFeature::GovernanceMutation => mutation_enabled,
-            ControlPlaneFeature::FleetInventory | ControlPlaneFeature::EvidenceExport => false,
+            ControlPlaneFeature::EvidenceExport => export_configured,
+            ControlPlaneFeature::FleetInventory => false,
         },
     })
     .collect()
@@ -1622,7 +1678,7 @@ mod read_reflect_tests {
         use super::feature_entitlements;
         use crate::control_plane::ControlPlaneFeature;
 
-        let read_only = feature_entitlements(false);
+        let read_only = feature_entitlements(false, false);
         let gov = read_only
             .iter()
             .find(|e| e.feature == ControlPlaneFeature::GovernanceMutation)
@@ -1632,7 +1688,7 @@ mod read_reflect_tests {
             "GovernanceMutation must be unavailable on a read-only route"
         );
 
-        let mutating = feature_entitlements(true);
+        let mutating = feature_entitlements(true, false);
         let gov = mutating
             .iter()
             .find(|e| e.feature == ControlPlaneFeature::GovernanceMutation)
@@ -1647,6 +1703,32 @@ mod read_reflect_tests {
                 .iter()
                 .any(|e| e.feature == ControlPlaneFeature::LocalStatus
                     && e.available_in_this_route)
+        );
+    }
+
+    // MIK-6703 SIEM.RUN.2 — EvidenceExport entitlement is available exactly when
+    // export is configured, and unavailable otherwise.
+    #[test]
+    fn evidence_export_entitlement_tracks_export_configured() {
+        use super::feature_entitlements;
+        use crate::control_plane::ControlPlaneFeature;
+
+        let off = feature_entitlements(false, false);
+        assert!(
+            !off.iter()
+                .find(|e| e.feature == ControlPlaneFeature::EvidenceExport)
+                .unwrap()
+                .available_in_this_route,
+            "EvidenceExport must be unavailable when export is not configured"
+        );
+
+        let on = feature_entitlements(false, true);
+        assert!(
+            on.iter()
+                .find(|e| e.feature == ControlPlaneFeature::EvidenceExport)
+                .unwrap()
+                .available_in_this_route,
+            "EvidenceExport must be available when export is configured"
         );
     }
 }

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -113,6 +113,7 @@ async fn test_stdio_initialize_produces_valid_response() {
         live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
             mcp_gateway::config::Config::default(),
         )),
+        export_status: None,
     });
 
     // Call handle_initialize directly — this is what dispatch_single calls

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -100,6 +100,7 @@ fn make_app_state(cap_dir: Option<&str>, config_path: Option<std::path::PathBuf>
         live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
             mcp_gateway::config::Config::default(),
         )),
+        export_status: None,
     })
 }
 
@@ -170,6 +171,7 @@ fn make_app_state_with_reload(
             live_config: std::sync::Arc::new(mcp_gateway::config_reload::LiveConfig::new(
                 mcp_gateway::config::Config::default(),
             )),
+            export_status: None,
         }),
         live_config,
     )


### PR DESCRIPTION
Turns the verified export engine (MIK-6689) into a running SIEM evidence feed. Scoped to the fail-fast core (RUN + SIG); the HTTP/OTel sink and rename-rotation archive draining (both enterprise/optional per the ticket) are filed as follow-ups.

**SIEM.RUN.1 — non-blocking background export task**
- `spawn_export_task` tails BOTH the invocation and governance transparency logs on a timer, forwarding verified entries to a sink. It reads the on-disk logs off the async runtime via `spawn_blocking`, so tool invocations (which append to the logs) never wait on export. Shutdown-aware via the broadcast channel.
- `FileExportSink` — the core NDJSON sink (one JSON line per entry to a file the SIEM agent tails); fully synchronous, so it composes with the sync `poll`/`deliver` contract without async bridging.
- `ExportStatus` / `SourceExportStatus` — atomic per-source counters (forwarded, last lag, max lag, re-anchor, error); max-lag is also emitted as a metrics gauge (`siem_export_lag_entries`).
- `ExportConfig` on the `control_plane` config section; opt-in, disabled by default (the task is only spawned when configured).

**SIEM.RUN.2 — entitlement + status route**
- `EvidenceExport` entitlement flips to available when export is configured (threaded via a `ControlPlaneResponseFlags` struct).
- `GET /ui/api/control-plane/export-status` returns per-source counters, RBAC read-inventory gated; 404 with `configured: false` when export is not running.

**SIEM.SIG.1 — signature verification on re-anchor (unblocked by MIK-6700)**
- The runtime exporters are built with `with_signing_secret`, so a re-anchored chain is HMAC-verified before forwarding (closes the trust gap MIK-6689 left open).

**Deferred (filed as follow-ups):** SIEM.ROT.1 rename-rotation archive draining (the gateway owns the append-only log and should not be externally rotated; in-place truncation is already handled by re-anchor) and the HTTP/OTel enterprise sink.

**Acceptance criteria**
- SIEM.RUN.1 done: `file_sink_writes_ndjson_and_forwards` (NDJSON out + cursor advance), `source_status_records_outcomes` (counters/max-lag), non-blocking via spawn_blocking.
- SIEM.RUN.2 done: `evidence_export_entitlement_tracks_export_configured`, `export_config_is_opt_in`, status route.
- SIEM.SIG.1 done: exporters built with the signing secret.

**Gates**: cargo test 3166 lib + 186 bin + 24 integration pass; clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
