### PR TITLE
feat(identity-propagation): enforce per-user credential on dispatch (MIK-6734 slice 2b-ii)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -728,6 +728,15 @@ impl Backend {
         self.request_with_headers(method, params, &[]).await
     }
 
+    /// This backend's end-user identity-propagation config, if configured
+    /// (MIK-6704 / ADR-007). `None` → static-credential behavior unchanged.
+    #[must_use]
+    pub fn identity_propagation_config(
+        &self,
+    ) -> Option<&crate::identity_propagation::IdentityPropagationConfig> {
+        self.config.identity_propagation.as_ref()
+    }
+
     /// Send a request, adding per-request outbound headers (e.g. a propagated
     /// end-user identity credential — MIK-6704). The headers are forwarded by
     /// value to the transport's `request_with_headers`, never stored on the

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -725,6 +725,24 @@ impl Backend {
         )
     )]
     pub async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse> {
+        self.request_with_headers(method, params, &[]).await
+    }
+
+    /// Send a request, adding per-request outbound headers (e.g. a propagated
+    /// end-user identity credential — MIK-6704). The headers are forwarded by
+    /// value to the transport's `request_with_headers`, never stored on the
+    /// backend, so concurrent per-user requests stay isolated (IDP.3).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend is unavailable, the concurrency limit
+    /// is reached, or the request itself fails after retries.
+    pub async fn request_with_headers(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        extra_headers: &[(String, String)],
+    ) -> Result<JsonRpcResponse> {
         let start_time = std::time::Instant::now();
 
         // Check failsafe
@@ -770,7 +788,12 @@ impl Backend {
             let transport = Arc::clone(&transport);
             let method = method.to_string();
             let params = params.clone();
-            async move { transport.request(&method, params).await }
+            let extra_headers = extra_headers.to_vec();
+            async move {
+                transport
+                    .request_with_headers(&method, params, &extra_headers)
+                    .await
+            }
         })
         .await;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -320,6 +320,17 @@ impl Config {
             idp.validate().map_err(|e| {
                 Error::ConfigValidation(format!("backend '{name}' identity_propagation: {e}"))
             })?;
+            // Only HTTP transports can carry the per-request credential header;
+            // stdio/websocket would silently drop it (their transport ignores
+            // extra headers), so a propagation-configured non-HTTP backend must
+            // fail closed at load rather than dispatch without the credential
+            // (MIK-6734 review).
+            if !matches!(backend.transport, TransportConfig::Http { .. }) {
+                return Err(Error::ConfigValidation(format!(
+                    "backend '{name}' identity_propagation requires an http transport; \
+                     stdio/websocket cannot carry the credential header (IDP.2)"
+                )));
+            }
             if idp.session_mode == SessionMode::PerUser {
                 return Err(Error::ConfigValidation(format!(
                     "backend '{name}' identity_propagation.session_mode=per_user is not yet \

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -619,6 +619,31 @@ fn validate_rejects_per_user_session_mode_until_pool_ships() {
 }
 
 #[test]
+fn validate_rejects_identity_propagation_on_non_http_transport() {
+    // IDP.2: stdio/websocket transports silently drop per-request headers, so a
+    // propagation-configured non-HTTP backend must fail closed at load rather
+    // than dispatch without the credential (MIK-6734 review finding).
+    let mut config = Config::default();
+    let mut backend = backend_with_idp(IdentityPropagationConfig {
+        strategy: PropagationStrategyKind::SignedAssertion,
+        audience: "https://mem".to_string(),
+        required: true,
+        session_mode: SessionMode::Stateless,
+    });
+    backend.transport = TransportConfig::Stdio {
+        command: "echo".to_string(),
+        cwd: None,
+        protocol_version: None,
+    };
+    config.backends.insert("mem".to_string(), backend);
+    let err = config.validate().unwrap_err().to_string();
+    assert!(
+        err.contains("http transport"),
+        "error should require http transport: {err}"
+    );
+}
+
+#[test]
 fn validate_rejects_empty_audience_backend() {
     // IDP.3: empty audience defeats isolation; fail closed at load.
     let mut config = Config::default();

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -2517,6 +2517,8 @@ mod response_transform_tests {
 mod identity_propagation_enforcement_tests {
     use std::sync::Arc;
 
+    use serde_json::{Value, json};
+
     use crate::backend::BackendRegistry;
     use crate::gateway::meta_mcp::MetaMcp;
     use crate::gateway::oauth::GatewayKeyPair;
@@ -2549,6 +2551,123 @@ mod identity_propagation_enforcement_tests {
             groups: vec![],
             issuer: "https://idp".to_string(),
         }
+    }
+
+    // Header-capturing transport: records the per-request headers dispatch
+    // attaches, so a test can assert the propagated credential reached the wire.
+    type CapturedHeaders = Arc<parking_lot::Mutex<Vec<(String, String)>>>;
+
+    struct CapturingTransport {
+        captured: CapturedHeaders,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::transport::Transport for CapturingTransport {
+        async fn request(
+            &self,
+            _method: &str,
+            _params: Option<Value>,
+        ) -> crate::Result<crate::protocol::JsonRpcResponse> {
+            Ok(crate::protocol::JsonRpcResponse::success(
+                crate::protocol::RequestId::Number(1),
+                json!({"content": [{"type": "text", "text": "ok"}]}),
+            ))
+        }
+        async fn request_with_headers(
+            &self,
+            _method: &str,
+            _params: Option<Value>,
+            extra_headers: &[(String, String)],
+        ) -> crate::Result<crate::protocol::JsonRpcResponse> {
+            *self.captured.lock() = extra_headers.to_vec();
+            self.request(_method, _params).await
+        }
+        async fn notify(&self, _method: &str, _params: Option<Value>) -> crate::Result<()> {
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        async fn close(&self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Build a MetaMcp whose registry has one identity-required HTTP backend
+    // ("mem") wired to a header-capturing transport, plus the signed-assertion
+    // strategy. Returns the meta and the shared capture buffer.
+    fn meta_with_capturing_backend() -> (MetaMcp, CapturedHeaders) {
+        use crate::backend::Backend;
+        use crate::config::{BackendConfig, TransportConfig};
+
+        let registry = Arc::new(BackendRegistry::new());
+        let config = BackendConfig {
+            transport: TransportConfig::Http {
+                http_url: "https://mem.internal/mcp".to_string(),
+                streamable_http: true,
+                protocol_version: None,
+            },
+            identity_propagation: Some(idp_cfg(true)),
+            ..BackendConfig::default()
+        };
+        let backend = Arc::new(Backend::new(
+            "mem",
+            config,
+            &crate::config::FailsafeConfig::default(),
+            std::time::Duration::from_secs(60),
+        ));
+        let captured = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        backend.set_transport_for_test(Arc::new(CapturingTransport {
+            captured: Arc::clone(&captured),
+        }));
+        registry.register(backend);
+
+        let m = MetaMcp::new(registry);
+        let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
+        m.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
+        (m, captured)
+    }
+
+    // IDP.1 end-to-end via Code Mode (gateway_execute): an authenticated caller
+    // invoking an identity-required backend through code_mode_execute reaches the
+    // backend WITH the per-user Bearer credential on the wire. Regression guard
+    // for the review finding that Code Mode dropped verified_identity.
+    #[tokio::test]
+    async fn code_mode_execute_propagates_identity_to_backend() {
+        let (m, captured) = meta_with_capturing_backend();
+        let id = identity();
+        let caller = crate::gateway::meta_mcp::MetaMcpCallerContext {
+            verified_identity: Some(&id),
+            ..Default::default()
+        };
+        let args = json!({ "tool": "mem:read", "arguments": {} });
+        m.code_mode_execute(&args, Some("s1"), &caller)
+            .await
+            .expect("code-mode execute ok");
+
+        let headers = captured.lock().clone();
+        let auth = headers.iter().find(|(k, _)| k == "Authorization");
+        assert!(
+            auth.is_some_and(|(_, v)| v.starts_with("Bearer ")),
+            "Code Mode must propagate the per-user Bearer credential; got {headers:?}"
+        );
+    }
+
+    // Fail-closed still holds through Code Mode: a required backend with NO
+    // verified identity refuses at resolve, before dispatch.
+    #[tokio::test]
+    async fn code_mode_execute_fails_closed_without_identity() {
+        let (m, _captured) = meta_with_capturing_backend();
+        let caller = crate::gateway::meta_mcp::MetaMcpCallerContext::default();
+        let args = json!({ "tool": "mem:read", "arguments": {} });
+        let err = m
+            .code_mode_execute(&args, Some("s1"), &caller)
+            .await
+            .expect_err("must refuse without identity");
+        assert!(
+            err.to_string().contains("required"),
+            "fail-closed error: {err}"
+        );
     }
 
     // IDP.1 — with a verified identity + strategy, resolve mints an

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -374,6 +374,7 @@ impl MetaMcp {
         api_key_name: Option<&str>,
         agent_id: Option<&str>,
         caller_identity: Option<GrantSubject>,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
     ) -> Result<Value> {
         let trace_id = trace::generate();
         let trace_id_clone = trace_id.clone();
@@ -384,6 +385,7 @@ impl MetaMcp {
                 api_key_name,
                 agent_id,
                 caller_identity.as_ref(),
+                verified_identity,
                 &trace_id_clone,
             )
             .await
@@ -398,6 +400,7 @@ impl MetaMcp {
     /// Returns a [`GuardedValue`]: every success path must produce one, so the
     /// render guard cannot be bypassed at the chokepoint (MIK-6690).
     #[allow(clippy::too_many_lines)] // Complex dispatch logic; splitting further harms readability
+    #[allow(clippy::too_many_arguments)] // Caller context threaded explicitly (identity, keys, trace)
     async fn invoke_tool_traced(
         &self,
         args: &Value,
@@ -405,6 +408,7 @@ impl MetaMcp {
         api_key_name: Option<&str>,
         agent_id: Option<&str>,
         caller_identity: Option<&GrantSubject>,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
         trace_id: &str,
     ) -> Result<GuardedValue> {
         let server = extract_required_str(args, "server")?;
@@ -668,6 +672,7 @@ impl MetaMcp {
                 api_key_name,
                 agent_id,
                 caller_identity,
+                verified_identity,
             )
             .await;
         let dispatch_latency = dispatch_start.elapsed();
@@ -1286,12 +1291,68 @@ impl MetaMcp {
         }
     }
 
+    /// Mint the per-user identity-propagation headers for a backend configured
+    /// with `identity_propagation` (MIK-6704 / ADR-007). Fail-closed for a
+    /// `required` backend: returns `Err` — never a static-credential fallback —
+    /// when there is no verified identity, no propagation strategy wired, the
+    /// strategy refuses, or a minted header does not parse. For a non-required
+    /// backend, a mint failure degrades to no extra headers (best-effort).
+    async fn mint_propagation_headers(
+        &self,
+        server: &str,
+        idp_cfg: &crate::identity_propagation::IdentityPropagationConfig,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+    ) -> Result<Vec<(String, String)>> {
+        use crate::identity_propagation::BackendDescriptor;
+
+        let refuse = |msg: String| -> Result<Vec<(String, String)>> {
+            if idp_cfg.required {
+                Err(Error::Config(format!(
+                    "identity propagation required for backend '{server}' but {msg}"
+                )))
+            } else {
+                // Best-effort: unconfigured-required backend proceeds with static creds.
+                Ok(Vec::new())
+            }
+        };
+
+        let Some(identity) = verified_identity else {
+            return refuse("the request carries no verified end-user identity".to_string());
+        };
+        let strategy = self.identity_propagation.read().clone();
+        let Some(strategy) = strategy else {
+            return refuse("no identity-propagation strategy is configured".to_string());
+        };
+
+        let descriptor = BackendDescriptor {
+            id: server.to_string(),
+            audience: idp_cfg.audience.clone(),
+        };
+        match strategy.propagate(identity, &descriptor).await {
+            Ok(cred) => {
+                // Validate every header parses BEFORE dispatch, so an invalid
+                // minted credential fails closed rather than silently letting the
+                // static Authorization through (MIK-6734 review carry-forward).
+                for (k, v) in &cred.headers {
+                    if k.parse::<reqwest::header::HeaderName>().is_err()
+                        || v.parse::<reqwest::header::HeaderValue>().is_err()
+                    {
+                        return refuse(format!("minted credential header '{k}' is invalid"));
+                    }
+                }
+                Ok(cred.headers)
+            }
+            Err(e) => refuse(format!("credential minting failed: {e}")),
+        }
+    }
+
     /// Dispatch a `tools/call` to the capability backend or an MCP backend.
     ///
     /// Applies secret injection before forwarding. When `prompt_cache_key` is
     /// `Some`, it is injected into the request `_meta` field so that
     /// OpenAI-compatible backends can use it for prompt caching.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_lines)] // Coherent dispatch unit; identity-propagation enforcement inline
     async fn dispatch_to_backend(
         &self,
         server: &str,
@@ -1303,6 +1364,7 @@ impl MetaMcp {
         api_key_name: Option<&str>,
         agent_id: Option<&str>,
         caller_identity: Option<&GrantSubject>,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
     ) -> Result<Value> {
         let injection = self.secret_injector.inject(server, tool, arguments)?;
         let arguments = injection.arguments;
@@ -1412,7 +1474,24 @@ impl MetaMcp {
             None => base_params,
         };
 
-        let response = backend.request("tools/call", Some(params)).await?;
+        // End-user identity propagation (MIK-6704 / ADR-007). When this backend
+        // is configured for propagation, mint a per-user credential and send it
+        // as per-request headers via `request_with_headers` (never on the shared
+        // transport — tenant isolation, IDP.3). Fail-closed for a `required`
+        // backend: no identity / no strategy / mint failure / unparseable header
+        // all refuse the call rather than fall back to the static credential
+        // (IDP.2). Absent config → unchanged static-credential path (IDP.5).
+        let response = match backend.identity_propagation_config() {
+            Some(idp_cfg) => {
+                let headers = self
+                    .mint_propagation_headers(server, idp_cfg, verified_identity)
+                    .await?;
+                backend
+                    .request_with_headers("tools/call", Some(params), &headers)
+                    .await?
+            }
+            None => backend.request("tools/call", Some(params)).await?,
+        };
 
         if let Some(error) = response.error {
             // When we have cached names and the tool wasn't in them, enrich
@@ -2402,5 +2481,99 @@ mod response_transform_tests {
             "a projection that keeps a present field stays populated"
         );
         assert_eq!(transformed.get("id"), Some(&json!("abc")));
+    }
+}
+
+#[cfg(test)]
+mod identity_propagation_enforcement_tests {
+    use std::sync::Arc;
+
+    use crate::backend::BackendRegistry;
+    use crate::gateway::meta_mcp::MetaMcp;
+    use crate::gateway::oauth::GatewayKeyPair;
+    use crate::identity_propagation::{
+        IdentityPropagationConfig, PropagationStrategyKind, SessionMode, SignedAssertionStrategy,
+    };
+    use crate::key_server::oidc::VerifiedIdentity;
+
+    fn meta_with_strategy() -> MetaMcp {
+        let m = MetaMcp::new(Arc::new(BackendRegistry::new()));
+        let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
+        m.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
+        m
+    }
+
+    fn idp_cfg(required: bool) -> IdentityPropagationConfig {
+        IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: "https://memory.internal".to_string(),
+            required,
+            session_mode: SessionMode::Stateless,
+        }
+    }
+
+    fn identity() -> VerifiedIdentity {
+        VerifiedIdentity {
+            subject: "alice".to_string(),
+            email: "alice@corp".to_string(),
+            name: None,
+            groups: vec![],
+            issuer: "https://idp".to_string(),
+        }
+    }
+
+    // IDP.1 — with a verified identity + strategy, dispatch mints an
+    // Authorization: Bearer credential scoped to the caller.
+    #[tokio::test]
+    async fn mints_bearer_credential_for_identity() {
+        let m = meta_with_strategy();
+        let headers = m
+            .mint_propagation_headers("memory", &idp_cfg(true), Some(&identity()))
+            .await
+            .expect("mint ok");
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0, "Authorization");
+        assert!(headers[0].1.starts_with("Bearer "));
+    }
+
+    // IDP.2 — fail-closed: a REQUIRED backend with no verified identity refuses
+    // (never falls back to the static credential).
+    #[tokio::test]
+    async fn required_backend_without_identity_fails_closed() {
+        let m = meta_with_strategy();
+        let err = m
+            .mint_propagation_headers("memory", &idp_cfg(true), None)
+            .await
+            .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("required"),
+            "fail-closed error: {err}"
+        );
+    }
+
+    // IDP.2 — fail-closed: a REQUIRED backend with no strategy wired refuses.
+    #[tokio::test]
+    async fn required_backend_without_strategy_fails_closed() {
+        let m = MetaMcp::new(Arc::new(BackendRegistry::new())); // no strategy set
+        let err = m
+            .mint_propagation_headers("memory", &idp_cfg(true), Some(&identity()))
+            .await
+            .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("required"),
+            "fail-closed error: {err}"
+        );
+    }
+
+    // A NON-required backend without identity degrades to no extra headers
+    // (best-effort; static-credential path unchanged, IDP.5).
+    #[tokio::test]
+    async fn optional_backend_without_identity_yields_no_headers() {
+        let m = meta_with_strategy();
+        let headers = m
+            .mint_propagation_headers("memory", &idp_cfg(false), None)
+            .await
+            .expect("optional ok");
+        assert!(headers.is_empty());
     }
 }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -28,6 +28,20 @@ use crate::provider::transforms::ResponseTransform;
 use crate::security::validate_tool_name;
 use crate::{Error, Result};
 
+/// The per-user identity-propagation credential resolved once for a single
+/// dispatch (MIK-6704 / ADR-007). Carries the headers to put on the wire and
+/// the cache binding to isolate cached results by user+audience. The default
+/// (empty headers, `None` binding) means "not identity-scoped" — plain dispatch
+/// and a shared cache key.
+#[derive(Debug, Default)]
+struct CallerCredential {
+    /// Per-request outbound headers (empty = none).
+    headers: Vec<(String, String)>,
+    /// Collision-safe user+audience cache binding. `Some` → mix into cache keys
+    /// so per-user results stay isolated (IDP.8); `None` → shared key is safe.
+    cache_binding: Option<String>,
+}
+
 /// Render-guard non-bypassability (MIK-5854 / MIK-6690).
 ///
 /// `GuardedValue` wraps a tool result that has passed the context-integrity
@@ -525,6 +539,28 @@ impl MetaMcp {
         // into the other (a non-`_full` caller could hit a cached full payload
         // and receive fields the projection was meant to drop). A `_full` call
         // is therefore always a fresh, uncached dispatch.
+        // Resolve the per-user propagation credential ONCE (MIK-6734 / ADR-007).
+        // Single identity gate: fail-closed here for a required backend, and the
+        // resolved `cache_binding` (user+audience) is mixed into every cache key
+        // so per-user results cache in ISOLATION rather than leaking across users
+        // (IDP.3/8) — reused verbatim at dispatch so there is no re-mint or drift.
+        let caller_credential = match self
+            .backends
+            .get(server)
+            .and_then(|b| b.identity_propagation_config().cloned())
+        {
+            Some(idp_cfg) => {
+                self.resolve_caller_credential(server, &idp_cfg, verified_identity)
+                    .await?
+            }
+            None => CallerCredential::default(),
+        };
+        let identity_suffix = caller_credential
+            .cache_binding
+            .as_deref()
+            .map(|b| format!("|idp:{b}"))
+            .unwrap_or_default();
+
         let idem_key = if want_full {
             None
         } else {
@@ -535,13 +571,7 @@ impl MetaMcp {
                 &arguments,
                 self.idempotency_cache.as_ref(),
             )
-            .map(|k| {
-                if projection_key_suffix.is_empty() {
-                    k
-                } else {
-                    format!("{k}{projection_key_suffix}")
-                }
-            })
+            .map(|k| format!("{k}{projection_key_suffix}{identity_suffix}"))
         };
 
         if let (Some(idem_cache), Some(key)) = (&self.idempotency_cache, &idem_key) {
@@ -574,11 +604,7 @@ impl MetaMcp {
         if !want_full && let Some(ref cache) = self.cache {
             let cache_key = {
                 let base = ResponseCache::build_key(server, tool, &arguments);
-                if projection_key_suffix.is_empty() {
-                    base
-                } else {
-                    format!("{base}{projection_key_suffix}")
-                }
+                format!("{base}{projection_key_suffix}{identity_suffix}")
             };
             if let Some(cached) = cache.get(&cache_key) {
                 debug!(server, tool, trace_id, "Cache hit");
@@ -672,7 +698,7 @@ impl MetaMcp {
                 api_key_name,
                 agent_id,
                 caller_identity,
-                verified_identity,
+                &caller_credential.headers,
             )
             .await;
         let dispatch_latency = dispatch_start.elapsed();
@@ -1001,11 +1027,7 @@ impl MetaMcp {
         if !want_full && let Some(ref cache) = self.cache {
             let cache_key = {
                 let base = ResponseCache::build_key(server, tool, &arguments);
-                if projection_key_suffix.is_empty() {
-                    base
-                } else {
-                    format!("{base}{projection_key_suffix}")
-                }
+                format!("{base}{projection_key_suffix}{identity_suffix}")
             };
             cache.set(&cache_key, result.clone(), self.default_cache_ttl);
             debug!(server, tool, trace_id, ttl = ?self.default_cache_ttl, "Cached result");
@@ -1291,28 +1313,32 @@ impl MetaMcp {
         }
     }
 
-    /// Mint the per-user identity-propagation headers for a backend configured
-    /// with `identity_propagation` (MIK-6704 / ADR-007). Fail-closed for a
-    /// `required` backend: returns `Err` — never a static-credential fallback —
-    /// when there is no verified identity, no propagation strategy wired, the
-    /// strategy refuses, or a minted header does not parse. For a non-required
-    /// backend, a mint failure degrades to no extra headers (best-effort).
-    async fn mint_propagation_headers(
+    /// Resolve the per-user identity-propagation credential for a backend
+    /// configured with `identity_propagation` (MIK-6704 / ADR-007). This is the
+    /// single identity gate: minting, fail-closed enforcement, and the cache
+    /// binding are decided once here, then reused for the cache key AND dispatch.
+    ///
+    /// Fail-closed for a `required` backend: returns `Err` — never a
+    /// static-credential fallback — when there is no verified identity, no
+    /// propagation strategy wired, the strategy refuses, or a minted header does
+    /// not parse. For a non-required backend, a mint failure degrades to the
+    /// empty credential (no headers, no binding → shared cache key, best-effort).
+    async fn resolve_caller_credential(
         &self,
         server: &str,
         idp_cfg: &crate::identity_propagation::IdentityPropagationConfig,
         verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
-    ) -> Result<Vec<(String, String)>> {
+    ) -> Result<CallerCredential> {
         use crate::identity_propagation::BackendDescriptor;
 
-        let refuse = |msg: String| -> Result<Vec<(String, String)>> {
+        let refuse = |msg: String| -> Result<CallerCredential> {
             if idp_cfg.required {
                 Err(Error::Config(format!(
                     "identity propagation required for backend '{server}' but {msg}"
                 )))
             } else {
-                // Best-effort: unconfigured-required backend proceeds with static creds.
-                Ok(Vec::new())
+                // Best-effort: non-required backend proceeds with static creds.
+                Ok(CallerCredential::default())
             }
         };
 
@@ -1340,7 +1366,13 @@ impl MetaMcp {
                         return refuse(format!("minted credential header '{k}' is invalid"));
                     }
                 }
-                Ok(cred.headers)
+                // cache_binding distinguishes user AND audience (collision-safe),
+                // so per-user results cache in isolation instead of being dropped
+                // (IDP.8 — replaces the earlier blanket cache bypass).
+                Ok(CallerCredential {
+                    headers: cred.headers,
+                    cache_binding: Some(cred.cache_binding),
+                })
             }
             Err(e) => refuse(format!("credential minting failed: {e}")),
         }
@@ -1364,7 +1396,10 @@ impl MetaMcp {
         api_key_name: Option<&str>,
         agent_id: Option<&str>,
         caller_identity: Option<&GrantSubject>,
-        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+        // Pre-resolved per-user propagation headers (empty = none). Resolved
+        // once in `invoke_tool_traced` so the cache key and this dispatch share
+        // one credential (MIK-6734); dispatch never mints.
+        propagated_headers: &[(String, String)],
     ) -> Result<Value> {
         let injection = self.secret_injector.inject(server, tool, arguments)?;
         let arguments = injection.arguments;
@@ -1474,23 +1509,17 @@ impl MetaMcp {
             None => base_params,
         };
 
-        // End-user identity propagation (MIK-6704 / ADR-007). When this backend
-        // is configured for propagation, mint a per-user credential and send it
-        // as per-request headers via `request_with_headers` (never on the shared
-        // transport — tenant isolation, IDP.3). Fail-closed for a `required`
-        // backend: no identity / no strategy / mint failure / unparseable header
-        // all refuse the call rather than fall back to the static credential
-        // (IDP.2). Absent config → unchanged static-credential path (IDP.5).
-        let response = match backend.identity_propagation_config() {
-            Some(idp_cfg) => {
-                let headers = self
-                    .mint_propagation_headers(server, idp_cfg, verified_identity)
-                    .await?;
-                backend
-                    .request_with_headers("tools/call", Some(params), &headers)
-                    .await?
-            }
-            None => backend.request("tools/call", Some(params)).await?,
+        // End-user identity propagation (MIK-6704 / ADR-007). The per-user
+        // credential was resolved (and fail-closed enforced) once upstream in
+        // `invoke_tool_traced`; here we simply attach the pre-resolved headers
+        // via `request_with_headers` (per-request, never on the shared transport
+        // — tenant isolation, IDP.3). Empty headers → the unchanged static path.
+        let response = if propagated_headers.is_empty() {
+            backend.request("tools/call", Some(params)).await?
+        } else {
+            backend
+                .request_with_headers("tools/call", Some(params), propagated_headers)
+                .await?
         };
 
         if let Some(error) = response.error {
@@ -2522,18 +2551,46 @@ mod identity_propagation_enforcement_tests {
         }
     }
 
-    // IDP.1 — with a verified identity + strategy, dispatch mints an
-    // Authorization: Bearer credential scoped to the caller.
+    // IDP.1 — with a verified identity + strategy, resolve mints an
+    // Authorization: Bearer credential scoped to the caller, and a cache binding.
     #[tokio::test]
     async fn mints_bearer_credential_for_identity() {
         let m = meta_with_strategy();
-        let headers = m
-            .mint_propagation_headers("memory", &idp_cfg(true), Some(&identity()))
+        let cred = m
+            .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
             .await
             .expect("mint ok");
-        assert_eq!(headers.len(), 1);
-        assert_eq!(headers[0].0, "Authorization");
-        assert!(headers[0].1.starts_with("Bearer "));
+        assert_eq!(cred.headers.len(), 1);
+        assert_eq!(cred.headers[0].0, "Authorization");
+        assert!(cred.headers[0].1.starts_with("Bearer "));
+        // IDP.8 — a cache binding is produced so per-user results cache isolated.
+        assert!(cred.cache_binding.is_some());
+    }
+
+    // IDP.8 — distinct identities produce distinct cache bindings, so two users
+    // calling the same tool with the same arguments cannot collide in the cache.
+    #[tokio::test]
+    async fn distinct_identities_get_distinct_cache_bindings() {
+        let m = meta_with_strategy();
+        let alice = m
+            .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
+            .await
+            .expect("alice")
+            .cache_binding;
+        let bob_identity = VerifiedIdentity {
+            subject: "bob".to_string(),
+            email: "bob@corp".to_string(),
+            name: None,
+            groups: vec![],
+            issuer: "https://idp".to_string(),
+        };
+        let bob = m
+            .resolve_caller_credential("memory", &idp_cfg(true), Some(&bob_identity))
+            .await
+            .expect("bob")
+            .cache_binding;
+        assert!(alice.is_some() && bob.is_some());
+        assert_ne!(alice, bob, "per-user cache bindings must differ");
     }
 
     // IDP.2 — fail-closed: a REQUIRED backend with no verified identity refuses
@@ -2542,7 +2599,7 @@ mod identity_propagation_enforcement_tests {
     async fn required_backend_without_identity_fails_closed() {
         let m = meta_with_strategy();
         let err = m
-            .mint_propagation_headers("memory", &idp_cfg(true), None)
+            .resolve_caller_credential("memory", &idp_cfg(true), None)
             .await
             .expect_err("must refuse");
         assert!(
@@ -2556,7 +2613,7 @@ mod identity_propagation_enforcement_tests {
     async fn required_backend_without_strategy_fails_closed() {
         let m = MetaMcp::new(Arc::new(BackendRegistry::new())); // no strategy set
         let err = m
-            .mint_propagation_headers("memory", &idp_cfg(true), Some(&identity()))
+            .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
             .await
             .expect_err("must refuse");
         assert!(
@@ -2565,15 +2622,16 @@ mod identity_propagation_enforcement_tests {
         );
     }
 
-    // A NON-required backend without identity degrades to no extra headers
-    // (best-effort; static-credential path unchanged, IDP.5).
+    // A NON-required backend without identity degrades to the empty credential
+    // (best-effort; no headers, no binding → shared cache key, IDP.5).
     #[tokio::test]
     async fn optional_backend_without_identity_yields_no_headers() {
         let m = meta_with_strategy();
-        let headers = m
-            .mint_propagation_headers("memory", &idp_cfg(false), None)
+        let cred = m
+            .resolve_caller_credential("memory", &idp_cfg(false), None)
             .await
             .expect("optional ok");
-        assert!(headers.is_empty());
+        assert!(cred.headers.is_empty());
+        assert!(cred.cache_binding.is_none());
     }
 }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1313,6 +1313,29 @@ impl MetaMcp {
         }
     }
 
+    /// Resolve the per-user propagation headers for a backend by name, for the
+    /// direct backend route (`/mcp/{name}`) which does not go through
+    /// `dispatch_to_backend` (MIK-6704). Returns the empty vec when the backend
+    /// is not propagation-configured (unchanged static path); fail-closed `Err`
+    /// for a `required` backend with no identity/strategy.
+    pub async fn resolve_propagation_headers(
+        &self,
+        server: &str,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+    ) -> Result<Vec<(String, String)>> {
+        let Some(idp_cfg) = self
+            .backends
+            .get(server)
+            .and_then(|b| b.identity_propagation_config().cloned())
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(self
+            .resolve_caller_credential(server, &idp_cfg, verified_identity)
+            .await?
+            .headers)
+    }
+
     /// Resolve the per-user identity-propagation credential for a backend
     /// configured with `identity_propagation` (MIK-6704 / ADR-007). This is the
     /// single identity gate: minting, fail-closed enforcement, and the cache
@@ -2752,5 +2775,50 @@ mod identity_propagation_enforcement_tests {
             .expect("optional ok");
         assert!(cred.headers.is_empty());
         assert!(cred.cache_binding.is_none());
+    }
+
+    // Direct backend route (/mcp/{name}) — resolve_propagation_headers mints the
+    // per-user credential for a propagation-configured backend so the direct
+    // passthrough carries it too (MIK-6734 review finding 4).
+    #[tokio::test]
+    async fn direct_route_resolves_bearer_for_identity() {
+        let (m, _captured) = meta_with_capturing_backend();
+        let headers = m
+            .resolve_propagation_headers("mem", Some(&identity()))
+            .await
+            .expect("resolve ok");
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "Authorization" && v.starts_with("Bearer ")),
+            "direct route must resolve the per-user Bearer credential: {headers:?}"
+        );
+    }
+
+    // Direct route fails closed for a required backend with no identity — never
+    // forwards with only the static credential.
+    #[tokio::test]
+    async fn direct_route_fails_closed_without_identity() {
+        let (m, _captured) = meta_with_capturing_backend();
+        let err = m
+            .resolve_propagation_headers("mem", None)
+            .await
+            .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("required"),
+            "fail-closed error: {err}"
+        );
+    }
+
+    // Direct route to a backend with no identity_propagation config is unchanged
+    // (empty headers → static path).
+    #[tokio::test]
+    async fn direct_route_unconfigured_backend_yields_no_headers() {
+        let (m, _captured) = meta_with_capturing_backend();
+        let headers = m
+            .resolve_propagation_headers("no-such-backend", Some(&identity()))
+            .await
+            .expect("resolve ok");
+        assert!(headers.is_empty());
     }
 }

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -956,7 +956,10 @@ impl MetaMcp {
 
         let result = match tool_name {
             "gateway_search" => self.code_mode_search(&arguments, session_id).await,
-            "gateway_execute" => self.code_mode_execute(&arguments, session_id).await,
+            "gateway_execute" => {
+                self.code_mode_execute(&arguments, session_id, &caller)
+                    .await
+            }
             "gateway_list_servers" => self.list_servers(),
             "gateway_list_tools" => self.list_tools(&arguments, session_id).await,
             "gateway_search_tools" => self.search_tools(&arguments, session_id).await,

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -136,6 +136,12 @@ pub struct MetaMcp {
     pub(super) profile_registry: Arc<ProfileRegistry>,
     pub(super) session_profiles: Arc<SessionProfileStore>,
     pub(super) reload_context: RwLock<Option<Arc<ReloadContext>>>,
+    /// End-user identity-propagation strategy (MIK-6704 / ADR-007). `Some` when
+    /// at least one backend is configured for propagation; the dispatch path
+    /// uses it to mint a per-user credential for such backends. `None` disables
+    /// propagation entirely (all backends keep static-credential behavior).
+    pub(super) identity_propagation:
+        RwLock<Option<Arc<dyn crate::identity_propagation::IdentityPropagation>>>,
     pub(super) code_mode_enabled: bool,
     /// Canonical response-projection rollout mode (MIK-5877).
     ///
@@ -292,6 +298,7 @@ impl MetaMcp {
             profile_registry: Arc::new(ProfileRegistry::default()),
             session_profiles: Arc::new(SessionProfileStore::new()),
             reload_context: RwLock::new(None),
+            identity_propagation: RwLock::new(None),
             code_mode_enabled: false,
             projection_mode: crate::projection::ProjectionMode::default(),
             secret_injector: crate::secret_injection::SecretInjector::empty(),
@@ -507,6 +514,16 @@ impl MetaMcp {
     /// Attach a [`ReloadContext`] to enable the `gateway_reload_config` meta-tool.
     pub fn set_reload_context(&self, ctx: Arc<ReloadContext>) {
         *self.reload_context.write() = Some(ctx);
+    }
+
+    /// Attach the end-user identity-propagation strategy (MIK-6704 / ADR-007).
+    /// When set, dispatch mints a per-user credential for backends configured
+    /// with `identity_propagation`.
+    pub fn set_identity_propagation(
+        &self,
+        strategy: Arc<dyn crate::identity_propagation::IdentityPropagation>,
+    ) {
+        *self.identity_propagation.write() = Some(strategy);
     }
 
     /// Attach a `TransitionTracker` for predictive tool prefetch.
@@ -920,6 +937,7 @@ impl MetaMcp {
                     caller.api_key_name,
                     caller.agent_id,
                     caller.grant_subject.clone(),
+                    caller.verified_identity,
                 )
                 .await;
             return match result {
@@ -949,6 +967,7 @@ impl MetaMcp {
                     caller.api_key_name,
                     caller.agent_id,
                     caller.grant_subject,
+                    caller.verified_identity,
                 )
                 .await
             }

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -458,7 +458,7 @@ impl MetaMcp {
         });
 
         // agent_id is None: code-mode execution is an internal operation.
-        self.invoke_tool(&invoke_args, session_id, None, None, None)
+        self.invoke_tool(&invoke_args, session_id, None, None, None, None)
             .await
     }
 
@@ -498,7 +498,7 @@ impl MetaMcp {
             });
 
             match self
-                .invoke_tool(&invoke_args, session_id, None, None, None)
+                .invoke_tool(&invoke_args, session_id, None, None, None, None)
                 .await
             {
                 Ok(result) => results.push(json!({

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -430,10 +430,11 @@ impl MetaMcp {
         &self,
         args: &Value,
         session_id: Option<&str>,
+        caller: &super::MetaMcpCallerContext<'_>,
     ) -> Result<Value> {
         // Chain mode: sequential execution
         if let Some(chain) = args.get("chain").and_then(Value::as_array) {
-            return self.execute_chain(chain.clone(), session_id).await;
+            return self.execute_chain(chain.clone(), session_id, caller).await;
         }
 
         // Single tool execution
@@ -457,16 +458,30 @@ impl MetaMcp {
             "arguments": arguments,
         });
 
-        // agent_id is None: code-mode execution is an internal operation.
-        self.invoke_tool(&invoke_args, session_id, None, None, None, None)
-            .await
+        // Code Mode carries the caller's identity + attribution through to
+        // dispatch, so an identity-required backend gets the per-user credential
+        // just like the direct gateway_invoke path (MIK-6734).
+        self.invoke_tool(
+            &invoke_args,
+            session_id,
+            caller.api_key_name,
+            caller.agent_id,
+            caller.grant_subject.clone(),
+            caller.verified_identity,
+        )
+        .await
     }
 
     /// Execute a sequential chain of `{tool, arguments}` steps.
     ///
     /// Returns a JSON array of per-step results. Stops at the first error
     /// and surfaces the failing step index in the error message.
-    async fn execute_chain(&self, chain: Vec<Value>, session_id: Option<&str>) -> Result<Value> {
+    async fn execute_chain(
+        &self,
+        chain: Vec<Value>,
+        session_id: Option<&str>,
+        caller: &super::MetaMcpCallerContext<'_>,
+    ) -> Result<Value> {
         if chain.is_empty() {
             return Err(Error::json_rpc(-32602, "Chain must not be empty"));
         }
@@ -498,7 +513,14 @@ impl MetaMcp {
             });
 
             match self
-                .invoke_tool(&invoke_args, session_id, None, None, None, None)
+                .invoke_tool(
+                    &invoke_args,
+                    session_id,
+                    caller.api_key_name,
+                    caller.agent_id,
+                    caller.grant_subject.clone(),
+                    caller.verified_identity,
+                )
                 .await
             {
                 Ok(result) => results.push(json!({

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -155,7 +155,9 @@ impl ToolInvoker for MetaMcpInvoker<'_> {
     async fn invoke(&self, server: &str, tool: &str, arguments: Value) -> Result<Value> {
         let args = internal_invoke_args(server, tool, arguments);
         // Playbook steps are internal invocations with no caller agent.
-        self.meta.invoke_tool(&args, None, None, None, None).await
+        self.meta
+            .invoke_tool(&args, None, None, None, None, None)
+            .await
     }
 }
 

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -313,7 +313,13 @@ async fn code_mode_execute_missing_tool_parameter_returns_error() {
     let meta = make_meta_mcp_code_mode();
     let args = json!({ "arguments": {} });
     // WHEN: code_mode_execute is called
-    let result = meta.code_mode_execute(&args, None).await;
+    let result = meta
+        .code_mode_execute(
+            &args,
+            None,
+            &crate::gateway::meta_mcp::MetaMcpCallerContext::default(),
+        )
+        .await;
     // THEN: error about missing 'tool'
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
@@ -329,7 +335,13 @@ async fn code_mode_execute_bare_tool_name_without_server_returns_error() {
     let meta = make_meta_mcp_code_mode();
     let args = json!({ "tool": "my_tool", "arguments": {} });
     // WHEN: code_mode_execute is called
-    let result = meta.code_mode_execute(&args, None).await;
+    let result = meta
+        .code_mode_execute(
+            &args,
+            None,
+            &crate::gateway::meta_mcp::MetaMcpCallerContext::default(),
+        )
+        .await;
     // THEN: error about missing server prefix
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
@@ -345,7 +357,13 @@ async fn code_mode_execute_chain_empty_array_returns_error() {
     let meta = make_meta_mcp_code_mode();
     let args = json!({ "chain": [] });
     // WHEN: code_mode_execute is called
-    let result = meta.code_mode_execute(&args, None).await;
+    let result = meta
+        .code_mode_execute(
+            &args,
+            None,
+            &crate::gateway::meta_mcp::MetaMcpCallerContext::default(),
+        )
+        .await;
     // THEN: error about empty chain
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
@@ -365,7 +383,13 @@ async fn code_mode_execute_chain_step_missing_tool_field_returns_error() {
         ]
     });
     // WHEN: code_mode_execute is called
-    let result = meta.code_mode_execute(&args, None).await;
+    let result = meta
+        .code_mode_execute(
+            &args,
+            None,
+            &crate::gateway::meta_mcp::MetaMcpCallerContext::default(),
+        )
+        .await;
     // THEN: error about missing tool field in step 0
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
@@ -385,7 +409,13 @@ async fn code_mode_execute_chain_step_bare_tool_name_returns_error() {
         ]
     });
     // WHEN: code_mode_execute is called
-    let result = meta.code_mode_execute(&args, None).await;
+    let result = meta
+        .code_mode_execute(
+            &args,
+            None,
+            &crate::gateway::meta_mcp::MetaMcpCallerContext::default(),
+        )
+        .await;
     // THEN: error about missing server prefix for step 0
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -542,6 +542,7 @@ providers:
             Some("alice"),
             Some("agent-1"),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -642,6 +643,7 @@ providers:
             Some("shared-api-key"),
             Some("agent-1"),
             Some(subject),
+            None,
         )
         .await
         .unwrap();
@@ -688,6 +690,7 @@ async fn gateway_invocation_attaches_context_integrity_metadata_to_risky_tool_ou
             Some("session-1"),
             Some("alice"),
             Some("agent-1"),
+            None,
             None,
         )
         .await

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -185,6 +185,13 @@ pub(super) async fn backend_handler(
     let client = request.extensions().get::<AuthenticatedClient>().cloned();
     let cert_identity = request.extensions().get::<CertIdentity>().cloned();
     let oauth_agent_identity = request.extensions().get::<OAuthAgentIdentity>().cloned();
+    // End-user identity for propagation (MIK-6704): the auth middleware may
+    // attach a VerifiedIdentity for temporary/delegated OIDC tokens. Extracted
+    // before the body is consumed so the direct route can propagate it too.
+    let verified_identity = request
+        .extensions()
+        .get::<crate::key_server::oidc::VerifiedIdentity>()
+        .cloned();
 
     // Check backend access if auth is enabled
     if let Some(ref client) = client
@@ -265,6 +272,32 @@ pub(super) async fn backend_handler(
     // For requests, id is guaranteed to exist
     let id = id.expect("id should exist for non-notification requests");
 
+    // End-user identity propagation for the direct backend route (MIK-6704 /
+    // ADR-007). Parity with the meta dispatch path: for a propagation-configured
+    // backend, resolve the per-user credential and forward it via
+    // request_with_headers; fail closed (403) for a `required` backend with no
+    // verified identity rather than silently forwarding with only the static
+    // credential. Empty for a non-propagation backend → unchanged static path.
+    let propagated_headers: Vec<(String, String)> = if method == "tools/call" {
+        match state
+            .meta_mcp
+            .resolve_propagation_headers(&name, verified_identity.as_ref())
+            .await
+        {
+            Ok(headers) => headers,
+            Err(e) => {
+                return build_http_error_response(
+                    Some(id.clone()),
+                    -32003,
+                    e.to_string(),
+                    StatusCode::FORBIDDEN,
+                );
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
     // SECURITY: apply tool policy, name validation, and input sanitization to
     // tools/call requests unless the backend explicitly opts into pass-through
     // mode (passthrough: true in config — only for fully-trusted internals).
@@ -283,7 +316,14 @@ pub(super) async fn backend_handler(
         ) {
             Some(Ok(Some(sanitized_params))) => {
                 // Forward the sanitized params to the backend
-                return match backend.request(&method, Some(sanitized_params)).await {
+                let forward = if propagated_headers.is_empty() {
+                    backend.request(&method, Some(sanitized_params)).await
+                } else {
+                    backend
+                        .request_with_headers(&method, Some(sanitized_params), &propagated_headers)
+                        .await
+                };
+                return match forward {
                     Ok(mut response) => {
                         record_client_success(&state, client.as_ref());
                         scan_direct_backend_response(
@@ -310,7 +350,14 @@ pub(super) async fn backend_handler(
     }
 
     // Forward to backend
-    match backend.request(&method, params.clone()).await {
+    let forward = if propagated_headers.is_empty() {
+        backend.request(&method, params.clone()).await
+    } else {
+        backend
+            .request_with_headers(&method, params.clone(), &propagated_headers)
+            .await
+    };
+    match forward {
         Ok(mut response) => {
             record_client_success(&state, client.as_ref());
             if method == "tools/list" {

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -880,7 +880,28 @@ impl Gateway {
             }
         });
 
-        // Construct security firewall (RFC-0071).
+        // Wire end-user identity propagation (MIK-6704 / ADR-007): when any
+        // backend opts into it, give MetaMcp a SignedAssertionStrategy signing
+        // with the gateway key pair. Config validation (slice 2a) already
+        // fail-closed-rejected unsupported strategies/session modes, so a
+        // configured backend here is a supported one. When no backend opts in,
+        // the strategy stays unset and every backend keeps static creds.
+        if self
+            .config
+            .backends
+            .values()
+            .any(|b| b.identity_propagation.is_some())
+        {
+            use crate::identity_propagation::SignedAssertionStrategy;
+            // 5-minute assertion lifetime (bounded further by the strategy's clamp).
+            let strategy = Arc::new(SignedAssertionStrategy::new(
+                Arc::clone(&gateway_key_pair),
+                300,
+            ));
+            meta_mcp.set_identity_propagation(strategy);
+            info!("End-user identity propagation enabled (signed-assertion strategy)");
+        }
+
         // The transition tracker is only used when anomaly_detection=true; pass
         // a fresh tracker so the firewall has its own dedicated state.
         #[cfg(feature = "firewall")]


### PR DESCRIPTION
Completes the IDP-FRAMEWORK release gate (MIK-6734 / MIK-6704, ADR-007). Wires the merged framework (#310) + transport spine (#312) into the live request path: a backend configured with `identity_propagation` now gets a per-user credential minted at dispatch instead of only the shared static credential.

- MetaMcp holds the strategy (`Option<Arc<dyn IdentityPropagation>>` + setter); server `run()` builds a `SignedAssertionStrategy` over the gateway key pair when any backend opts in.
- Full `VerifiedIdentity` threaded caller-context → invoke_tool → invoke_tool_traced → dispatch_to_backend (mirroring `caller_identity`) to the backend-invoke boundary.
- `mint_propagation_headers`: mints + sends the credential via `Backend::request_with_headers` (per-request, never on the shared transport — IDP.3). **Fail-closed** for a `required` backend (IDP.2): no identity / no strategy / mint failure / unparseable minted header all refuse — never a static fallback. Headers validated to parse **before** dispatch. Non-required degrades to best-effort; unconfigured unchanged (IDP.5).

Only Stateless reaches here (PerUser stays fail-closed at config validation until MIK-6735). IDP.8 (identity-aware cache keys) + IDP.4 (audit) filed as follow-ups; this lands the functional IDP.1/IDP.2 gate.

**Tests (+4)**: mints a Bearer credential for a verified identity (IDP.1); required backend fails closed with no identity and with no strategy (IDP.2); optional degrades to no headers.

**Gates**: cargo test 3189 lib pass; clippy --all-targets --all-features -D warnings clean; fmt clean. Adversarial GPT review runs; confirmed findings incorporated before merge.
