### PR TITLE
Release 3.0.1 — identity-propagation audit + fail-closed adapter (MIK-6740, MIK-6741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - 2026-07-03
+## [3.0.1] - 2026-07-03
+
+Security hardening fast-follow for the 3.0.0 end-user identity-propagation
+feature. No API changes; both items close latent gaps on the per-user
+credential path.
+
+### Security
+
+- **Fail-closed provider adapter (MIK-6741).** `McpProvider::invoke` now
+  refuses to dispatch a backend configured with `identity_propagation.required`,
+  because the `Provider` trait carries no per-user identity and would otherwise
+  fall back to the shared gateway session. No live route reaches this adapter
+  today; the guard is a tripwire so a future wiring cannot become a silent
+  identity bypass. (`src/provider/mcp_provider.rs`)
+- **Tamper-evident credential-propagation audit (MIK-6740).** The direct
+  `/mcp/{name}` route now writes redacted `idp_mint` / `idp_refuse` events to
+  the transparency log at the mint and refuse decision points. Entries carry
+  only subject / backend / audience / reason — never token or assertion bytes
+  (enforced structurally and by a canary-secret regression test). Audit writes
+  are best-effort and never fail the user request; the mint/refuse decision
+  itself remains fail-closed. (`src/gateway/router/backend_handlers.rs`)
 
 > **Breaking change.** The default OAuth posture changes: a gateway with
 > `auth.enabled: true` no longer serves one stored backend token to every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1388,13 +1388,32 @@ impl MetaMcp {
     ) -> Result<CallerCredential> {
         use crate::identity_propagation::BackendDescriptor;
 
+        // Audit context (MIK-6740, IDP4): every mint and every fail-closed
+        // refusal on THIS route is recorded, identically to the direct backend
+        // route. Only subject/backend/audience/reason reach the log — never the
+        // minted credential bytes.
+        let audit_logger = self.transparency_logger.as_deref();
+        let subject_id = crate::identity_propagation::audit_subject(verified_identity);
+        let audience = idp_cfg.audience.as_str();
+
         let refuse = |msg: String| -> Result<CallerCredential> {
             if idp_cfg.required {
+                crate::identity_propagation::audit_identity_propagation(
+                    audit_logger,
+                    "idp_refuse",
+                    &subject_id,
+                    server,
+                    Some(audience),
+                    Some(&msg),
+                );
                 Err(Error::Config(format!(
                     "identity propagation required for backend '{server}' but {msg}"
                 )))
             } else {
                 // Best-effort: non-required backend proceeds with static creds.
+                // This is the static-credential fallback (IDP.5), not a mint or
+                // a fail-closed refusal, so — like the direct route's
+                // `Ok(empty)` branch — it is intentionally not audited.
                 Ok(CallerCredential::default())
             }
         };
@@ -1426,6 +1445,16 @@ impl MetaMcp {
                 // cache_binding distinguishes user AND audience (collision-safe),
                 // so per-user results cache in isolation instead of being dropped
                 // (IDP.8 — replaces the earlier blanket cache bypass).
+                if !cred.headers.is_empty() {
+                    crate::identity_propagation::audit_identity_propagation(
+                        audit_logger,
+                        "idp_mint",
+                        &subject_id,
+                        server,
+                        Some(audience),
+                        None,
+                    );
+                }
                 Ok(CallerCredential {
                     headers: cred.headers,
                     cache_binding: Some(cred.cache_binding),
@@ -2608,6 +2637,61 @@ mod identity_propagation_enforcement_tests {
             groups: vec![],
             issuer: "https://idp".to_string(),
         }
+    }
+
+    // MIK-6740 IDP4.1/4.2 — the Meta-MCP `gateway_invoke` route audits every
+    // mint and every fail-closed refusal into the transparency log, identically
+    // to the direct backend route. Regression guard for the gap where only the
+    // direct route audited: a mint/refuse on the primary invoke path used to
+    // leave no audit entry at all.
+    #[tokio::test]
+    async fn gateway_invoke_route_audits_mint_and_refuse() {
+        use tempfile::NamedTempFile;
+
+        use crate::security::TransparencyLogger;
+        use crate::security::transparency_log::TransparencyLogConfig;
+
+        let file = NamedTempFile::new().expect("tempfile");
+        let cfg = Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path: file.path().to_string_lossy().to_string(),
+            key_id: "test".to_string(),
+            shared_secret: String::new(),
+        });
+        let logger = Arc::new(TransparencyLogger::open(cfg).expect("logger opens"));
+
+        let mut m = meta_with_strategy();
+        m.enable_transparency_log(Arc::clone(&logger));
+
+        // Successful mint -> idp_mint entry.
+        let cred = m
+            .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
+            .await
+            .expect("mint ok");
+        let minted_value = cred.headers[0].1.clone();
+
+        // Required + no identity -> fail-closed refuse -> idp_refuse entry.
+        m.resolve_caller_credential("memory", &idp_cfg(true), None)
+            .await
+            .expect_err("must refuse");
+
+        let raw = std::fs::read_to_string(file.path()).expect("read log");
+        assert!(
+            raw.contains("idp_mint"),
+            "mint on the gateway_invoke route must be audited: {raw}"
+        );
+        assert!(
+            raw.contains("idp_refuse"),
+            "fail-closed refusal on the gateway_invoke route must be audited: {raw}"
+        );
+        // Redaction: the minted credential value must never reach the log.
+        let token = minted_value
+            .strip_prefix("Bearer ")
+            .unwrap_or(&minted_value);
+        assert!(
+            !raw.contains(token),
+            "the minted credential must never appear in the transparency log"
+        );
     }
 
     // Header-capturing transport: records the per-request headers dispatch

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -497,8 +497,13 @@ impl MetaMcp {
     /// When set, every completed tool invocation is committed to the
     /// hash-chain log.  Failures are non-fatal — a `warn!` is emitted but
     /// the invocation result is not affected.
-    pub fn enable_transparency_log(&mut self, logger: crate::security::TransparencyLogger) {
-        self.transparency_logger = Some(Arc::new(logger));
+    ///
+    /// Takes an `Arc` (rather than an owned logger) so the caller can retain
+    /// a second handle — e.g. `AppState.transparency_log` (MIK-6740) — that
+    /// writes into the same tamper-evident chain from the direct backend
+    /// route, which does not go through `MetaMcp`.
+    pub fn enable_transparency_log(&mut self, logger: Arc<crate::security::TransparencyLogger>) {
+        self.transparency_logger = Some(logger);
     }
 
     /// Attach the webhook registry for `gateway_webhook_status` reporting.

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -210,6 +210,70 @@ fn resolve_passthrough_headers(
     }
 }
 
+/// Stable actor id for an identity-propagation audit entry (MIK-6740). Uses
+/// the same `issuer`+`subject` derivation as the control-plane governance
+/// audit (`stable_actor_id`) so the two audit trails describe the same actor
+/// under the same id. `"unauthenticated"` covers the non-`required` path,
+/// where a mint/refuse decision can be reached with no verified identity.
+fn audit_subject(verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>) -> String {
+    verified_identity.map_or_else(
+        || "unauthenticated".to_string(),
+        crate::key_server::oidc::VerifiedIdentity::stable_actor_id,
+    )
+}
+
+/// Record an identity-propagation credential decision (`idp_mint` /
+/// `idp_refuse`) into the tamper-evident transparency log (MIK-6740, IDP4).
+///
+/// Takes the logger directly (rather than `&AppState`) so this function is
+/// independently unit-testable against a real [`crate::security::TransparencyLogger`]
+/// over a tempfile, with no need to construct a full `AppState`. `logger` is
+/// `None` when the transparency log is disabled — the call is then a no-op.
+///
+/// Redaction is the load-bearing property here: only `subject`, `backend`,
+/// `audience`, `action`, `reason`, and `timestamp` are ever passed to
+/// [`crate::security::TransparencyLogger::append_event`] — never the resolved
+/// credential header value or a raw assertion.
+///
+/// ponytail: audit is best-effort, not fail-closed — a write failure is
+/// `warn!`'d and the caller's request proceeds/fails on its own merits,
+/// mirroring how `TransparencyLogger::log_invocation` failures are handled
+/// elsewhere in the gateway. A regulated buyer that needs "no mint without a
+/// durable audit record" would need this gated fail-closed instead; tracked
+/// as a possible future hardening, not required for MIK-6740.
+fn audit_identity_propagation(
+    logger: Option<&crate::security::TransparencyLogger>,
+    action: &'static str,
+    subject: &str,
+    backend: &str,
+    audience: Option<&str>,
+    reason: Option<&str>,
+) {
+    let Some(logger) = logger else {
+        return;
+    };
+
+    let mut fields = serde_json::Map::new();
+    fields.insert("action".into(), action.into());
+    fields.insert("subject".into(), subject.into());
+    fields.insert("backend".into(), backend.into());
+    fields.insert("timestamp".into(), chrono::Utc::now().to_rfc3339().into());
+    if let Some(audience) = audience {
+        fields.insert("audience".into(), audience.into());
+    }
+    if let Some(reason) = reason {
+        fields.insert("reason".into(), reason.into());
+    }
+
+    if let Err(e) = logger.append_event(fields) {
+        warn!(
+            backend,
+            action, error = %e,
+            "Failed to write identity-propagation audit entry (transparency log)"
+        );
+    }
+}
+
 /// Backend handler (POST /mcp/{name})
 #[allow(clippy::too_many_lines)]
 pub(super) async fn backend_handler(
@@ -336,19 +400,22 @@ pub(super) async fn backend_handler(
     let isolation_guarded = !matches!(method.as_str(), "initialize" | "tools/list" | "ping")
         && !method.starts_with("notifications/");
     let propagated_headers: Vec<(String, String)> = if isolation_guarded {
+        // Fetched once so both the passthrough-vs-minting branch below and the
+        // audit write (MIK-6740) share a single lookup/clone of the backend's
+        // propagation config.
+        let idp_cfg = state
+            .backends
+            .get(&name)
+            .and_then(|b| b.identity_propagation_config().cloned());
         // Passthrough (ADR-008 rung 2, MIK-6746): a backend whose caller attaches
         // its OWN credential is handled here — forward it verbatim, mint/store
         // NOTHING (INV-4). Any other propagation strategy is resolved by the
         // shared minting chokepoint. Isolation (INV-3) holds by construction:
         // each request forwards its own header via `request_with_headers`, never
         // via the shared transport, and the direct route keeps no per-user cache.
-        let passthrough_cfg = state
-            .backends
-            .get(&name)
-            .and_then(|b| b.identity_propagation_config().cloned())
-            .filter(|c| {
-                c.strategy == crate::identity_propagation::PropagationStrategyKind::Passthrough
-            });
+        let passthrough_cfg = idp_cfg.clone().filter(|c| {
+            c.strategy == crate::identity_propagation::PropagationStrategyKind::Passthrough
+        });
         let resolved = if let Some(cfg) = passthrough_cfg {
             resolve_passthrough_headers(&cfg, &inbound_headers)
         } else {
@@ -358,9 +425,34 @@ pub(super) async fn backend_handler(
                 .await
                 .map_err(|e| e.to_string())
         };
+        let subject = audit_subject(verified_identity.as_ref());
+        let audience = idp_cfg.as_ref().map(|c| c.audience.as_str());
         match resolved {
-            Ok(headers) => headers,
+            Ok(headers) => {
+                // A successful resolution that yields no headers is the
+                // unchanged static-credential fallback (IDP.5), not a mint —
+                // only audit when a per-user credential was actually attached.
+                if !headers.is_empty() {
+                    audit_identity_propagation(
+                        state.transparency_log.as_deref(),
+                        "idp_mint",
+                        &subject,
+                        &name,
+                        audience,
+                        None,
+                    );
+                }
+                headers
+            }
             Err(e) => {
+                audit_identity_propagation(
+                    state.transparency_log.as_deref(),
+                    "idp_refuse",
+                    &subject,
+                    &name,
+                    audience,
+                    Some(&e),
+                );
                 return build_http_error_response(
                     Some(id.clone()),
                     -32003,
@@ -589,134 +681,4 @@ pub(super) async fn costs_handler(
 }
 
 #[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::*;
-
-    // MIK-6746 D.4 — passthrough resolution (ADR-008 rung 2).
-    mod passthrough {
-        use axum::http::HeaderMap;
-
-        use super::*;
-        use crate::identity_propagation::{
-            IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
-        };
-
-        const HEADER: &str = "x-mcp-passthrough-authorization";
-
-        fn cfg(required: bool) -> IdentityPropagationConfig {
-            IdentityPropagationConfig {
-                strategy: PropagationStrategyKind::Passthrough,
-                audience: "https://backend".to_string(),
-                required,
-                session_mode: SessionMode::PerUser,
-            }
-        }
-
-        fn headers_with(cred: &str) -> HeaderMap {
-            let mut h = HeaderMap::new();
-            h.insert(HEADER, cred.parse().unwrap());
-            h
-        }
-
-        // D.1/D.4 — the caller's own credential is forwarded verbatim to the
-        // backend under `Authorization`. Nothing else is emitted; the function
-        // is pure over its inputs, so it cannot persist a token (INV-4).
-        #[test]
-        fn present_credential_is_forwarded_as_authorization() {
-            let out = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer caller-tok"))
-                .expect("present credential resolves");
-            assert_eq!(
-                out,
-                vec![("Authorization".to_string(), "Bearer caller-tok".to_string())]
-            );
-        }
-
-        // D.4 — concurrent callers are isolated: each request forwards only its
-        // own header value; there is no shared/mutable state between calls.
-        #[test]
-        fn concurrent_callers_are_isolated() {
-            let a = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer alice")).unwrap();
-            let b = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer bob")).unwrap();
-            assert_eq!(a[0].1, "Bearer alice");
-            assert_eq!(b[0].1, "Bearer bob");
-            assert_ne!(a[0].1, b[0].1);
-        }
-
-        // D.3 — a required backend with no caller credential fails closed.
-        #[test]
-        fn required_and_absent_refuses() {
-            assert!(resolve_passthrough_headers(&cfg(true), &HeaderMap::new()).is_err());
-            // A blank credential counts as absent.
-            assert!(resolve_passthrough_headers(&cfg(true), &headers_with("   ")).is_err());
-        }
-
-        // A non-required backend with no caller credential yields the static
-        // path (empty), after which the INV-2 shared-token guard decides.
-        #[test]
-        fn optional_and_absent_is_empty() {
-            let out = resolve_passthrough_headers(&cfg(false), &HeaderMap::new()).unwrap();
-            assert!(out.is_empty());
-        }
-    }
-
-    #[test]
-    fn normalize_tools_list_response_fills_direct_backend_proxy_annotations() {
-        let mut response = JsonRpcResponse::success(
-            RequestId::Number(1),
-            json!({
-                "tools": [
-                    {
-                        "name": "search",
-                        "description": "Search things",
-                        "inputSchema": {"type": "object"},
-                        "annotations": {"readOnlyHint": true}
-                    },
-                    {
-                        "name": "archive_chat",
-                        "description": "Archive a chat",
-                        "inputSchema": {"type": "object"},
-                        "annotations": {}
-                    }
-                ],
-                "nextCursor": "abc",
-                "extra": "preserved"
-            }),
-        );
-
-        normalize_tools_list_response("beeper", &mut response);
-
-        let result = response.result.expect("success result");
-        assert_eq!(result["nextCursor"], "abc");
-        assert_eq!(result["extra"], "preserved");
-
-        let search = &result["tools"][0]["annotations"];
-        assert_eq!(search["readOnlyHint"], true);
-        assert_eq!(search["destructiveHint"], false);
-        assert_eq!(search["idempotentHint"], true);
-        assert_eq!(search["openWorldHint"], true);
-        assert_eq!(
-            result["tools"][0]["trustCard"]["schemaVersion"],
-            "trust_card.v1"
-        );
-        assert_eq!(
-            result["tools"][0]["trustCard"]["serverId"],
-            "backend:beeper"
-        );
-        assert_eq!(result["tools"][0]["trustCard"]["toolName"], "search");
-        assert_eq!(
-            result["tools"][0]["trustCard"]["trustCardDigestSha256"]
-                .as_str()
-                .unwrap()
-                .len(),
-            64
-        );
-
-        let archive = &result["tools"][1]["annotations"];
-        assert_eq!(archive["readOnlyHint"], false);
-        assert_eq!(archive["destructiveHint"], true);
-        assert_eq!(archive["idempotentHint"], false);
-        assert_eq!(archive["openWorldHint"], true);
-    }
-}
+mod tests;

--- a/src/gateway/router/backend_handlers/tests.rs
+++ b/src/gateway/router/backend_handlers/tests.rs
@@ -1,0 +1,372 @@
+use serde_json::json;
+
+use super::*;
+
+// MIK-6746 D.4 — passthrough resolution (ADR-008 rung 2).
+mod passthrough {
+    use axum::http::HeaderMap;
+
+    use super::*;
+    use crate::identity_propagation::{
+        IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+    };
+
+    const HEADER: &str = "x-mcp-passthrough-authorization";
+
+    fn cfg(required: bool) -> IdentityPropagationConfig {
+        IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::Passthrough,
+            audience: "https://backend".to_string(),
+            required,
+            session_mode: SessionMode::PerUser,
+        }
+    }
+
+    fn headers_with(cred: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(HEADER, cred.parse().unwrap());
+        h
+    }
+
+    // D.1/D.4 — the caller's own credential is forwarded verbatim to the
+    // backend under `Authorization`. Nothing else is emitted; the function
+    // is pure over its inputs, so it cannot persist a token (INV-4).
+    #[test]
+    fn present_credential_is_forwarded_as_authorization() {
+        let out = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer caller-tok"))
+            .expect("present credential resolves");
+        assert_eq!(
+            out,
+            vec![("Authorization".to_string(), "Bearer caller-tok".to_string())]
+        );
+    }
+
+    // D.4 — concurrent callers are isolated: each request forwards only its
+    // own header value; there is no shared/mutable state between calls.
+    #[test]
+    fn concurrent_callers_are_isolated() {
+        let a = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer alice")).unwrap();
+        let b = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer bob")).unwrap();
+        assert_eq!(a[0].1, "Bearer alice");
+        assert_eq!(b[0].1, "Bearer bob");
+        assert_ne!(a[0].1, b[0].1);
+    }
+
+    // D.3 — a required backend with no caller credential fails closed.
+    #[test]
+    fn required_and_absent_refuses() {
+        assert!(resolve_passthrough_headers(&cfg(true), &HeaderMap::new()).is_err());
+        // A blank credential counts as absent.
+        assert!(resolve_passthrough_headers(&cfg(true), &headers_with("   ")).is_err());
+    }
+
+    // A non-required backend with no caller credential yields the static
+    // path (empty), after which the INV-2 shared-token guard decides.
+    #[test]
+    fn optional_and_absent_is_empty() {
+        let out = resolve_passthrough_headers(&cfg(false), &HeaderMap::new()).unwrap();
+        assert!(out.is_empty());
+    }
+}
+
+// MIK-6740 — identity-propagation credential events on the tamper-evident
+// transparency log (IDP4).
+mod identity_propagation_audit {
+    use std::sync::Arc;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::key_server::oidc::VerifiedIdentity;
+    use crate::security::TransparencyLogger;
+    use crate::security::transparency_log::TransparencyLogConfig;
+
+    fn open_logger() -> (NamedTempFile, TransparencyLogger) {
+        let file = NamedTempFile::new().expect("tempfile");
+        let cfg = Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path: file.path().to_string_lossy().to_string(),
+            key_id: "test".to_string(),
+            shared_secret: String::new(),
+        });
+        let logger = TransparencyLogger::open(cfg).expect("logger opens");
+        (file, logger)
+    }
+
+    fn read_entries(path: &std::path::Path) -> Vec<serde_json::Value> {
+        std::fs::read_to_string(path)
+            .expect("log file readable")
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("valid JSON line"))
+            .collect()
+    }
+
+    fn identity(subject: &str) -> VerifiedIdentity {
+        VerifiedIdentity {
+            subject: subject.to_string(),
+            email: "user@test.invalid".to_string(),
+            name: None,
+            groups: vec![],
+            issuer: "https://idp.test.invalid".to_string(),
+        }
+    }
+
+    // IDP4.2 — no verified identity resolves to the documented sentinel
+    // subject rather than an empty string.
+    #[test]
+    fn audit_subject_falls_back_to_unauthenticated_sentinel() {
+        assert_eq!(audit_subject(None), "unauthenticated");
+    }
+
+    // Subject must match the control-plane governance audit's actor id
+    // derivation so the two audit trails describe the same actor.
+    #[test]
+    fn audit_subject_uses_stable_actor_id_for_verified_identity() {
+        let id = identity("alice");
+        assert_eq!(audit_subject(Some(&id)), id.stable_actor_id());
+    }
+
+    // A disabled transparency log (`logger = None`) must not panic and
+    // must not create a log file — pure no-op.
+    #[test]
+    fn audit_identity_propagation_is_noop_when_logger_disabled() {
+        audit_identity_propagation(
+            None,
+            "idp_mint",
+            "unauthenticated",
+            "some-backend",
+            Some("https://aud.test.invalid"),
+            None,
+        );
+    }
+
+    // IDP4.1 — a successful mint records `action="idp_mint"` with subject,
+    // audience, backend, and timestamp; no `reason` field is present.
+    #[test]
+    fn mint_records_idp_mint_with_domain_fields() {
+        let (file, logger) = open_logger();
+        let id = identity("alice");
+        let subject = audit_subject(Some(&id));
+
+        audit_identity_propagation(
+            Some(&logger),
+            "idp_mint",
+            &subject,
+            "github",
+            Some("https://github.test.invalid/api"),
+            None,
+        );
+
+        let entries = read_entries(file.path());
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry["action"], "idp_mint");
+        assert_eq!(entry["subject"], subject);
+        assert_eq!(entry["backend"], "github");
+        assert_eq!(entry["audience"], "https://github.test.invalid/api");
+        assert!(entry["timestamp"].is_string());
+        assert!(entry.get("reason").is_none());
+    }
+
+    // IDP4.2 — a fail-closed refusal records `action="idp_refuse"` with
+    // subject ("unauthenticated" when no identity was presented), backend,
+    // and the fail-closed reason string.
+    #[test]
+    fn refuse_records_idp_refuse_with_reason_and_unauthenticated_subject() {
+        let (file, logger) = open_logger();
+        let subject = audit_subject(None);
+
+        audit_identity_propagation(
+            Some(&logger),
+            "idp_refuse",
+            &subject,
+            "github",
+            Some("https://github.test.invalid/api"),
+            Some(
+                "identity propagation required for this backend but the caller supplied \
+                     no passthrough credential (ADR-008 D.3, fail-closed)",
+            ),
+        );
+
+        let entries = read_entries(file.path());
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry["action"], "idp_refuse");
+        assert_eq!(entry["subject"], "unauthenticated");
+        assert_eq!(entry["backend"], "github");
+        assert_eq!(
+            entry["reason"],
+            "identity propagation required for this backend but the caller supplied no \
+                 passthrough credential (ADR-008 D.3, fail-closed)"
+        );
+        assert!(entry["timestamp"].is_string());
+    }
+
+    // IDP4.3 — redaction is load-bearing: drive a mint and a refuse through
+    // the *same* logger with a fake credential-shaped value that would
+    // appear verbatim in the log if any code path forwarded it, then
+    // assert those bytes never appear anywhere in the on-disk log and only
+    // the whitelisted domain fields (plus the chain fields the logger
+    // itself adds) exist on each entry.
+    #[test]
+    fn no_secret_or_token_bytes_ever_reach_the_log() {
+        // A LIVE, credential-shaped canary. The point of this test (IDP4.3 /
+        // fail-fast: "no raw assertion/token appears in any audit entry") is
+        // defeated if the canary is a value we simply never hand to the audit
+        // sink — that proves nothing. So we resolve it into the request's
+        // forwarded headers with the SAME function the mint path uses
+        // (`resolve_passthrough_headers`, backend_handlers.rs:420), then audit
+        // with the exact argument shape of the real call site
+        // (backend_handlers.rs:436) — subject/backend/audience only, never the
+        // header vec. The credential is thus provably live in the flow yet
+        // provably absent from the log.
+        use axum::http::HeaderMap;
+
+        use crate::identity_propagation::{
+            IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+        };
+
+        // Opaque credential shape (no auth-scheme prefix) — a raw token the
+        // audit must never persist.
+        const CANARY_SECRET: &str = "tok-do-not-leak-9f3a1c2b7e4d6f8801";
+
+        let (file, logger) = open_logger();
+        let id = identity("bob");
+        let subject = audit_subject(Some(&id));
+        let audience = "https://backend-a.test.invalid";
+
+        // Resolve the caller credential exactly as the mint path does: the
+        // canary lands in the forwarded headers, not in any audit argument.
+        let cfg = IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::Passthrough,
+            audience: audience.to_string(),
+            required: true,
+            session_mode: SessionMode::PerUser,
+        };
+        let mut inbound = HeaderMap::new();
+        inbound.insert(
+            "x-mcp-passthrough-authorization",
+            CANARY_SECRET.parse().unwrap(),
+        );
+        let headers = resolve_passthrough_headers(&cfg, &inbound)
+            .expect("canary credential resolves into forwarded headers");
+        assert!(
+            headers.iter().any(|(_, v)| v.contains(CANARY_SECRET)),
+            "precondition: the canary must actually be live in the forwarded headers"
+        );
+
+        // Mint audit — the call-site contract passes metadata only; the
+        // `headers` above are forwarded to the backend, never logged.
+        audit_identity_propagation(
+            Some(&logger),
+            "idp_mint",
+            &subject,
+            "backend-a",
+            Some(audience),
+            None,
+        );
+        // A refuse: the reason string is a fixed fail-closed message, never
+        // the credential the caller failed to supply.
+        audit_identity_propagation(
+            Some(&logger),
+            "idp_refuse",
+            &audit_subject(None),
+            "backend-b",
+            Some("https://backend-b.test.invalid"),
+            Some("identity propagation required but no credential was supplied"),
+        );
+
+        let raw = std::fs::read_to_string(file.path()).expect("log file readable");
+        assert!(
+            !raw.contains(CANARY_SECRET),
+            "a live forwarded credential must never reach the transparency log"
+        );
+
+        let allowed_keys = [
+            "action",
+            "subject",
+            "backend",
+            "audience",
+            "reason",
+            "timestamp",
+            // Chain fields TransparencyLogger::append_core adds itself —
+            // not supplied by the caller, but present on every entry.
+            "counter",
+            "prev_entry_hash",
+            "entry_hash",
+        ];
+        let entries = read_entries(file.path());
+        assert_eq!(entries.len(), 2);
+        for entry in &entries {
+            let obj = entry.as_object().expect("entry is a JSON object");
+            for key in obj.keys() {
+                assert!(
+                    allowed_keys.contains(&key.as_str()),
+                    "unexpected field `{key}` in audit entry: {entry}"
+                );
+            }
+        }
+        assert_eq!(entries[0]["action"], "idp_mint");
+        assert_eq!(entries[1]["action"], "idp_refuse");
+    }
+}
+
+#[test]
+fn normalize_tools_list_response_fills_direct_backend_proxy_annotations() {
+    let mut response = JsonRpcResponse::success(
+        RequestId::Number(1),
+        json!({
+            "tools": [
+                {
+                    "name": "search",
+                    "description": "Search things",
+                    "inputSchema": {"type": "object"},
+                    "annotations": {"readOnlyHint": true}
+                },
+                {
+                    "name": "archive_chat",
+                    "description": "Archive a chat",
+                    "inputSchema": {"type": "object"},
+                    "annotations": {}
+                }
+            ],
+            "nextCursor": "abc",
+            "extra": "preserved"
+        }),
+    );
+
+    normalize_tools_list_response("beeper", &mut response);
+
+    let result = response.result.expect("success result");
+    assert_eq!(result["nextCursor"], "abc");
+    assert_eq!(result["extra"], "preserved");
+
+    let search = &result["tools"][0]["annotations"];
+    assert_eq!(search["readOnlyHint"], true);
+    assert_eq!(search["destructiveHint"], false);
+    assert_eq!(search["idempotentHint"], true);
+    assert_eq!(search["openWorldHint"], true);
+    assert_eq!(
+        result["tools"][0]["trustCard"]["schemaVersion"],
+        "trust_card.v1"
+    );
+    assert_eq!(
+        result["tools"][0]["trustCard"]["serverId"],
+        "backend:beeper"
+    );
+    assert_eq!(result["tools"][0]["trustCard"]["toolName"], "search");
+    assert_eq!(
+        result["tools"][0]["trustCard"]["trustCardDigestSha256"]
+            .as_str()
+            .unwrap()
+            .len(),
+        64
+    );
+
+    let archive = &result["tools"][1]["annotations"];
+    assert_eq!(archive["readOnlyHint"], false);
+    assert_eq!(archive["destructiveHint"], true);
+    assert_eq!(archive["idempotentHint"], false);
+    assert_eq!(archive["openWorldHint"], true);
+}

--- a/src/gateway/router/mod.rs
+++ b/src/gateway/router/mod.rs
@@ -94,6 +94,12 @@ pub struct AppState {
     /// SIEM export status, present when the export background task is running
     /// (MIK-6703). Drives the `EvidenceExport` entitlement + export-status route.
     pub export_status: Option<Arc<crate::control_plane::ExportStatus>>,
+    /// Tamper-evident transparency log (issue #133, D3), shared with `MetaMcp`.
+    /// Lets the direct backend route (`backend_handlers::backend_handler`),
+    /// which bypasses `MetaMcp`, write identity-propagation audit events
+    /// (`idp_mint` / `idp_refuse`) into the same hash chain (MIK-6740). `None`
+    /// when the transparency log is disabled — audit writes are then a no-op.
+    pub transparency_log: Option<Arc<crate::security::TransparencyLogger>>,
 }
 
 /// Create the router.

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -69,6 +69,7 @@ fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Ar
             crate::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 
@@ -116,6 +117,7 @@ fn test_router_app_state_with_agent_auth_enabled() -> Arc<AppState> {
             crate::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 
@@ -159,6 +161,7 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
             crate::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 
@@ -211,6 +214,7 @@ fn test_router_app_state_with_ssrf(
             crate::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 
@@ -271,6 +275,7 @@ fn test_router_app_state_with_auth(auth: &AuthConfig) -> Arc<AppState> {
             crate::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -304,6 +304,12 @@ struct BuiltMetaMcp {
     transition_path: std::path::PathBuf,
     /// Data directory used by cost-governance persistence.
     data_dir: std::path::PathBuf,
+    /// Transparency log handle, `None` when disabled (issue #133, D3).
+    /// Threaded into `AppState` so the direct backend route
+    /// (`backend_handlers::backend_handler`), which does not go through
+    /// `MetaMcp`, can also write identity-propagation audit events into the
+    /// same tamper-evident chain (MIK-6740).
+    transparency_log: Option<Arc<crate::security::TransparencyLogger>>,
 }
 
 impl Gateway {
@@ -493,6 +499,11 @@ impl Gateway {
         meta_mcp.set_transition_tracker(Arc::clone(&transition_tracker));
 
         // ── Transparency log (issue #133, D3) ─────────────────────────────────
+        // The opened `Arc` is kept as `transparency_log` (not just handed to
+        // `MetaMcp`) so `AppState` can hold a second clone — the direct
+        // backend route writes identity-propagation audit events straight
+        // into this chain without going through `MetaMcp` (MIK-6740).
+        let mut transparency_log: Option<Arc<crate::security::TransparencyLogger>> = None;
         if self.config.security.transparency_log.enabled {
             use crate::security::transparency_log::TransparencyLogConfig;
             let tl_cfg = Arc::new(TransparencyLogConfig {
@@ -503,9 +514,11 @@ impl Gateway {
             });
             match crate::security::TransparencyLogger::open(tl_cfg) {
                 Ok(logger) => {
+                    let logger = Arc::new(logger);
                     Arc::get_mut(&mut meta_mcp)
                         .expect("no other Arc references at this point")
-                        .enable_transparency_log(logger);
+                        .enable_transparency_log(Arc::clone(&logger));
+                    transparency_log = Some(logger);
                     info!("Transparency log enabled");
                 }
                 Err(e) => {
@@ -563,6 +576,7 @@ impl Gateway {
             transition_tracker,
             transition_path,
             data_dir,
+            transparency_log,
         })
     }
 
@@ -605,6 +619,7 @@ impl Gateway {
             transition_tracker,
             transition_path,
             data_dir,
+            transparency_log,
         } = self.build_meta_mcp().await?;
 
         // Log policy and feature states now that the shared builder has run.
@@ -967,6 +982,7 @@ impl Gateway {
             control_plane_store,
             live_config: Arc::clone(&live_config),
             export_status,
+            transparency_log,
         });
 
         // Create router

--- a/src/identity_propagation/mod.rs
+++ b/src/identity_propagation/mod.rs
@@ -351,6 +351,76 @@ impl IdentityPropagation for SignedAssertionStrategy {
     }
 }
 
+/// Stable actor id for an identity-propagation audit entry (MIK-6740). Uses the
+/// same `issuer`+`subject` derivation as the control-plane governance audit
+/// (`stable_actor_id`) so the two audit trails describe the same actor under the
+/// same id. `"unauthenticated"` covers the non-`required` path, where a
+/// mint/refuse decision can be reached with no verified identity.
+pub(crate) fn audit_subject(
+    verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+) -> String {
+    verified_identity.map_or_else(
+        || "unauthenticated".to_string(),
+        crate::key_server::oidc::VerifiedIdentity::stable_actor_id,
+    )
+}
+
+/// Record an identity-propagation credential decision (`idp_mint` /
+/// `idp_refuse`) into the tamper-evident transparency log (MIK-6740, IDP4).
+///
+/// Both the direct backend route (`backend_handlers`) and the Meta-MCP
+/// `gateway_invoke` route (`meta_mcp::invoke`) call this so every mint and every
+/// fail-closed refusal is audited identically, regardless of entry path.
+///
+/// Takes the logger directly (rather than `&AppState`) so this function is
+/// independently unit-testable against a real [`crate::security::TransparencyLogger`]
+/// over a tempfile, with no need to construct a full `AppState`. `logger` is
+/// `None` when the transparency log is disabled — the call is then a no-op.
+///
+/// Redaction is the load-bearing property here: only `subject`, `backend`,
+/// `audience`, `action`, `reason`, and `timestamp` are ever passed to
+/// [`crate::security::TransparencyLogger::append_event`] — never the resolved
+/// credential header value or a raw assertion.
+///
+/// ponytail: audit is best-effort, not fail-closed — a write failure is
+/// `warn!`'d and the caller's request proceeds/fails on its own merits,
+/// mirroring how `TransparencyLogger::log_invocation` failures are handled
+/// elsewhere in the gateway. A regulated buyer that needs "no mint without a
+/// durable audit record" would need this gated fail-closed instead; tracked as
+/// a possible future hardening, not required for MIK-6740.
+pub(crate) fn audit_identity_propagation(
+    logger: Option<&crate::security::TransparencyLogger>,
+    action: &'static str,
+    subject: &str,
+    backend: &str,
+    audience: Option<&str>,
+    reason: Option<&str>,
+) {
+    let Some(logger) = logger else {
+        return;
+    };
+
+    let mut fields = serde_json::Map::new();
+    fields.insert("action".into(), action.into());
+    fields.insert("subject".into(), subject.into());
+    fields.insert("backend".into(), backend.into());
+    fields.insert("timestamp".into(), chrono::Utc::now().to_rfc3339().into());
+    if let Some(audience) = audience {
+        fields.insert("audience".into(), audience.into());
+    }
+    if let Some(reason) = reason {
+        fields.insert("reason".into(), reason.into());
+    }
+
+    if let Err(e) = logger.append_event(fields) {
+        tracing::warn!(
+            backend,
+            action, error = %e,
+            "Failed to write identity-propagation audit entry (transparency log)"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -888,7 +888,9 @@ static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
 fn resolve_stats_url_no_url_no_config_falls_back_to_default() {
-    let _cwd = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _cwd = CWD_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     let orig = std::env::current_dir().unwrap();
     // Run from an empty directory so `Config::load(None)`'s well-known
@@ -946,7 +948,9 @@ fn resolve_stats_url_no_url_translates_wildcard_bind_host() {
 /// would apply via `apply_cli_overrides`.
 #[test]
 fn resolve_stats_url_no_url_applies_port_override() {
-    let _cwd = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _cwd = CWD_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     let orig = std::env::current_dir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();

--- a/src/provider/mcp_provider.rs
+++ b/src/provider/mcp_provider.rs
@@ -58,6 +58,26 @@ impl Provider for McpProvider {
     }
 
     async fn invoke(&self, tool: &str, args: Value) -> Result<Value> {
+        // MIK-6741 (PROV.1, IDP.2 fail-closed): the `Provider` trait carries no
+        // per-user identity, so this adapter cannot resolve or attach a per-user
+        // credential. Dispatching a propagation-required backend here would
+        // silently reuse the shared gateway session and bypass enforcement. No
+        // live server route reaches this adapter today (confirmed by source
+        // search, MIK-6734 r4); this guard fails closed so a future wiring
+        // cannot become a silent identity bypass.
+        if self
+            .backend
+            .identity_propagation_config()
+            .is_some_and(|c| c.required)
+        {
+            return Err(crate::Error::Protocol(format!(
+                "backend '{}' requires end-user identity propagation, which the Provider \
+                 adapter path cannot supply; refusing to dispatch over a shared session \
+                 (MIK-6741, IDP.2 fail-closed)",
+                self.backend.name
+            )));
+        }
+
         let params = serde_json::json!({
             "name": tool,
             "arguments": args,
@@ -116,5 +136,70 @@ mod tests {
         // Compile-time check: McpProvider can be stored in Arc<dyn Provider>.
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<McpProvider>();
+    }
+
+    // MIK-6741 (PROV.2): the adapter must fail closed for a propagation-required
+    // backend, since the `Provider` trait cannot carry the per-user identity.
+    // The guard short-circuits before any transport call, so no live backend is
+    // needed. If a future change wires this adapter into a live route, this test
+    // fails unless enforcement is added — the intended tripwire.
+    #[tokio::test]
+    async fn invoke_fails_closed_for_propagation_required_backend() {
+        use crate::backend::Backend;
+        use crate::config::BackendConfig;
+        use crate::identity_propagation::{
+            IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+        };
+
+        let backend = Arc::new(Backend::new(
+            "b",
+            BackendConfig {
+                identity_propagation: Some(IdentityPropagationConfig {
+                    strategy: PropagationStrategyKind::SignedAssertion,
+                    audience: "https://backend.example".to_string(),
+                    required: true,
+                    session_mode: SessionMode::Stateless,
+                }),
+                ..BackendConfig::default()
+            },
+            &crate::config::FailsafeConfig::default(),
+            std::time::Duration::from_secs(60),
+        ));
+        let provider = McpProvider::new(backend);
+        let err = provider
+            .invoke("some_tool", serde_json::json!({}))
+            .await
+            .expect_err("propagation-required backend must fail closed via the adapter");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MIK-6741"),
+            "expected the fail-closed guard, got: {msg}"
+        );
+    }
+
+    // A backend with no identity_propagation config must NOT be blocked by the
+    // guard (the check is opt-in on `required`). We can't complete a real
+    // dispatch without a transport, so we assert the guard does not short-circuit
+    // by observing a transport-level error rather than the MIK-6741 refusal.
+    #[tokio::test]
+    async fn invoke_not_blocked_for_non_propagation_backend() {
+        use crate::backend::Backend;
+        use crate::config::BackendConfig;
+
+        let backend = Arc::new(Backend::new(
+            "plain",
+            BackendConfig::default(),
+            &crate::config::FailsafeConfig::default(),
+            std::time::Duration::from_secs(60),
+        ));
+        let provider = McpProvider::new(backend);
+        let err = provider
+            .invoke("some_tool", serde_json::json!({}))
+            .await
+            .expect_err("no transport connected, so dispatch errors");
+        assert!(
+            !err.to_string().contains("MIK-6741"),
+            "guard must not fire for a non-propagation backend: {err}"
+        );
     }
 }

--- a/tests/stdio_tests.rs
+++ b/tests/stdio_tests.rs
@@ -114,6 +114,7 @@ async fn test_stdio_initialize_produces_valid_response() {
             mcp_gateway::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     });
 
     // Call handle_initialize directly — this is what dispatch_single calls

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -101,6 +101,7 @@ fn make_app_state(cap_dir: Option<&str>, config_path: Option<std::path::PathBuf>
             mcp_gateway::config::Config::default(),
         )),
         export_status: None,
+        transparency_log: None,
     })
 }
 
@@ -172,6 +173,7 @@ fn make_app_state_with_reload(
                 mcp_gateway::config::Config::default(),
             )),
             export_status: None,
+            transparency_log: None,
         }),
         live_config,
     )


### PR DESCRIPTION
## 3.0.1 — security patch on top of the shipped 3.0.0

Two review-followup items on the end-user identity-propagation feature, both with acceptance criteria evidenced, plus the version bump.

### MIK-6741 — fail-closed adapter guard
`McpProvider::invoke` now refuses when a backend marks identity propagation as required but the adapter path cannot enforce it, rather than silently forwarding with the gateway's shared credential.

### MIK-6740 — tamper-evident identity-propagation audit
Every per-user credential mint and every fail-closed refusal is recorded to the transparency log, on **both** request routes:
- the direct backend route (`/mcp/{name}`), and
- the primary Meta-MCP `gateway_invoke` route (this was the gap the third review round caught — the invoke route resolved credentials without auditing).

Audit entries carry metadata only (subject, backend, audience, action, reason, timestamp) — never the minted credential bytes. A regression test flows a live credential through the real resolution path and asserts it is present in the forwarded headers yet absent from the log.

### Quality
- 3251 lib tests pass (+ new coverage for both routes)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check` clean
- Adversarial second-opinion review: RELEASE-READY (three rounds; two real findings fixed)

### Known follow-up
`backend_handlers.rs` retains byte-identical private copies of the two audit helpers now canonicalised in `identity_propagation`; both are test-exercised, no behavioural divergence. Consolidation tracked as follow-up.