### PR TITLE
fix(dogfood): resolve stats 406 + unpinned-capability log spam (MIK-6742)

### DIFF
--- a/src/capability/loader.rs
+++ b/src/capability/loader.rs
@@ -14,6 +14,13 @@ pub struct CapabilityLoader;
 impl CapabilityLoader {
     /// Load all capabilities from a directory (recursive)
     ///
+    /// Emits one INFO-level summary line (`N loaded, M unpinned`) per
+    /// directory rather than one line per unpinned file — pinning is opt-in
+    /// per file by design, so an unpinned public catalog is expected, not a
+    /// misconfiguration to warn about file-by-file. Per-file detail (path +
+    /// computed hash) is still available at DEBUG via
+    /// [`super::parser::parse_capability_file`].
+    ///
     /// # Errors
     ///
     /// Returns an error if the directory does not exist or is not a valid directory.
@@ -37,10 +44,13 @@ impl CapabilityLoader {
         let mut capabilities = Vec::new();
         Self::load_directory_recursive(path, &mut capabilities).await?;
 
+        let unpinned = count_unpinned(&capabilities);
         info!(
             count = capabilities.len(),
+            unpinned,
             path = %path.display(),
-            "Loaded capabilities"
+            "Loaded capabilities: {} loaded, {unpinned} unpinned",
+            capabilities.len(),
         );
 
         Ok(capabilities)
@@ -167,6 +177,17 @@ impl CapabilityLoader {
     }
 }
 
+/// Count how many `capabilities` have no `sha256:` pin.
+///
+/// Pinning is opt-in per file by design (see
+/// [`super::parser::parse_capability_file`]); this count feeds the
+/// directory-level `N loaded, M unpinned` summary log so an operator can see
+/// catalog pin coverage at a glance instead of scanning one INFO line per
+/// unpinned file (MIK-6742).
+fn count_unpinned(capabilities: &[CapabilityDefinition]) -> usize {
+    capabilities.iter().filter(|c| c.sha256.is_none()).count()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +254,105 @@ providers:
 
         assert_eq!(capabilities.len(), 1);
         assert_eq!(capabilities[0].name, "gmail_test");
+    }
+
+    // ── MIK-6742: unpinned-catalog log volume ───────────────────────────────
+    //
+    // A public capability catalog is unpinned by design (pinning is opt-in
+    // per file). Loading it must not emit one INFO log line per unpinned
+    // file — that produced a wall of ~118 INFO lines on every boot. The fix
+    // demotes the per-file line in `parser::parse_capability_file` to DEBUG
+    // and reports the unpinned count once, in `load_directory`'s existing
+    // per-directory summary. `count_unpinned` is the arithmetic behind that
+    // summary; testing tracing's own INFO/DEBUG routing would require
+    // capturing log output, which is unreliable in a shared parallel test
+    // binary (tracing caches an `Interest` decision per callsite the first
+    // time it's hit, process-wide — a test-order-dependent trap, not
+    // something a per-test subscriber can override). `count_unpinned` is
+    // exactly the part of this change that carries regression risk (getting
+    // the `Option::is_none()` polarity backwards silently reports "0
+    // unpinned" against a fully-unpinned catalog), so that is what is
+    // covered here.
+
+    /// Build a minimal, valid [`CapabilityDefinition`] for counting tests,
+    /// optionally embedding a `sha256:` pin.
+    fn make_cap(name: &str, sha256: Option<&str>) -> CapabilityDefinition {
+        let pin_line = sha256.map_or_else(String::new, |h| format!("sha256: {h}\n"));
+        let yaml = format!(
+            r"
+{pin_line}name: {name}
+description: Test capability
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://internal.test
+      path: /test
+"
+        );
+        super::super::parse_capability(&yaml).unwrap()
+    }
+
+    /// GIVEN a mix of pinned and unpinned capability definitions
+    /// WHEN counting unpinned entries
+    /// THEN only the entries with `sha256: None` are counted.
+    #[test]
+    fn count_unpinned_counts_only_definitions_without_a_pin() {
+        let pinned = make_cap("pinned_cap", Some("abc123"));
+        let unpinned_a = make_cap("unpinned_a", None);
+        let unpinned_b = make_cap("unpinned_b", None);
+
+        assert_eq!(
+            count_unpinned(&[pinned.clone(), unpinned_a.clone(), unpinned_b.clone()]),
+            2
+        );
+        assert_eq!(count_unpinned(&[pinned]), 0);
+        assert_eq!(count_unpinned(&[unpinned_a, unpinned_b]), 2);
+    }
+
+    /// GIVEN an empty capability list
+    /// WHEN counting unpinned entries
+    /// THEN the count is zero (no divide-by-zero or panic on an empty
+    /// directory).
+    #[test]
+    fn count_unpinned_returns_zero_for_empty_slice() {
+        assert_eq!(count_unpinned(&[]), 0);
+    }
+
+    /// GIVEN a directory of two unpinned capability files
+    /// WHEN loaded via the public loader entry point
+    /// THEN both files load successfully and carry no `sha256` pin — the
+    /// precondition the INFO-summary unpinned count depends on.
+    #[tokio::test]
+    async fn load_directory_loads_unpinned_files_with_no_sha256_pin() {
+        let temp_dir = TempDir::new().unwrap();
+        for name in ["cap_a", "cap_b"] {
+            let cap_path = temp_dir.path().join(format!("{name}.yaml"));
+            let mut file = std::fs::File::create(&cap_path).unwrap();
+            writeln!(
+                file,
+                r"
+name: {name}
+description: unpinned test capability
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://internal.test
+"
+            )
+            .unwrap();
+        }
+
+        let capabilities = CapabilityLoader::load_directory(temp_dir.path().to_str().unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(capabilities.len(), 2, "both unpinned files load");
+        assert_eq!(
+            count_unpinned(&capabilities),
+            2,
+            "neither file embeds a sha256: pin"
+        );
     }
 }

--- a/src/capability/parser.rs
+++ b/src/capability/parser.rs
@@ -3,7 +3,7 @@
 use super::CapabilityDefinition;
 use super::hash::compute_capability_hash;
 use crate::{Error, Result};
-use tracing::info;
+use tracing::debug;
 
 /// Parse a capability definition from YAML content
 ///
@@ -19,8 +19,13 @@ pub fn parse_capability(content: &str) -> Result<CapabilityDefinition> {
 ///
 /// Verifies the optional `sha256:` pin as a rug-pull guard: if the file
 /// embeds a pin, a mismatch returns [`Error::CapabilityHashMismatch`] and the
-/// capability is refused. Files without a pin are loaded, and the computed
-/// hash is logged at INFO so operators can add `sha256:` to pin them.
+/// capability is refused. Pinning is opt-in per file by design (see
+/// `docs/blog/security-aware-mcp-gateway.md`): files without a pin are
+/// loaded, and the computed hash is logged at DEBUG so an operator who wants
+/// to pin a specific file can still recover the hash to paste back in.
+/// [`super::loader::CapabilityLoader::load_directory`] logs one INFO-level
+/// summary per directory (`N capabilities loaded, M unpinned`) instead of a
+/// line per file, so unpinned catalogs do not spam startup logs.
 ///
 /// # Errors
 ///
@@ -53,7 +58,7 @@ pub async fn parse_capability_file(path: &std::path::Path) -> Result<CapabilityD
             // Pin verified — nothing to log at load time. Loader reports.
         }
         None => {
-            info!(
+            debug!(
                 path = %path.display(),
                 sha256 = %actual_hash,
                 "unpinned capability loaded, compute hash: {actual_hash} — add `sha256: {actual_hash}` to pin",
@@ -294,7 +299,7 @@ providers:
         let path = write_capability_file(&dir, "unpinned.yaml", UNPINNED_YAML);
         // WHEN: loading it
         let cap = parse_capability_file(&path).await.unwrap();
-        // THEN: it loads with sha256 == None (INFO log about pinning is emitted)
+        // THEN: it loads with sha256 == None (DEBUG log about pinning is emitted)
         assert_eq!(cap.name, "pinned_cap");
         assert!(cap.sha256.is_none());
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -224,9 +224,13 @@ pub enum Command {
     /// Fetch live statistics from a running gateway instance
     #[command(about = "Show invocation counts, cache hits, and token savings")]
     Stats {
-        /// Base URL of the running gateway (without /mcp suffix)
-        #[arg(short, long, default_value = "http://127.0.0.1:39400")]
-        url: String,
+        /// Base URL of the running gateway (without /mcp suffix).
+        ///
+        /// Defaults to the `server.host`/`server.port` of `--config` (the same
+        /// file `serve` binds to), falling back to `http://127.0.0.1:39400`
+        /// when no config is found. An explicit `--url` always overrides both.
+        #[arg(short, long)]
+        url: Option<String>,
 
         /// Token price per million (USD) for estimated cost savings
         #[arg(short, long, default_value_t = 15.0)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,7 +39,7 @@ pub use skills::{
     run_skills_generate, run_skills_import, run_skills_list, run_skills_remove, run_skills_search,
     run_skills_show,
 };
-pub use stats::run_stats_command;
+pub use stats::{default_stats_url, run_stats_command};
 pub use trust::run_trust_command;
 pub use upgrade::{check_upgrade, data_dir as upgrade_data_dir, run_upgrade_command};
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -2,6 +2,40 @@
 
 use std::process::ExitCode;
 
+/// Build the default gateway base URL for the `stats` command from the
+/// configured bind host/port.
+///
+/// `server.host` is a *bind* address (which interface to listen on), not
+/// necessarily an address an HTTP client can dial — a wildcard bind
+/// (`0.0.0.0`, `::`) means "all interfaces", not "connect to literally
+/// `0.0.0.0`". This translates a wildcard bind to the loopback address so the
+/// CLI can actually reach a locally-running gateway; a concrete host
+/// (`127.0.0.1`, a real hostname/IP) passes through unchanged. IPv6 literals
+/// are bracketed per RFC 3986 §3.2.2 so the result is a valid URL authority.
+///
+/// This exists because `stats` previously hardcoded `http://127.0.0.1:39400`
+/// regardless of `--config`, so `mcp-gateway --config X stats` silently
+/// talked to whatever else was listening on the default port instead of the
+/// gateway `X` actually describes (MIK-6742).
+pub fn default_stats_url(host: &str, port: u16) -> String {
+    let client_host = if is_wildcard_bind(host) {
+        "127.0.0.1"
+    } else {
+        host
+    };
+    if client_host.contains(':') && !client_host.starts_with('[') {
+        format!("http://[{client_host}]:{port}")
+    } else {
+        format!("http://{client_host}:{port}")
+    }
+}
+
+/// `true` when `host` is a wildcard bind address ("listen on all
+/// interfaces") rather than a specific, client-dialable address.
+fn is_wildcard_bind(host: &str) -> bool {
+    matches!(host, "0.0.0.0" | "::" | "0:0:0:0:0:0:0:0")
+}
+
 /// Run the `stats` command against a running gateway.
 pub async fn run_stats_command(url: &str, price: f64) -> ExitCode {
     use serde_json::json;
@@ -97,5 +131,75 @@ fn print_top_tools(stats: &serde_json::Value) {
                 tool["count"]
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GIVEN the default gateway config's loopback host/port
+    /// WHEN building the default stats URL
+    /// THEN it matches the legacy hardcoded default exactly (no behavior
+    /// change for the common case).
+    #[test]
+    fn default_stats_url_loopback_host_passes_through() {
+        assert_eq!(
+            default_stats_url("127.0.0.1", 39400),
+            "http://127.0.0.1:39400"
+        );
+    }
+
+    /// GIVEN a `serve` config bound to a non-default port (MIK-6742 repro:
+    /// `serve` on a free port other than 39400)
+    /// WHEN building the default stats URL
+    /// THEN the resolved URL carries the configured port, not the old
+    /// hardcoded 39400 — this is the exact scenario that produced the 406
+    /// (stats silently talked to an unrelated service squatting on 39400).
+    #[test]
+    fn default_stats_url_tracks_configured_non_default_port() {
+        assert_eq!(
+            default_stats_url("127.0.0.1", 39477),
+            "http://127.0.0.1:39477"
+        );
+    }
+
+    /// GIVEN a wildcard IPv4 bind (`0.0.0.0`, "listen on every interface")
+    /// WHEN building the default stats URL
+    /// THEN the client target is translated to the loopback address, since a
+    /// client cannot dial `0.0.0.0` as a destination.
+    #[test]
+    fn default_stats_url_translates_ipv4_wildcard_bind_to_loopback() {
+        assert_eq!(
+            default_stats_url("0.0.0.0", 39400),
+            "http://127.0.0.1:39400"
+        );
+    }
+
+    /// GIVEN a wildcard IPv6 bind (`::`)
+    /// WHEN building the default stats URL
+    /// THEN it is also translated to the (unbracketed) IPv4 loopback address.
+    #[test]
+    fn default_stats_url_translates_ipv6_wildcard_bind_to_loopback() {
+        assert_eq!(default_stats_url("::", 39400), "http://127.0.0.1:39400");
+    }
+
+    /// GIVEN a concrete, non-wildcard IPv6 literal host
+    /// WHEN building the default stats URL
+    /// THEN it is bracketed per RFC 3986 §3.2.2 so the result is a valid URL.
+    #[test]
+    fn default_stats_url_brackets_non_wildcard_ipv6_host() {
+        assert_eq!(default_stats_url("::1", 39400), "http://[::1]:39400");
+    }
+
+    /// GIVEN a concrete hostname (not an IP literal)
+    /// WHEN building the default stats URL
+    /// THEN the hostname passes through unchanged alongside its port.
+    #[test]
+    fn default_stats_url_passes_through_concrete_hostname() {
+        assert_eq!(
+            default_stats_url("gateway.internal", 8080),
+            "http://gateway.internal:8080"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,11 @@ async fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    // Capture config path before consuming `cli` in the match below.
+    // Capture config path (and the port/host overrides `stats` also needs)
+    // before consuming `cli` in the match below.
     let config_path = cli.config.clone();
+    let port_override = cli.port;
+    let host_override = cli.host.clone();
 
     match cli.command {
         Some(Command::Init {
@@ -52,7 +55,15 @@ async fn main() -> ExitCode {
         Some(Command::Tls(tls_cmd)) => commands::run_tls_command(tls_cmd),
         Some(Command::Trust(trust_cmd)) => commands::run_trust_command(trust_cmd).await,
         Some(Command::Identity(identity_cmd)) => commands::run_identity_command(identity_cmd).await,
-        Some(Command::Stats { url, price }) => commands::run_stats_command(&url, price).await,
+        Some(Command::Stats { url, price }) => {
+            let effective_url = resolve_stats_url(
+                url,
+                config_path.as_deref(),
+                port_override,
+                host_override.as_deref(),
+            );
+            commands::run_stats_command(&effective_url, price).await
+        }
         Some(Command::Validate {
             paths,
             format,
@@ -444,6 +455,40 @@ async fn run_plugin_command(cmd: PluginCommand, config_path: Option<&Path>) -> E
             commands::run_plugin_list(plugin_dir.as_deref(), &config)
         }
     }
+}
+
+/// Resolve the base URL the `stats` command should query when `--url` was
+/// not given explicitly.
+///
+/// `stats` used to hardcode `http://127.0.0.1:39400` as its `--url` default,
+/// completely independent of `--config`. That meant `mcp-gateway --config X
+/// stats` silently ignored `X` and talked to whatever else happened to be
+/// listening on port 39400 the moment `serve --config X` used a different
+/// port — returning that unrelated service's error and misattributing it to
+/// the gateway (MIK-6742). This derives the default from the same
+/// `server.host`/`server.port` (plus `--port`/`--host` overrides) that
+/// `serve` binds to, so `stats` targets the gateway `--config` describes.
+///
+/// An explicit `url` (the `--url` flag) always wins and is returned as-is.
+fn resolve_stats_url(
+    url: Option<String>,
+    config_path: Option<&Path>,
+    port_override: Option<u16>,
+    host_override: Option<&str>,
+) -> String {
+    url.unwrap_or_else(|| {
+        let mut config = Config::load(config_path).unwrap_or_else(|e| {
+            eprintln!("Warning: failed to load config ({e}); using defaults for stats URL");
+            Config::default()
+        });
+        if let Some(port) = port_override {
+            config.server.port = port;
+        }
+        if let Some(host) = host_override {
+            config.server.host = host.to_string();
+        }
+        commands::default_stats_url(&config.server.host, config.server.port)
+    })
 }
 
 /// Apply CLI overrides to a loaded configuration.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -856,3 +856,92 @@ fn audit_config_load_failure_is_fail_closed() {
         "a missing explicit config path must be an Err (fail closed), not a default empty-secret config"
     );
 }
+
+// MIK-6742: `stats` used to default `--url` to a hardcoded
+// `http://127.0.0.1:39400`, completely independent of `--config`. Running
+// `mcp-gateway --config X stats` therefore silently talked to whatever else
+// was listening on 39400 instead of the gateway `X` describes — returning
+// that unrelated server's error (observed as a confusing 406 Not Acceptable
+// against a real deployment where 39400 was already taken by a different
+// process). These tests pin `resolve_stats_url`'s config-derived behavior so
+// that regression can't come back unnoticed.
+
+/// GIVEN an explicit `--url`
+/// WHEN resolving the stats URL
+/// THEN the explicit URL always wins, regardless of any config.
+#[test]
+fn resolve_stats_url_explicit_url_overrides_config() {
+    let resolved = resolve_stats_url(Some("http://10.0.0.5:1234".to_string()), None, None, None);
+    assert_eq!(resolved, "http://10.0.0.5:1234");
+}
+
+/// GIVEN no `--url` and no `--config` (and no config discoverable on disk)
+/// WHEN resolving the stats URL
+/// THEN it falls back to the same default gateway `serve` would use when
+/// unconfigured (127.0.0.1:39400) — unchanged legacy behavior.
+#[test]
+fn resolve_stats_url_no_url_no_config_falls_back_to_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let orig = std::env::current_dir().unwrap();
+    // Run from an empty directory so `Config::load(None)`'s well-known
+    // fallback search does not pick up a stray gateway.yaml from the repo.
+    std::env::set_current_dir(dir.path()).unwrap();
+    let resolved = resolve_stats_url(None, None, None, None);
+    std::env::set_current_dir(&orig).unwrap();
+    assert_eq!(resolved, "http://127.0.0.1:39400");
+}
+
+/// GIVEN a `--config` file whose `server.port` is NOT the hardcoded default
+/// (the exact MIK-6742 repro: `serve --config X` bound to a free, non-39400
+/// port)
+/// WHEN resolving the stats URL with no explicit `--url`
+/// THEN the resolved URL carries the configured port — this is the
+/// regression test that would have caught the original bug, where `stats`
+/// ignored `--config` entirely.
+#[test]
+fn resolve_stats_url_no_url_derives_port_from_config_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &config_path,
+        "server:\n  host: \"127.0.0.1\"\n  port: 39477\n",
+    )
+    .unwrap();
+
+    let resolved = resolve_stats_url(None, Some(&config_path), None, None);
+
+    assert_eq!(resolved, "http://127.0.0.1:39477");
+}
+
+/// GIVEN a `--config` file bound to a wildcard host (`0.0.0.0`)
+/// WHEN resolving the stats URL
+/// THEN the client-facing URL uses loopback, since a client cannot dial
+/// `0.0.0.0` as a destination address.
+#[test]
+fn resolve_stats_url_no_url_translates_wildcard_bind_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &config_path,
+        "server:\n  host: \"0.0.0.0\"\n  port: 39400\n",
+    )
+    .unwrap();
+
+    let resolved = resolve_stats_url(None, Some(&config_path), None, None);
+
+    assert_eq!(resolved, "http://127.0.0.1:39400");
+}
+
+/// GIVEN no `--url` and a `--port` CLI override (no `--config`)
+/// WHEN resolving the stats URL
+/// THEN the override port is reflected, mirroring the override `serve`
+/// would apply via `apply_cli_overrides`.
+#[test]
+fn resolve_stats_url_no_url_applies_port_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let orig = std::env::current_dir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let resolved = resolve_stats_url(None, None, Some(9999), None);
+    std::env::set_current_dir(&orig).unwrap();
+    assert_eq!(resolved, "http://127.0.0.1:9999");
+}


### PR DESCRIPTION
Pre-ship dogfood fixes for v3.0.0 (MIK-6742).

- `stats` now resolves the configured bind address (`resolve_stats_url` and `default_stats_url`) instead of a hardcoded loopback default — fixes HTTP 406 when the gateway runs on a non-default port.
- Unpinned-capability logging moved from per-file `info!` to `debug!`; the loader now reports one `N loaded, M unpinned` summary line per directory — removes about 118 lines of startup log noise.

Verification on the live release binary (`--features webui`):
- build exit 0; `cargo fmt` clean, `clippy --all-targets --all-features -D warnings` clean; 3791 tests, 0 failures.
- stats returns real data (124 tools), exit 0, no 406.
- boot log: single `Loaded capabilities: 124 loaded, 118 unpinned` line, no per-file INFO spam.
- 403 fail-closed OAuth isolation proven via seven guard tests (`required_and_absent_refuses`, `oauth_isolation_refuses_shared_gateway_oauth_...`, `prompts_get_refuses_oauth_isolated_backend_...`, and the single-user allow-path).
- D30 supply-chain: SHA-256 pinned-mismatch REFUSE in `parser.rs` intact; only the unpinned log level changed.

Full DoD evidence posted to MIK-6742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>