### PR TITLE
fix(cli): serve degrades to defaults when --config path is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **stdio serve boots without a mounted config (Glama build).** An explicit
+  `--config <path>` that does not exist was a hard error, so
+  `mcp-gateway serve --stdio --config /config.yaml` exited non-zero when the
+  file was absent — the exact shape of Glama's container build smoke-test,
+  which passes that placeholder while the generated Dockerfile never writes the
+  file. The stdio serve path now downgrades a missing explicit `--config` to
+  the normal no-config resolution (fallback locations, env vars, then defaults)
+  with a stderr warning. Scoped to stdio only: the HTTP server path stays
+  fail-loud so a missing intended config can never silently start with
+  authentication disabled.
+
 ## [3.0.1] - 2026-07-03
 
 Security hardening fast-follow for the 3.0.0 end-user identity-propagation

--- a/src/main.rs
+++ b/src/main.rs
@@ -512,12 +512,43 @@ fn apply_cli_overrides_and_validate(config: &mut Config, cli: &Cli) -> mcp_gatew
 }
 
 /// Run the gateway in stdio mode (newline-delimited JSON-RPC on stdin/stdout).
+/// Resolve the effective `--config` path for the **stdio** serve command only.
+///
+/// An explicitly-supplied path that does not exist is downgraded to `None`
+/// (fall through to `Config::load`'s fallback-location search, then env vars,
+/// then built-in defaults) instead of a hard failure, so the published
+/// container image boots over stdio when no config has been mounted yet. Glama's
+/// build smoke-test starts the container with `serve --stdio --config
+/// /config.yaml` even though the generated Dockerfile never writes that file;
+/// fail-loud there reports a spurious "build failed".
+///
+/// Scoped to stdio deliberately: stdio is a local pipe with no network listener,
+/// so starting on defaults cannot expose an unauthenticated network surface. The
+/// HTTP `run_server` path stays fail-loud (`Config::load(cli.config)` directly)
+/// because its defaults (`auth.enabled=false`, `meta_mcp.enabled=true`) would be
+/// a fail-open regression if an intended `--config` went missing. `audit`/
+/// `validate`/`doctor` likewise keep `Config::load`'s fail-loud behavior.
+fn serve_config_path(cli: &Cli) -> Option<std::path::PathBuf> {
+    match cli.config.as_deref() {
+        Some(p) if !p.exists() => {
+            eprintln!(
+                "Warning: config file {} not found; continuing over stdio without it \
+                 (fallback locations, env vars, then defaults)",
+                p.display()
+            );
+            None
+        }
+        other => other.map(std::path::Path::to_path_buf),
+    }
+}
+
 async fn run_stdio_server(cli: Cli) -> ExitCode {
     if let Err(e) = commands::check_upgrade(&commands::upgrade_data_dir()) {
         eprintln!("Warning: upgrade check failed: {e}");
     }
 
-    let config = match Config::load(cli.config.as_deref()) {
+    let config_path = serve_config_path(&cli);
+    let config = match Config::load(config_path.as_deref()) {
         Ok(mut config) => {
             if let Err(e) = apply_cli_overrides_and_validate(&mut config, &cli) {
                 eprintln!("Failed to apply configuration overrides: {e}");
@@ -531,7 +562,6 @@ async fn run_stdio_server(cli: Cli) -> ExitCode {
         }
     };
 
-    let config_path = cli.config.as_deref().map(std::path::Path::to_path_buf);
     let gateway = match Gateway::new_with_path(config, config_path).await {
         Ok(g) => g,
         Err(e) => {
@@ -559,6 +589,11 @@ async fn run_server(cli: Cli) -> ExitCode {
         eprintln!("Warning: upgrade check failed: {e}");
     }
 
+    // HTTP serve stays fail-loud: an explicit --config that cannot be loaded
+    // must NOT silently start on defaults (auth.enabled=false,
+    // meta_mcp.enabled=true would be a network-facing fail-open). Only the
+    // stdio path (a local pipe, no network auth surface) degrades — see
+    // serve_config_path / run_stdio_server.
     let config = match Config::load(cli.config.as_deref()) {
         Ok(mut config) => {
             if let Err(e) = apply_cli_overrides_and_validate(&mut config, &cli) {

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -958,3 +958,40 @@ fn resolve_stats_url_no_url_applies_port_override() {
     std::env::set_current_dir(&orig).unwrap();
     assert_eq!(resolved, "http://127.0.0.1:9999");
 }
+
+fn make_cli_with_config(config: Option<std::path::PathBuf>) -> Cli {
+    Cli {
+        config,
+        port: None,
+        host: None,
+        log_level: "info".to_string(),
+        log_format: None,
+        no_meta_mcp: false,
+        command: None,
+    }
+}
+
+#[test]
+fn serve_config_path_none_stays_none() {
+    let cli = make_cli_with_config(None);
+    assert_eq!(serve_config_path(&cli), None);
+}
+
+#[test]
+fn serve_config_path_missing_downgrades_to_none() {
+    // Glama passes --config /config.yaml with no such file; serve must not
+    // fail-loud on it (that reported a spurious "build failed").
+    let cli = make_cli_with_config(Some(std::path::PathBuf::from(
+        "/nonexistent/does-not-exist-config.yaml",
+    )));
+    assert_eq!(serve_config_path(&cli), None);
+}
+
+#[test]
+fn serve_config_path_existing_is_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, "server:\n  port: 8080\n").unwrap();
+    let cli = make_cli_with_config(Some(path.clone()));
+    assert_eq!(serve_config_path(&cli), Some(path));
+}


### PR DESCRIPTION
## Problem

Glama's build smoke-test starts the published container with `mcp-gateway serve --stdio --config /config.yaml` (its placeholder parameter), but the Glama-generated Dockerfile never writes that file. An explicit `--config <path>` that does not exist is a hard error in `Config::load` (`src/config/mod.rs:181`), so serve exited non-zero and Glama reported a spurious "build failed".

## Fix

`serve_config_path()` downgrades a non-existent explicit `--config` to the normal no-config resolution (fallback locations, env vars, then defaults) with a stderr warning — **for the stdio serve path only** (`run_stdio_server`).

Scoped to stdio deliberately: stdio is a local pipe with no network listener, so starting on defaults cannot expose an unauthenticated network surface. The HTTP `run_server` path stays **fail-loud** — its defaults (`auth.enabled=false`, `meta_mcp.enabled=true`) would be a fail-open regression if an intended `--config` went missing. `audit`/`validate`/`doctor` keep `Config::load`'s fail-loud behavior.

## Review

Adversarial GPT-5.5 second opinion: round 1 BLOCK (flagged the HTTP fail-open when the downgrade was applied to both paths); round 2 after scoping to stdio + reverting HTTP: **LGTM / SAFE TO MERGE**, verified at 5d998b2c.

## Tests

- `serve_config_path_none_stays_none`
- `serve_config_path_missing_downgrades_to_none` (the Glama case)
- `serve_config_path_existing_is_preserved`

## Gates

cargo test (3 new) pass · fmt clean · clippy --all-features -D warnings clean · full CI green.

## Note

Fixes the code defect. The Glama listing turns green only once (1) the fix ships in a release binary and (2) Glama's Dockerfile pin advances off v2.9.0 — Glama downloads a pinned release binary, it does not build from source.