### PR TITLE
fix(deps): bump quick-xml to 0.41 to clear RUSTSEC-2026-0194 and 0195 (MIK-6731)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ axum-server = { version = "0.8", features = ["tls-rustls"] }
 tokio-rustls = "0.26"
 
 # XML parsing (for APIs that return XML, e.g. ECB exchange rates)
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 # Environment file loading
 dotenvy = "0.15"

--- a/src/capability/executor/xml.rs
+++ b/src/capability/executor/xml.rs
@@ -138,3 +138,46 @@ fn local_name(raw: &[u8]) -> String {
         None => s.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::xml_to_json;
+    use serde_json::json;
+
+    // Correctness contract (guards quick-xml bumps — MIK-6731): namespace prefix
+    // stripped, attributes -> "@" fields, text -> "#text", repeated children ->
+    // array. Mirrors the ECB exchange-rate feed shape.
+    #[test]
+    fn xml_to_json_maps_attrs_text_and_repeated_children() {
+        let xml = r#"<gesmes:Envelope>
+            <Cube>
+                <Cube currency="USD" rate="1.05"/>
+                <Cube currency="GBP" rate="0.85"/>
+            </Cube>
+            <note>hello</note>
+        </gesmes:Envelope>"#;
+
+        let v = xml_to_json(xml).expect("parse ok");
+        // Single root <Envelope> is unwrapped; namespace prefix stripped.
+        // The outer <Cube> wraps the two repeated inner <Cube> elements, which
+        // collapse into an array with @-prefixed attributes.
+        let inner = &v["Cube"]["Cube"];
+        assert!(
+            inner.is_array(),
+            "repeated inner <Cube> must be an array: {v}"
+        );
+        let arr = inner.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["@currency"], json!("USD"));
+        assert_eq!(arr[0]["@rate"], json!("1.05"));
+        assert_eq!(arr[1]["@currency"], json!("GBP"));
+        // Text content -> "#text".
+        assert_eq!(v["note"]["#text"], json!("hello"));
+    }
+
+    #[test]
+    fn xml_to_json_reports_parse_error() {
+        // Malformed (unclosed tag) must surface an Err, not panic.
+        assert!(xml_to_json("<a><b></a>").is_err());
+    }
+}


### PR DESCRIPTION
Two newly-published (2026-06-29) high-severity advisories against quick-xml 0.40.1 (a direct dep) were failing `cargo audit` + the Docker security gate on **every** new PR — `cargo audit` pulls the advisory DB fresh, so main went green earlier but new PRs fail on the identical dependency tree. This blocked the entire merge pipeline, including the Trust Fabric version bump.

- **RUSTSEC-2026-0194**: quadratic run time checking a start tag for duplicate attribute names.
- **RUSTSEC-2026-0195**: unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS).

Both advisories' solution is "Upgrade to >=0.41.0".

**Change**
- `Cargo.toml`: quick-xml `0.40` → `0.41`; lockfile pinned to 0.41.0. `cargo audit` now exits 0.
- Only consumer is `src/capability/executor/xml.rs::xml_to_json` (`Reader` + `events::Event`); the 0.41 API is source-compatible (no code change).
- Added the missing correctness tests for `xml_to_json` (a parser with a correctness contract had zero coverage): attrs→`@`fields, text→`#text`, repeated children→array, namespace stripping, malformed→`Err`.

**Gates**: cargo test 3171 lib pass; clippy --all-targets --all-features -D warnings clean; fmt clean; cargo audit clean. Unblocks dependency-audit + security-gate for all open PRs.
