### PR TITLE
fix(security): redact credentials from Debug output (CWE-532)

### DIFF
--- a/src/gateway/auth.rs
+++ b/src/gateway/auth.rs
@@ -29,8 +29,15 @@ use crate::key_server::KeyServer;
 /// Type alias for our rate limiter
 type ClientRateLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 
+/// Short, non-reversible fingerprint of a secret for log correlation (CWE-532).
+///
+/// Returns the first 12 hex chars of the SHA-256 digest — enough to correlate
+/// which credential is active across logs, useless as a credential itself.
+fn bearer_token_fingerprint(token: &str) -> String {
+    crate::hashing::sha256_hex(token.as_bytes())[..12].to_string()
+}
+
 /// Resolved authentication configuration (tokens expanded)
-#[derive(Debug)]
 pub struct ResolvedAuthConfig {
     /// Whether auth is enabled
     pub enabled: bool,
@@ -49,7 +56,7 @@ pub struct ResolvedAuthConfig {
 }
 
 /// Resolved API key with expanded values
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ResolvedApiKey {
     /// The actual key value
     pub key: String,
@@ -67,6 +74,43 @@ pub struct ResolvedApiKey {
     pub admin: bool,
 }
 
+// Manual `Debug` that redacts resolved secrets (CWE-532, mirrors MIK-6733).
+// A derived `Debug` would print the bearer token / API key verbatim into any
+// trace or error context. Only a non-reversible fingerprint is shown.
+impl std::fmt::Debug for ResolvedAuthConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedAuthConfig")
+            .field("enabled", &self.enabled)
+            .field(
+                "bearer_token",
+                &self
+                    .bearer_token
+                    .as_deref()
+                    .map(|t| format!("<redacted:{}>", bearer_token_fingerprint(t))),
+            )
+            .field("api_keys", &self.api_keys)
+            .field("public_paths", &self.public_paths)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for ResolvedApiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedApiKey")
+            .field(
+                "key",
+                &format!("<redacted:{}>", bearer_token_fingerprint(&self.key)),
+            )
+            .field("name", &self.name)
+            .field("rate_limit", &self.rate_limit)
+            .field("backends", &self.backends)
+            .field("allowed_tools", &self.allowed_tools)
+            .field("denied_tools", &self.denied_tools)
+            .field("admin", &self.admin)
+            .finish()
+    }
+}
+
 impl ResolvedAuthConfig {
     /// Create resolved config from `AuthConfig`.
     ///
@@ -76,11 +120,18 @@ impl ResolvedAuthConfig {
     pub fn try_from_config(config: &AuthConfig) -> Result<Self> {
         let bearer_token = config.resolve_bearer_token()?;
 
-        // Log if auto-generated token
+        // Signal auto-generation WITHOUT logging the secret (CWE-532). The
+        // plaintext bearer is a master gateway credential; INFO logs ship to
+        // files, journald, and aggregators where log-read access would become
+        // full auth bypass. Emit only a short non-reversible fingerprint so
+        // operators can correlate the active token without it being usable.
         if config.bearer_token.as_deref() == Some("auto")
             && let Some(ref token) = bearer_token
         {
-            tracing::info!("Auto-generated bearer token: {}", token);
+            tracing::info!(
+                "Auto-generated bearer token (fingerprint {})",
+                bearer_token_fingerprint(token)
+            );
         }
 
         let api_keys: Vec<ResolvedApiKey> = config
@@ -537,6 +588,54 @@ mod tests {
         assert!(config.is_public_path("/metrics"));
         assert!(!config.is_public_path("/mcp"));
         assert!(!config.is_public_path("/"));
+    }
+
+    #[test]
+    fn debug_output_redacts_bearer_and_api_keys() {
+        // CWE-532 / MIK-6733 sibling: {:?} must never leak resolved secrets.
+        let config = ResolvedAuthConfig {
+            enabled: true,
+            bearer_token: Some("super-secret-bearer-VALUE".to_string()),
+            api_keys: vec![ResolvedApiKey {
+                key: "api-key-SECRET-VALUE".to_string(),
+                name: "client-a".to_string(),
+                rate_limit: 60,
+                backends: vec![],
+                allowed_tools: None,
+                denied_tools: None,
+                admin: false,
+            }],
+            public_paths: vec![],
+            rate_limiters: DashMap::new(),
+            client_circuit_breaker: None,
+            client_circuit_breakers: DashMap::new(),
+        };
+        let dbg = format!("{config:?}");
+        assert!(
+            !dbg.contains("super-secret-bearer-VALUE"),
+            "Debug leaked the bearer token: {dbg}"
+        );
+        assert!(
+            !dbg.contains("api-key-SECRET-VALUE"),
+            "Debug leaked the API key: {dbg}"
+        );
+        assert!(
+            dbg.contains("<redacted"),
+            "expected redaction marker: {dbg}"
+        );
+        // Non-secret fields stay visible for diagnostics.
+        assert!(
+            dbg.contains("client-a"),
+            "api key name should remain visible"
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_not_the_secret() {
+        let fp = bearer_token_fingerprint("super-secret-bearer-VALUE");
+        assert_eq!(fp.len(), 12);
+        assert!(!fp.contains("secret"));
+        assert_ne!(fp, "super-secret-bearer-VALUE");
     }
 
     #[test]

--- a/src/key_server/handler.rs
+++ b/src/key_server/handler.rs
@@ -56,7 +56,7 @@ use crate::config::KeyServerOidcConfig;
 // ── Request / Response types ───────────────────────────────────────────────
 
 /// RFC 8693 token exchange request body.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct TokenExchangeRequest {
     /// Must be `urn:ietf:params:oauth:grant-type:token-exchange`.
     pub grant_type: String,
@@ -70,8 +70,21 @@ pub struct TokenExchangeRequest {
     pub scope: String,
 }
 
+// Manual `Debug` redacts the OIDC subject token / issued bearer (CWE-532,
+// mirrors MIK-6733) so these credentials never reach a trace or error log.
+impl std::fmt::Debug for TokenExchangeRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenExchangeRequest")
+            .field("grant_type", &self.grant_type)
+            .field("subject_token", &"<redacted>")
+            .field("subject_token_type", &self.subject_token_type)
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
 /// RFC 8693 token exchange response.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct TokenExchangeResponse {
     /// The issued opaque bearer token.
     pub access_token: String,
@@ -83,6 +96,18 @@ pub struct TokenExchangeResponse {
     pub scope: String,
     /// JTI for revocation.
     pub jti: String,
+}
+
+impl std::fmt::Debug for TokenExchangeResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenExchangeResponse")
+            .field("access_token", &"<redacted>")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field("scope", &self.scope)
+            .field("jti", &self.jti)
+            .finish()
+    }
 }
 
 /// Query params for bulk revocation.
@@ -395,6 +420,37 @@ fn error_response(status: StatusCode, error: &str, message: &str) -> axum::respo
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_output_redacts_exchange_tokens() {
+        // CWE-532 / MIK-6733 sibling: {:?} must never leak the OIDC subject
+        // token or the issued bearer.
+        let req = TokenExchangeRequest {
+            grant_type: "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
+            subject_token: "eyJ-SUBJECT-JWT-SECRET".to_string(),
+            subject_token_type: "urn:ietf:params:oauth:token-type:id_token".to_string(),
+            scope: "gmail".to_string(),
+        };
+        let resp = TokenExchangeResponse {
+            access_token: "mcpgw_ISSUED-BEARER-SECRET".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 3600,
+            scope: "gmail".to_string(),
+            jti: "jti-123".to_string(),
+        };
+        let rdbg = format!("{req:?}");
+        let sdbg = format!("{resp:?}");
+        assert!(
+            !rdbg.contains("eyJ-SUBJECT-JWT-SECRET"),
+            "leaked subject token: {rdbg}"
+        );
+        assert!(
+            !sdbg.contains("mcpgw_ISSUED-BEARER-SECRET"),
+            "leaked access token: {sdbg}"
+        );
+        assert!(rdbg.contains("<redacted>") && sdbg.contains("<redacted>"));
+        assert!(sdbg.contains("jti-123"), "jti stays visible for revocation");
+    }
 
     #[test]
     fn parse_scope_string_empty() {

--- a/src/key_server/store.rs
+++ b/src/key_server/store.rs
@@ -24,7 +24,7 @@ use tracing::debug;
 use super::oidc::VerifiedIdentity;
 
 /// A temporary gateway token issued after OIDC verification.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TemporaryToken {
     /// Unique token identifier (used for revocation).
     pub jti: String,
@@ -41,6 +41,23 @@ pub struct TemporaryToken {
     /// Client IP at issuance (for audit).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_ip: Option<IpAddr>,
+}
+
+// Manual `Debug` redacts the opaque bearer value (CWE-532, mirrors MIK-6733).
+// A derived `Debug` would print a live, usable session credential into logs;
+// the `jti` is shown instead for correlation/revocation.
+impl std::fmt::Debug for TemporaryToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TemporaryToken")
+            .field("jti", &self.jti)
+            .field("token", &"<redacted>")
+            .field("identity", &self.identity)
+            .field("scopes", &self.scopes)
+            .field("iat", &self.iat)
+            .field("exp", &self.exp)
+            .field("client_ip", &self.client_ip)
+            .finish()
+    }
 }
 
 impl TemporaryToken {
@@ -288,6 +305,20 @@ mod tests {
             exp,
             client_ip: None,
         }
+    }
+
+    #[test]
+    fn debug_output_redacts_bearer_value() {
+        // CWE-532 / MIK-6733 sibling: {:?} must never leak the live bearer.
+        let token = make_token("user-1", "u1@test.local", 3600);
+        let raw = token.token.clone();
+        let dbg = format!("{token:?}");
+        assert!(!dbg.contains(&raw), "Debug leaked the bearer value: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "expected redaction marker: {dbg}"
+        );
+        assert!(dbg.contains(&token.jti), "jti stays visible for revocation");
     }
 
     #[tokio::test]

--- a/src/security/message_signing.rs
+++ b/src/security/message_signing.rs
@@ -67,13 +67,29 @@ pub const EVICTION_INTERVAL: Duration = Duration::from_secs(60);
 /// let signed = signer.sign_response(response, Some("nonce-42"));
 /// assert!(signed.get("_signature").is_some());
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MessageSigner {
     secret: Vec<u8>,
     /// Retained for zero-downtime rotation; used in future `verify_response()` API.
     #[allow(dead_code)]
     previous_secret: Option<Vec<u8>>,
     key_id: String,
+}
+
+// Manual `Debug` that redacts the HMAC signing secret (CWE-532, mirrors MIK-6733).
+// A derived `Debug` would print the raw signing material — leaking it lets an
+// attacker forge signed responses. Only the key id is shown.
+impl std::fmt::Debug for MessageSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessageSigner")
+            .field("secret", &"<redacted>")
+            .field(
+                "previous_secret",
+                &self.previous_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("key_id", &self.key_id)
+            .finish()
+    }
 }
 
 impl MessageSigner {
@@ -276,6 +292,22 @@ mod tests {
             None,
             "test".to_string(),
         )
+    }
+
+    #[test]
+    fn debug_output_redacts_signing_secret() {
+        // CWE-532 / MIK-6733 sibling: {:?} must never leak the HMAC secret.
+        let signer = make_signer();
+        let dbg = format!("{signer:?}");
+        assert!(
+            !dbg.contains("a-test-secret-that-is-at-least-32-bytes-long"),
+            "Debug leaked the signing secret: {dbg}"
+        );
+        assert!(
+            dbg.contains("<redacted>"),
+            "expected redaction marker: {dbg}"
+        );
+        assert!(dbg.contains("test"), "key_id should remain visible");
     }
 
     // ── sign_response ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Five structs across the auth, key-server, and message-signing paths derived `Debug` over live secrets. Any `{:?}` reaching a trace or error context would print the credential verbatim (CWE-532). Same leak class as the JWKS private-key redaction in MIK-6733, which turned out not to be isolated to `jwks.rs`.

## Findings fixed

| # | Location | Secret exposed | Severity |
|---|----------|----------------|----------|
| 1 | auth path | `info!` logged the plaintext auto-generated master bearer | High (active log write) |
| 2 | message-signing path | `MessageSigner` HMAC secret | High |
| 3 | key-server handler | OIDC subject token + issued bearer | High |
| 4 | auth path | `ResolvedAuthConfig.bearer_token`, `ResolvedApiKey.key` | Medium-High |
| 5 | key-server store | `TemporaryToken.token` live bearer | Medium |

## Approach

- Finding 1 now emits a non-reversible SHA-256 fingerprint (first 12 hex chars) instead of the token, so operators keep log correlation without a usable credential.
- Findings 2-5 replace the derived `Debug` with a manual impl that redacts only the secret field and keeps non-secret diagnostics (key id, jti, client name) visible.
- Serialize/Deserialize/Clone derives preserved; only Debug changes.
- Reuses `crate::hashing::sha256_hex` rather than adding a hashing path.

## Verification

- 6 redaction tests added; all green.
- `cargo test --lib`: 3257 passed, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.

Generated with Claude Code