### PR TITLE
fix(idp): fail-closed identity propagation on ALL direct-route methods (MIK-6728)

### DIFF
--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -278,24 +278,30 @@ pub(super) async fn backend_handler(
     // request_with_headers; fail closed (403) for a `required` backend with no
     // verified identity rather than silently forwarding with only the static
     // credential. Empty for a non-propagation backend → unchanged static path.
-    let propagated_headers: Vec<(String, String)> = if method == "tools/call" {
-        match state
-            .meta_mcp
-            .resolve_propagation_headers(&name, verified_identity.as_ref())
-            .await
-        {
-            Ok(headers) => headers,
-            Err(e) => {
-                return build_http_error_response(
-                    Some(id.clone()),
-                    -32003,
-                    e.to_string(),
-                    StatusCode::FORBIDDEN,
-                );
-            }
+    //
+    // ADR-007 IDP.2/IDP.3: this gate applies to EVERY request method that
+    // reaches the backend, not only `tools/call`. Discovery methods
+    // (tools/list, resources/list, resources/templates/list, prompts/list) and
+    // any other backend-reaching request must fail closed for a `required`
+    // backend rather than downgrade to the shared static credential — otherwise
+    // a caller with no verified identity could read another user's backend
+    // metadata under the shared account. `resolve_propagation_headers` returns
+    // an empty set for a non-propagation or non-required backend, so the static
+    // path below is unchanged for those (IDP.5 backward-compat).
+    let propagated_headers: Vec<(String, String)> = match state
+        .meta_mcp
+        .resolve_propagation_headers(&name, verified_identity.as_ref())
+        .await
+    {
+        Ok(headers) => headers,
+        Err(e) => {
+            return build_http_error_response(
+                Some(id.clone()),
+                -32003,
+                e.to_string(),
+                StatusCode::FORBIDDEN,
+            );
         }
-    } else {
-        Vec::new()
     };
 
     // SECURITY: apply tool policy, name validation, and input sanitization to

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -828,6 +828,64 @@ async fn backend_handler_missing_backend_returns_jsonrpc_not_found() {
 }
 
 #[tokio::test]
+async fn backend_handler_discovery_method_fails_closed_for_required_propagation() {
+    // ADR-007 IDP.2/IDP.3 regression guard: a discovery method (resources/list)
+    // on a propagation-`required` backend must fail closed (403) when the
+    // request carries no verified identity — never downgrade to the shared
+    // static credential. Guards the fix that extends the per-user credential
+    // gate beyond `tools/call` to every backend-reaching method (MIK-6728).
+    use crate::identity_propagation::{
+        IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+    };
+
+    let config = BackendConfig {
+        identity_propagation: Some(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: "https://mem.internal/mcp".to_string(),
+            required: true,
+            session_mode: SessionMode::Stateless,
+        }),
+        ..BackendConfig::default()
+    };
+    let backend = Arc::new(Backend::new(
+        "demo",
+        config,
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+
+    let router = create_router(test_router_app_state_with_backend(backend));
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "resources/list"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], -32003);
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("required"),
+        "fail-closed error message: {}",
+        json["error"]["message"]
+    );
+}
+
+#[tokio::test]
 async fn backend_handler_notification_uses_notify_and_returns_accepted() {
     let backend = Arc::new(Backend::new(
         "demo",


### PR DESCRIPTION
## What this fixes

**MIK-6728 / ADR-007 release-blocker.** The direct backend route (`/mcp/{name}`) gated end-user credential resolution on `method == "tools/call"`. Every other request method — `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`, and any other id-bearing request — forwarded to the backend with **only** the shared, per-backend static OAuth token that is identical for every caller.

For a propagation-`required` backend this violated two ADR-007 invariants:
- **IDP.2 (fail-closed):** a required backend with no obtainable per-user credential must have the call *refused*, never downgraded to the static credential.
- **IDP.3 (tenant isolation):** a caller with no verified end-user identity could read another user's backend metadata under the shared account.

## The fix

Call `resolve_propagation_headers` for **every** request method, not just `tools/call`:
- Non-propagation / non-`required` backend → `Ok(empty)` → static path unchanged (**IDP.5 backward-compat**).
- `required` backend with no verified identity → `Err` → `403` / `-32003`, fail-closed.

The `tools/call`-specific security-sanitize and annotation-normalize blocks stay method-gated (they are correctly tool-specific). `src/gateway/meta_mcp/invoke.rs` is **untouched** — `resolve_propagation_headers` was already method-agnostic; only the handler wiring changed.

## Evidence

- **New regression test** (`tests.rs`): HTTP-level — `resources/list` on a `required`-propagation backend with no identity → `403` + `-32003` + message contains `"required"`.
- Suites: `router` 67/67, `invoke` 33/33, new test 1/1 — all pass.
- `cargo fmt --check` clean · `cargo clippy --all-targets --all-features -- -D warnings` exit 0.
- **Adversarial GPT second-opinion + source trace.** The one concern raised — "does this 403 an unauthenticated `initialize`/`ping` handshake?" — resolves as correct behavior: `verified_identity` is attached by the gateway auth layer (`mod.rs:154`) *upstream* of this handler, so a caller reaching the gate has already cleared gateway auth; a missing end-user identity for a `required` backend *should* be refused. MCP session bootstrap runs downstream of the gate using the propagated per-user credential. No exemption for `initialize`/`ping` is needed or wanted.

## Scope

- Does **not** tag or lift the release hold — version stays `3.0.0-dev`, `MIK-6742` hold untouched.
- Independent of #316 (branched off `hold-v3-multiuser-oauth` head for a clean diff).
- **Follow-up, not this PR:** notifications early-return before the gate (fire-and-forget, no cross-tenant read) — pre-existing behavior, not the release-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
