### PR TITLE
feat(identity-propagation): per-backend config + fail-closed validation (MIK-6728 slice 2a)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -302,6 +302,33 @@ impl Config {
         self.runtime.validate()?;
         self.validate_backend_runtime_profiles()?;
         self.control_plane.role_mapping.validate()?;
+        self.validate_identity_propagation()?;
+        Ok(())
+    }
+
+    /// Validate per-backend identity-propagation config (MIK-6704 / ADR-007),
+    /// failing closed at load so a misconfigured propagation backend never
+    /// starts. Also rejects `SessionMode::PerUser` until the per-user transport
+    /// pool ships (a required `PerUser` backend would otherwise reuse one shared
+    /// MCP session across users — IDP.7); `Stateless` is supported now.
+    fn validate_identity_propagation(&self) -> Result<()> {
+        use crate::identity_propagation::SessionMode;
+        for (name, backend) in &self.backends {
+            let Some(idp) = backend.identity_propagation.as_ref() else {
+                continue;
+            };
+            idp.validate().map_err(|e| {
+                Error::ConfigValidation(format!("backend '{name}' identity_propagation: {e}"))
+            })?;
+            if idp.session_mode == SessionMode::PerUser {
+                return Err(Error::ConfigValidation(format!(
+                    "backend '{name}' identity_propagation.session_mode=per_user is not yet \
+                     supported (needs the per-user transport pool, MIK-6728 slice 2c); use \
+                     stateless for a backend that keeps no per-session state, or wait for the \
+                     pool. Refusing to start rather than reuse a shared session (IDP.7)."
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -637,6 +664,12 @@ pub struct BackendConfig {
     /// Runtime profile name resolved from top-level `runtime.profiles`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_profile: Option<String>,
+    /// End-user identity propagation (MIK-6704 / ADR-007). When set, the gateway
+    /// mints a per-user credential for outbound calls to this backend instead of
+    /// presenting only the shared static credential. Absent → unchanged
+    /// static-credential behavior (IDP.5).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_propagation: Option<crate::identity_propagation::IdentityPropagationConfig>,
 }
 
 impl Default for BackendConfig {
@@ -653,6 +686,7 @@ impl Default for BackendConfig {
             secrets: Vec::new(),
             passthrough: false,
             runtime_profile: None,
+            identity_propagation: None,
         }
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -559,3 +559,104 @@ fn validate_rejects_tampered_remote_backend_provenance_signature() {
         "error should name the backend and invalid signature: {msg}"
     );
 }
+
+// ── MIK-6728 slice 2a: identity_propagation config validation (fail-closed) ──
+
+use crate::identity_propagation::{
+    IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+};
+
+fn backend_with_idp(idp: IdentityPropagationConfig) -> BackendConfig {
+    BackendConfig {
+        transport: TransportConfig::Http {
+            http_url: "https://backend.internal/mcp".to_string(),
+            streamable_http: false,
+            protocol_version: None,
+        },
+        identity_propagation: Some(idp),
+        ..BackendConfig::default()
+    }
+}
+
+#[test]
+fn validate_accepts_stateless_signed_assertion_backend() {
+    let mut config = Config::default();
+    config.backends.insert(
+        "memory".to_string(),
+        backend_with_idp(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: "https://memory.internal".to_string(),
+            required: true,
+            session_mode: SessionMode::Stateless,
+        }),
+    );
+    assert!(
+        config.validate().is_ok(),
+        "stateless signed-assertion must validate"
+    );
+}
+
+#[test]
+fn validate_rejects_per_user_session_mode_until_pool_ships() {
+    // IDP.7: per_user needs the transport pool (slice 2c); refuse rather than
+    // reuse a shared session.
+    let mut config = Config::default();
+    config.backends.insert(
+        "mem".to_string(),
+        backend_with_idp(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: "https://mem".to_string(),
+            required: true,
+            session_mode: SessionMode::PerUser,
+        }),
+    );
+    let err = config.validate().unwrap_err().to_string();
+    assert!(
+        err.contains("per_user"),
+        "error should name per_user: {err}"
+    );
+    assert!(err.contains("mem"), "error should name the backend: {err}");
+}
+
+#[test]
+fn validate_rejects_empty_audience_backend() {
+    // IDP.3: empty audience defeats isolation; fail closed at load.
+    let mut config = Config::default();
+    config.backends.insert(
+        "b".to_string(),
+        backend_with_idp(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: String::new(),
+            required: true,
+            session_mode: SessionMode::Stateless,
+        }),
+    );
+    assert!(matches!(
+        config.validate(),
+        Err(crate::Error::ConfigValidation(_))
+    ));
+}
+
+#[test]
+fn validate_rejects_required_unimplemented_strategy() {
+    // IDP.2: a required backend on an unimplemented strategy must not silently
+    // run without propagation.
+    let mut config = Config::default();
+    config.backends.insert(
+        "b".to_string(),
+        backend_with_idp(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::TokenExchange,
+            audience: "https://mail".to_string(),
+            required: true,
+            session_mode: SessionMode::Stateless,
+        }),
+    );
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn validate_backend_without_idp_is_unchanged() {
+    // IDP.5: absent config keeps today's behavior — default config validates.
+    let config = Config::default();
+    assert!(config.validate().is_ok());
+}

--- a/tests/backend_tests.rs
+++ b/tests/backend_tests.rs
@@ -24,6 +24,7 @@ fn create_test_backend(name: &str, command: &str) -> Backend {
         secrets: Vec::new(),
         passthrough: false,
         runtime_profile: None,
+        identity_propagation: None,
     };
 
     let failsafe = FailsafeConfig::default();


### PR DESCRIPTION
Slice 2a of the IDP-FRAMEWORK live-path wiring (ADR-007, MIK-6728). Adds the per-backend opt-in config surface and enforces the safety invariants at config-load time, before any hot-path change. The invasive dispatch/transport threading is MIK-6734 (slice 2b, the release gate); the per-user transport pool is MIK-6735 (slice 2c).

- `BackendConfig` gains `identity_propagation: Option<IdentityPropagationConfig>` (serde default None, so absent config keeps unchanged static-credential behavior — IDP.5).
- `Config::validate()` gains `validate_identity_propagation()`, failing closed at load so a misconfigured propagation backend never starts:
  - IDP.3: empty audience rejected.
  - IDP.2: a `required` backend on an unimplemented strategy rejected (no silent downgrade).
  - IDP.7: `session_mode=per_user` rejected as not-yet-supported (needs the per-user transport pool, slice 2c) — refuse rather than reuse a shared MCP session across users. `stateless` accepted now.

**Tests (+5)**: stateless signed-assertion validates; per_user rejected (names the backend); empty audience rejected; required+unimplemented-strategy rejected; absent config unchanged (IDP.5).

**Gates**: cargo test 3183 lib pass; clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
