### PR TITLE
feat(identity-propagation): transport credential-header spine + identity to dispatch (MIK-6734 slice 2b-i)

### DIFF
--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -107,6 +107,10 @@ pub struct MetaMcpCallerContext<'a> {
     pub agent_id: Option<&'a str>,
     /// Verified caller subject for identity-grant evaluation.
     pub grant_subject: Option<GrantSubject>,
+    /// Full verified end-user identity, when present. Carried (not collapsed to
+    /// `grant_subject`) so the backend-invoke boundary can propagate the real
+    /// user to a backend that requires it (MIK-6704 / ADR-007 R2).
+    pub verified_identity: Option<&'a crate::key_server::oidc::VerifiedIdentity>,
 }
 
 // ============================================================================

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -620,6 +620,7 @@ pub(super) async fn meta_mcp_handler(
                         api_key_name,
                         agent_id,
                         grant_subject,
+                        verified_identity: verified_identity.as_ref(),
                     },
                 )
                 .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,7 +495,10 @@ async fn run_stdio_server(cli: Cli) -> ExitCode {
         }
     };
 
-    if let Err(e) = gateway.run_stdio().await {
+    // Box::pin: the run_stdio future is large (>16KB) since MetaMcpCallerContext
+    // gained the identity-propagation field (MIK-6734); boxing keeps it off the
+    // stack and satisfies clippy::large_futures.
+    if let Err(e) = Box::pin(gateway.run_stdio()).await {
         eprintln!("stdio gateway error: {e}");
         return ExitCode::FAILURE;
     }

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -559,13 +559,35 @@ impl HttpTransport {
 
     /// Send a raw request to the message endpoint
     async fn send_request(&self, request: &JsonRpcRequest) -> Result<JsonRpcResponse> {
+        self.send_request_with_headers(request, &[]).await
+    }
+
+    /// Send a raw request, merging `extra_headers` into the outbound header set
+    /// after the standard headers are built. Used for per-request identity
+    /// credentials (MIK-6704): the credential is applied here, on the value
+    /// passed down the call stack, never on shared `&self` state.
+    async fn send_request_with_headers(
+        &self,
+        request: &JsonRpcRequest,
+        extra_headers: &[(String, String)],
+    ) -> Result<JsonRpcResponse> {
         let message_url = self.get_message_url();
 
-        let headers = self
+        let mut headers = self
             .build_mcp_headers(HeaderMode::Request {
                 method: &request.method,
             })
             .await?;
+        // Per-request identity credential headers (e.g. Authorization: Bearer
+        // <assertion>) override any static header of the same name for this call.
+        for (k, v) in extra_headers {
+            if let (Ok(name), Ok(value)) = (
+                k.parse::<header::HeaderName>(),
+                v.parse::<header::HeaderValue>(),
+            ) {
+                headers.insert(name, value);
+            }
+        }
 
         let response = self
             .client
@@ -643,6 +665,15 @@ impl HttpTransport {
 #[async_trait]
 impl Transport for HttpTransport {
     async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse> {
+        self.request_with_headers(method, params, &[]).await
+    }
+
+    async fn request_with_headers(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        extra_headers: &[(String, String)],
+    ) -> Result<JsonRpcResponse> {
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: self.next_id(),
@@ -650,7 +681,9 @@ impl Transport for HttpTransport {
             params,
         };
 
-        let result = self.send_request(&request).await;
+        let result = self
+            .send_request_with_headers(&request, extra_headers)
+            .await;
 
         // MIK-5982 / MIK-6040: when the backend's session expires (daemon restart,
         // or a remote invalidating the MCP session on OAuth token refresh), every
@@ -682,7 +715,9 @@ impl Transport for HttpTransport {
             );
             *self.session_id.write() = None;
             self.initialize().await?;
-            return self.send_request(&request).await;
+            return self
+                .send_request_with_headers(&request, extra_headers)
+                .await;
         }
 
         result

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -908,3 +908,107 @@ fn session_expired_response_detection_matches_known_signatures() {
         error: None,
     }));
 }
+
+// MIK-6734 slice 2b-i — request_with_headers injects per-request headers on the
+// wire (the spine for identity-credential propagation), and a per-request header
+// overrides a static header of the same name for that call only.
+#[tokio::test]
+async fn request_with_headers_injects_and_overrides_on_the_wire() {
+    use axum::{Json, Router, extract::State, http::HeaderMap, routing::post};
+    use tokio::sync::{Mutex, oneshot};
+
+    async fn capture(
+        State(sender): State<Arc<Mutex<Option<oneshot::Sender<HeaderMap>>>>>,
+        headers: HeaderMap,
+        _body: axum::body::Bytes,
+    ) -> Json<serde_json::Value> {
+        if let Some(s) = sender.lock().await.take() {
+            let _ = s.send(headers);
+        }
+        Json(serde_json::json!({"jsonrpc":"2.0","id":1,"result":{}}))
+    }
+
+    let (tx, rx) = oneshot::channel();
+    let state = Arc::new(Mutex::new(Some(tx)));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/messages", post(capture))
+        .with_state(state);
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    // Static header "Authorization: static" on the transport.
+    let mut custom = HashMap::new();
+    custom.insert("Authorization".to_string(), "static".to_string());
+    let transport = make_transport_with_headers(&format!("http://{addr}/mcp"), custom);
+    *transport.message_url.write() = Some(format!("http://{addr}/messages"));
+
+    // Per-request headers: override Authorization + add a fresh header.
+    let extra = vec![
+        (
+            "Authorization".to_string(),
+            "Bearer per-user-assertion".to_string(),
+        ),
+        ("X-Idp-Audience".to_string(), "https://mem".to_string()),
+    ];
+    let _ = transport
+        .request_with_headers("tools/call", None, &extra)
+        .await;
+
+    let headers = tokio::time::timeout(Duration::from_secs(1), rx)
+        .await
+        .unwrap()
+        .unwrap();
+    // Per-request value wins over the static one.
+    assert_eq!(headers["authorization"], "Bearer per-user-assertion");
+    assert_eq!(headers["x-idp-audience"], "https://mem");
+    server.abort();
+}
+
+// The default trait method ignores extra headers: plain request() behaves the
+// same as request_with_headers(&[]) — no accidental leakage into a call that
+// passes none.
+#[tokio::test]
+async fn request_without_extra_headers_uses_static_only() {
+    use axum::{Json, Router, extract::State, http::HeaderMap, routing::post};
+    use tokio::sync::{Mutex, oneshot};
+
+    async fn capture(
+        State(sender): State<Arc<Mutex<Option<oneshot::Sender<HeaderMap>>>>>,
+        headers: HeaderMap,
+        _body: axum::body::Bytes,
+    ) -> Json<serde_json::Value> {
+        if let Some(s) = sender.lock().await.take() {
+            let _ = s.send(headers);
+        }
+        Json(serde_json::json!({"jsonrpc":"2.0","id":1,"result":{}}))
+    }
+
+    let (tx, rx) = oneshot::channel();
+    let state = Arc::new(Mutex::new(Some(tx)));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/messages", post(capture))
+        .with_state(state);
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let mut custom = HashMap::new();
+    custom.insert("Authorization".to_string(), "static".to_string());
+    let transport = make_transport_with_headers(&format!("http://{addr}/mcp"), custom);
+    *transport.message_url.write() = Some(format!("http://{addr}/messages"));
+
+    let _ = transport.request("tools/call", None).await;
+
+    let headers = tokio::time::timeout(Duration::from_secs(1), rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(headers["authorization"], "static");
+    assert!(!headers.contains_key("x-idp-audience"));
+    server.abort();
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -19,6 +19,24 @@ pub trait Transport: Send + Sync {
     /// Send a request and wait for response
     async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse>;
 
+    /// Send a request with additional per-request outbound headers (e.g. a
+    /// propagated end-user identity credential, MIK-6704).
+    ///
+    /// The headers are passed by value down the call stack — never stashed on
+    /// the shared transport — so concurrent requests from different users cannot
+    /// cross-contaminate (tenant isolation, IDP.3). Transports that carry no
+    /// HTTP headers (stdio, websocket) ignore `extra_headers` and behave exactly
+    /// like [`Transport::request`]; only HTTP-header-bearing transports apply
+    /// them. Default impl ignores the headers.
+    async fn request_with_headers(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        _extra_headers: &[(String, String)],
+    ) -> Result<JsonRpcResponse> {
+        self.request(method, params).await
+    }
+
     /// Send a notification (no response expected)
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<()>;
 


### PR DESCRIPTION
First sub-slice of the IDP live-path wiring (MIK-6734, the release gate for MIK-6704). This is the **spine + plumbing** — zero behavior change, nothing consumes it yet. The enforcement/audit/cache logic (slice 2b-ii) builds directly on top of this; splitting keeps the risky hot-path enforcement in its own reviewable diff.

**Transport — the credential-on-the-wire mechanism**
- `Transport::request_with_headers(method, params, extra_headers)`: additive default trait method that ignores the headers (stdio/websocket unchanged); `HttpTransport` overrides it to merge per-request headers after the standard set, a per-request value overriding a static header of the same name.
- Headers are passed **by value down the call stack**, never stashed on the shared `&self` transport — so concurrent requests from different users cannot cross-contaminate (tenant isolation, IDP.3). `send_request` delegates to `send_request_with_headers`; the session-expiry retry re-sends with the same headers.
- Tests (2, mock axum server): injects a fresh header + overrides a static one on the wire; plain `request()` sends static-only (no leakage into a no-extra-headers call).

**Dispatch — carry the real identity to the boundary (ADR-007 R2)**
- `MetaMcpCallerContext` gains `verified_identity: Option<&VerifiedIdentity>`, populated at the meta_mcp handler — carried rather than collapsed to `grant_subject`, so slice 2b-ii's enforcement point has the full identity.
- `Box::pin(run_stdio)` in main.rs: the future crossed clippy's 16KB `large_futures` threshold after the new field.

**Gates**: cargo test 3185 lib pass; clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
