### PR TITLE
Fix cross-user upstream session sharing (MIK-6784)

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -744,7 +744,7 @@ impl Backend {
         )
     )]
     pub async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse> {
-        self.request_with_headers(method, params, &[]).await
+        self.request_with_headers(method, params, &[], None).await
     }
 
     /// This backend's end-user identity-propagation config, if configured
@@ -794,6 +794,11 @@ impl Backend {
     /// value to the transport's `request_with_headers`, never stored on the
     /// backend, so concurrent per-user requests stay isolated (IDP.3).
     ///
+    /// `identity_key` is the caller's stable identity binding (MIK-6784); the
+    /// transport uses it to partition upstream `MCP-Session-Id` state so one
+    /// user's session is never reused for another. `None` selects the shared
+    /// default bucket (single-tenant behavior unchanged).
+    ///
     /// # Errors
     ///
     /// Returns an error if the backend is unavailable, the concurrency limit
@@ -803,6 +808,7 @@ impl Backend {
         method: &str,
         params: Option<Value>,
         extra_headers: &[(String, String)],
+        identity_key: Option<&str>,
     ) -> Result<JsonRpcResponse> {
         let start_time = std::time::Instant::now();
 
@@ -845,14 +851,19 @@ impl Backend {
 
         // Execute with retry
         let name = self.name.clone();
+        // Own the identity key so the retry closure (Fn, invoked once per
+        // attempt) can hand a borrow to each attempt's future without tying the
+        // closure to the caller's borrow lifetime (MIK-6784).
+        let identity_key = identity_key.map(str::to_string);
         let result = with_retry(&self.failsafe.retry_policy, &name, || {
             let transport = Arc::clone(&transport);
             let method = method.to_string();
             let params = params.clone();
             let extra_headers = extra_headers.to_vec();
+            let identity_key = identity_key.clone();
             async move {
                 transport
-                    .request_with_headers(&method, params, &extra_headers)
+                    .request_with_headers(&method, params, &extra_headers, identity_key.as_deref())
                     .await
             }
         })

--- a/src/config/features/key_server.rs
+++ b/src/config/features/key_server.rs
@@ -124,6 +124,39 @@ impl KeyServerConfig {
             }
         })
     }
+
+    /// Validate the key-server config at load time (MIK-6784, GW.4).
+    ///
+    /// A disabled key server is not validated (its providers are inert). When
+    /// enabled, every OIDC provider MUST declare a non-empty `audiences` list:
+    /// an empty list would accept a token minted for *any* client
+    /// (audience-confusion). The runtime verifier historically skipped the
+    /// `aud` check when `audiences` was empty, so the guard must live here — at
+    /// config load — to fail closed before any token is accepted. This mirrors
+    /// the non-empty-audience enforcement in
+    /// [`crate::identity_propagation::IdentityPropagationConfig::validate`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigValidation`] for the first provider with an empty
+    /// (or whitespace-only) audience list.
+    pub fn validate(&self) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        for (idx, provider) in self.oidc.iter().enumerate() {
+            let has_audience = provider.audiences.iter().any(|a| !a.trim().is_empty());
+            if !has_audience {
+                return Err(Error::ConfigValidation(format!(
+                    "key_server.oidc[{idx}] (issuer '{}') must declare at least one non-empty \
+                     audience; an empty `audiences` list accepts a token minted for any client \
+                     (audience-confusion, MIK-6784)",
+                    provider.issuer
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Configuration for a single OIDC identity provider.
@@ -145,7 +178,10 @@ pub struct KeyServerProviderConfig {
     /// legacy `{issuer}/.well-known/jwks.json` guess.
     #[serde(default = "default_auto_discover")]
     pub auto_discover: bool,
-    /// Expected audience values (`aud` claim). Empty = any audience accepted.
+    /// Expected audience values (`aud` claim). When the key server is enabled
+    /// this MUST be non-empty (enforced by [`KeyServerConfig::validate`],
+    /// MIK-6784): an empty list would accept a token minted for any client
+    /// (audience-confusion).
     #[serde(default)]
     pub audiences: Vec<String>,
     /// Restrict to these email domains. Empty = any domain accepted.
@@ -199,4 +235,87 @@ pub struct PolicyScopesConfig {
 pub struct KeyServerOidcConfig {
     /// Maximum age of an incoming OIDC token (seconds).
     pub max_token_age_secs: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(issuer: &str, audiences: Vec<&str>) -> KeyServerProviderConfig {
+        KeyServerProviderConfig {
+            issuer: issuer.to_string(),
+            jwks_uri: None,
+            discovery_url: None,
+            auto_discover: true,
+            audiences: audiences.into_iter().map(String::from).collect(),
+            allowed_domains: Vec::new(),
+        }
+    }
+
+    fn enabled_with(providers: Vec<KeyServerProviderConfig>) -> KeyServerConfig {
+        KeyServerConfig {
+            enabled: true,
+            oidc: providers,
+            ..KeyServerConfig::default()
+        }
+    }
+
+    /// GW.4: an enabled provider with a non-empty audience passes validation.
+    #[test]
+    fn validate_accepts_non_empty_audience() {
+        let cfg = enabled_with(vec![provider(
+            "https://accounts.google.com",
+            vec!["client-id"],
+        )]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    /// GW.4: an enabled provider with an empty audience list is rejected at load
+    /// (audience-confusion fail-closed).
+    #[test]
+    fn validate_rejects_empty_audience_list() {
+        let cfg = enabled_with(vec![provider("https://issuer.example", vec![])]);
+        let err = cfg
+            .validate()
+            .expect_err("empty audiences must fail closed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("audience"),
+            "message names the audience gap: {msg}"
+        );
+        assert!(
+            msg.contains("issuer.example"),
+            "message names the offending issuer: {msg}"
+        );
+    }
+
+    /// GW.4: a whitespace-only audience is not a real audience — still rejected.
+    #[test]
+    fn validate_rejects_whitespace_only_audience() {
+        let cfg = enabled_with(vec![provider("https://issuer.example", vec!["   "])]);
+        assert!(cfg.validate().is_err());
+    }
+
+    /// GW.4: the second provider's empty audience is caught even when the first
+    /// is valid.
+    #[test]
+    fn validate_rejects_when_any_provider_lacks_audience() {
+        let cfg = enabled_with(vec![
+            provider("https://good.example", vec!["aud"]),
+            provider("https://bad.example", vec![]),
+        ]);
+        let err = cfg.validate().expect_err("any bad provider must fail");
+        assert!(err.to_string().contains("bad.example"));
+    }
+
+    /// A disabled key server is inert: its providers are never validated.
+    #[test]
+    fn validate_skips_disabled_key_server() {
+        let cfg = KeyServerConfig {
+            enabled: false,
+            oidc: vec![provider("https://issuer.example", vec![])],
+            ..KeyServerConfig::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -303,6 +303,7 @@ impl Config {
         self.validate_backend_runtime_profiles()?;
         self.control_plane.role_mapping.validate()?;
         self.validate_identity_propagation()?;
+        self.key_server.validate()?;
         Ok(())
     }
 

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -752,6 +752,7 @@ impl MetaMcp {
                 agent_id,
                 caller_identity,
                 &caller_credential.headers,
+                caller_credential.cache_binding.as_deref(),
             )
             .await;
         let dispatch_latency = dispatch_start.elapsed();
@@ -1376,17 +1377,37 @@ impl MetaMcp {
         server: &str,
         verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
     ) -> Result<Vec<(String, String)>> {
+        Ok(self
+            .resolve_propagation_credential(server, verified_identity)
+            .await?
+            .0)
+    }
+
+    /// Like [`Self::resolve_propagation_headers`] but also returns the caller's
+    /// stable identity binding (MIK-6784), so the direct backend route can
+    /// partition upstream `MCP-Session-Id` state per identity. The binding is
+    /// `None` for a non-propagation backend (unchanged static path).
+    ///
+    /// # Errors
+    ///
+    /// Fail-closed `Err` for a `required` backend with no identity/strategy —
+    /// same contract as [`Self::resolve_propagation_headers`].
+    pub async fn resolve_propagation_credential(
+        &self,
+        server: &str,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+    ) -> Result<(Vec<(String, String)>, Option<String>)> {
         let Some(idp_cfg) = self
             .backends
             .get(server)
             .and_then(|b| b.identity_propagation_config().cloned())
         else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), None));
         };
-        Ok(self
+        let cred = self
             .resolve_caller_credential(server, &idp_cfg, verified_identity)
-            .await?
-            .headers)
+            .await?;
+        Ok((cred.headers, cred.cache_binding))
     }
 
     /// Resolve the per-user identity-propagation credential for a backend
@@ -1530,6 +1551,10 @@ impl MetaMcp {
         // once in `invoke_tool_traced` so the cache key and this dispatch share
         // one credential (MIK-6734); dispatch never mints.
         propagated_headers: &[(String, String)],
+        // Caller's stable identity binding (MIK-6784), used by the transport to
+        // partition upstream `MCP-Session-Id` state per identity. `None` → the
+        // shared default bucket (single-tenant behavior unchanged).
+        identity_key: Option<&str>,
     ) -> Result<Value> {
         let injection = self.secret_injector.inject(server, tool, arguments)?;
         let arguments = injection.arguments;
@@ -1639,16 +1664,19 @@ impl MetaMcp {
             None => base_params,
         };
 
-        // End-user identity propagation (MIK-6704 / ADR-007). The per-user
-        // credential was resolved (and fail-closed enforced) once upstream in
+        // End-user identity propagation (MIK-6704 / ADR-007) and per-identity
+        // upstream session partitioning (MIK-6784). The per-user credential was
+        // resolved (and fail-closed enforced) once upstream in
         // `invoke_tool_traced`; here we simply attach the pre-resolved headers
-        // via `request_with_headers` (per-request, never on the shared transport
-        // — tenant isolation, IDP.3). Empty headers → the unchanged static path.
-        let response = if propagated_headers.is_empty() {
+        // plus the caller's identity key via `request_with_headers` (per-request,
+        // never on the shared transport — tenant isolation, IDP.3). Only when
+        // there are neither headers nor an identity key do we take the unchanged
+        // static path (shared default session bucket).
+        let response = if propagated_headers.is_empty() && identity_key.is_none() {
             backend.request("tools/call", Some(params)).await?
         } else {
             backend
-                .request_with_headers("tools/call", Some(params), propagated_headers)
+                .request_with_headers("tools/call", Some(params), propagated_headers, identity_key)
                 .await?
         };
 
@@ -2744,9 +2772,14 @@ mod identity_propagation_enforcement_tests {
     // Header-capturing transport: records the per-request headers dispatch
     // attaches, so a test can assert the propagated credential reached the wire.
     type CapturedHeaders = Arc<parking_lot::Mutex<Vec<(String, String)>>>;
+    // Records the identity key dispatch threads for upstream session
+    // partitioning (MIK-6784), so a test can assert distinct identities produce
+    // distinct keys.
+    type CapturedIdentityKeys = Arc<parking_lot::Mutex<Vec<Option<String>>>>;
 
     struct CapturingTransport {
         captured: CapturedHeaders,
+        captured_identity: CapturedIdentityKeys,
     }
 
     #[async_trait::async_trait]
@@ -2766,8 +2799,12 @@ mod identity_propagation_enforcement_tests {
             _method: &str,
             _params: Option<Value>,
             extra_headers: &[(String, String)],
+            identity_key: Option<&str>,
         ) -> crate::Result<crate::protocol::JsonRpcResponse> {
             *self.captured.lock() = extra_headers.to_vec();
+            self.captured_identity
+                .lock()
+                .push(identity_key.map(str::to_string));
             self.request(_method, _params).await
         }
         async fn notify(&self, _method: &str, _params: Option<Value>) -> crate::Result<()> {
@@ -2785,6 +2822,13 @@ mod identity_propagation_enforcement_tests {
     // ("mem") wired to a header-capturing transport, plus the signed-assertion
     // strategy. Returns the meta and the shared capture buffer.
     fn meta_with_capturing_backend() -> (MetaMcp, CapturedHeaders) {
+        let (m, captured, _identity) = meta_with_capturing_backend_full();
+        (m, captured)
+    }
+
+    /// Like [`meta_with_capturing_backend`] but also exposes the buffer of
+    /// identity keys the transport received (MIK-6784).
+    fn meta_with_capturing_backend_full() -> (MetaMcp, CapturedHeaders, CapturedIdentityKeys) {
         use crate::backend::Backend;
         use crate::config::{BackendConfig, TransportConfig};
 
@@ -2805,15 +2849,17 @@ mod identity_propagation_enforcement_tests {
             std::time::Duration::from_secs(60),
         ));
         let captured = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let captured_identity = Arc::new(parking_lot::Mutex::new(Vec::new()));
         backend.set_transport_for_test(Arc::new(CapturingTransport {
             captured: Arc::clone(&captured),
+            captured_identity: Arc::clone(&captured_identity),
         }));
         registry.register(backend);
 
         let m = MetaMcp::new(registry);
         let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
         m.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
-        (m, captured)
+        (m, captured, captured_identity)
     }
 
     // IDP.1 end-to-end via Code Mode (gateway_execute): an authenticated caller

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -410,6 +410,12 @@ pub(super) async fn backend_handler(
     // schema stay reachable; every other id-bearing request is guarded.
     let isolation_guarded = !matches!(method.as_str(), "initialize" | "tools/list" | "ping")
         && !method.starts_with("notifications/");
+    // Caller's stable identity binding (MIK-6784) for per-identity upstream
+    // session partitioning on this direct route. Set only when a minting
+    // strategy resolves a binding; passthrough / no-identity keep `None` (shared
+    // default session bucket — passthrough forwards the caller's own credential
+    // inline and is gated to trusted internals).
+    let mut identity_key: Option<String> = None;
     let propagated_headers: Vec<(String, String)> = if isolation_guarded {
         // Fetched once so both the passthrough-vs-minting branch below and the
         // audit write (MIK-6740) share a single lookup/clone of the backend's
@@ -434,11 +440,18 @@ pub(super) async fn backend_handler(
                 backend.transport_carries_identity_headers(),
             )
         } else {
-            state
+            match state
                 .meta_mcp
-                .resolve_propagation_headers(&name, verified_identity.as_ref())
+                .resolve_propagation_credential(&name, verified_identity.as_ref())
                 .await
-                .map_err(|e| e.to_string())
+            {
+                Ok((headers, binding)) => {
+                    // Bind the upstream session bucket to this caller (MIK-6784).
+                    identity_key = binding;
+                    Ok(headers)
+                }
+                Err(e) => Err(e.to_string()),
+            }
         };
         let subject = audit_subject(verified_identity.as_ref());
         let audience = idp_cfg.as_ref().map(|c| c.audience.as_str());
@@ -518,11 +531,16 @@ pub(super) async fn backend_handler(
         ) {
             Some(Ok(Some(sanitized_params))) => {
                 // Forward the sanitized params to the backend
-                let forward = if propagated_headers.is_empty() {
+                let forward = if propagated_headers.is_empty() && identity_key.is_none() {
                     backend.request(&method, Some(sanitized_params)).await
                 } else {
                     backend
-                        .request_with_headers(&method, Some(sanitized_params), &propagated_headers)
+                        .request_with_headers(
+                            &method,
+                            Some(sanitized_params),
+                            &propagated_headers,
+                            identity_key.as_deref(),
+                        )
                         .await
                 };
                 return match forward {
@@ -552,11 +570,16 @@ pub(super) async fn backend_handler(
     }
 
     // Forward to backend
-    let forward = if propagated_headers.is_empty() {
+    let forward = if propagated_headers.is_empty() && identity_key.is_none() {
         backend.request(&method, params.clone()).await
     } else {
         backend
-            .request_with_headers(&method, params.clone(), &propagated_headers)
+            .request_with_headers(
+                &method,
+                params.clone(),
+                &propagated_headers,
+                identity_key.as_deref(),
+            )
             .await
     };
     match forward {

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -947,6 +947,30 @@ impl Gateway {
             );
         }
 
+        // MIK-6784 (GW.3): warn when the operator has asserted `single_user =
+        // true` (the sole switch that can suppress the per-user isolation guard)
+        // while a backend still relies on a gateway-held OAuth token that is NOT
+        // blessed for shared use (`oauth.enabled && !shared_account`). In that
+        // configuration the single-user assertion is the ONLY thing preventing
+        // one user's token — and its upstream MCP session — from being served to
+        // another; if the gateway is ever reached by more than one identity the
+        // isolation the guard would have provided is silently gone. We warn
+        // rather than refuse because a genuinely single-user deployment is valid.
+        if self.config.auth.single_user {
+            let leaky_backends = leaky_single_user_backends(&self.config);
+            if !leaky_backends.is_empty() {
+                warn!(
+                    backends = ?leaky_backends,
+                    "auth.single_user=true suppresses the per-user OAuth isolation guard, but \
+                     these backends hold a non-shared gateway OAuth token. If more than one user \
+                     reaches this gateway their tokens and upstream MCP sessions will be shared \
+                     (MIK-6784). Fix: remove single_user, set oauth.shared_account=true only \
+                     for genuinely shared service accounts, or enable per-user identity \
+                     propagation."
+                );
+            }
+        }
+
         // The transition tracker is only used when anomaly_detection=true; pass
         // a fresh tracker so the firewall has its own dedicated state.
         #[cfg(feature = "firewall")]
@@ -1557,6 +1581,31 @@ fn config_installs_minting_strategy(config: &crate::config::Config) -> bool {
     configured_minting_strategy_kind(config).is_some()
 }
 
+/// Backends whose gateway-held OAuth token is not blessed for shared use
+/// (`oauth.enabled && !oauth.shared_account`) — the set the GW.3 startup
+/// warning names (MIK-6784).
+///
+/// Returns empty unless `auth.single_user` is asserted: the warning only
+/// matters when that single switch is the sole thing suppressing the per-user
+/// OAuth isolation guard. Under `single_user = true`, any such backend leaks
+/// its token — and its upstream MCP session — across users the moment a second
+/// identity reaches the gateway.
+fn leaky_single_user_backends(config: &Config) -> Vec<&str> {
+    if !config.auth.single_user {
+        return Vec::new();
+    }
+    config
+        .backends
+        .iter()
+        .filter(|(_, b)| {
+            b.oauth
+                .as_ref()
+                .is_some_and(|o| o.enabled && !o.shared_account)
+        })
+        .map(|(name, _)| name.as_str())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1641,6 +1690,78 @@ mod tests {
             backend_with_strategy(PropagationStrategyKind::Passthrough),
         );
         assert!(super::config_installs_minting_strategy(&minting));
+    }
+
+    // ── GW.3 (MIK-6784): the single_user startup warning must name exactly the
+    // backends that hold a non-shared gateway OAuth token, and stay silent
+    // otherwise. `leaky_single_user_backends` is the pure predicate the warning
+    // branch consumes. ──
+    fn backend_with_oauth(enabled: bool, shared: bool) -> BackendConfig {
+        BackendConfig {
+            oauth: Some(crate::config::OAuthConfig {
+                enabled,
+                scopes: vec![],
+                client_id: None,
+                client_secret: None,
+                callback_host: None,
+                callback_port: None,
+                callback_path: None,
+                token_refresh_buffer_secs: 300,
+                shared_account: shared,
+            }),
+            ..BackendConfig::default()
+        }
+    }
+
+    #[test]
+    fn leaky_backends_empty_when_not_single_user() {
+        let mut config = Config::default();
+        config.auth.single_user = false;
+        config
+            .backends
+            .insert("leaky".to_string(), backend_with_oauth(true, false));
+        assert!(
+            super::leaky_single_user_backends(&config).is_empty(),
+            "no warning target unless single_user is asserted"
+        );
+    }
+
+    #[test]
+    fn leaky_backends_names_only_non_shared_oauth_under_single_user() {
+        let mut config = Config::default();
+        config.auth.single_user = true;
+        config
+            .backends
+            .insert("leaky".to_string(), backend_with_oauth(true, false));
+        config
+            .backends
+            .insert("shared".to_string(), backend_with_oauth(true, true));
+        config
+            .backends
+            .insert("disabled".to_string(), backend_with_oauth(false, false));
+        config
+            .backends
+            .insert("no_oauth".to_string(), BackendConfig::default());
+
+        let leaky = super::leaky_single_user_backends(&config);
+        assert_eq!(
+            leaky,
+            vec!["leaky"],
+            "only the enabled, non-shared gateway-OAuth backend leaks under single_user"
+        );
+    }
+
+    #[test]
+    fn leaky_backends_silent_when_all_oauth_is_shared() {
+        let mut config = Config::default();
+        config.auth.single_user = true;
+        config
+            .backends
+            .insert("shared".to_string(), backend_with_oauth(true, true));
+        assert!(
+            super::leaky_single_user_backends(&config).is_empty(),
+            "shared_account=true opts out of the leak warning"
+        );
     }
 
     #[test]

--- a/src/key_server/oidc.rs
+++ b/src/key_server/oidc.rs
@@ -425,7 +425,10 @@ impl OidcVerifier {
             jsonwebtoken::decode(token, &decoding_key, &validation)?;
         let claims = token_data.claims;
 
-        // Manual audience check
+        // Manual audience check. For an enabled key server, `audiences` is
+        // guaranteed non-empty by `KeyServerConfig::validate` (MIK-6784, GW.4),
+        // so this branch always runs in production; the emptiness guard remains
+        // only for directly-constructed providers in unit tests.
         if !provider.audiences.is_empty() {
             check_audience(&claims.aud, &provider.audiences)?;
         }

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -85,8 +85,20 @@ pub struct HttpTransport {
     message_url: RwLock<Option<String>>,
     /// Custom headers
     headers: HashMap<String, String>,
-    /// Session ID (extracted from `message_url` or headers)
-    session_id: RwLock<Option<String>>,
+    /// Per-caller-identity MCP session ids (MIK-6784).
+    ///
+    /// A single `HttpTransport` is Arc-shared across every gateway user for a
+    /// given backend, so a single `Option<String>` session slot (the prior
+    /// design) let the first caller's `MCP-Session-Id` be stamped onto every
+    /// other caller's outbound request — a stateful upstream could then serve
+    /// one user's session-bound data to another. Partitioning by the caller's
+    /// stable identity binding
+    /// ([`crate::identity_propagation::PropagatedCredential::cache_binding`])
+    /// closes that hole: each identity negotiates and reuses its own upstream
+    /// session. The empty-string key is the shared default bucket used by the
+    /// no-identity static path (plain [`Transport::request`]), so single-tenant
+    /// behavior is byte-for-byte unchanged.
+    sessions: RwLock<HashMap<String, String>>,
     /// Request ID counter
     request_id: AtomicU64,
     /// Connected flag
@@ -168,7 +180,7 @@ impl HttpTransport {
             base_url: url.to_string(),
             message_url: RwLock::new(None),
             headers,
-            session_id: RwLock::new(None),
+            sessions: RwLock::new(HashMap::new()),
             request_id: AtomicU64::new(1),
             connected: AtomicBool::new(false),
             timeout,
@@ -361,7 +373,11 @@ impl HttpTransport {
     /// This is the single source of truth for all outgoing request headers in
     /// this transport. The four behavioral variants are captured in
     /// [`HeaderMode`] so the asymmetries stay explicit.
-    async fn build_mcp_headers(&self, mode: HeaderMode<'_>) -> Result<header::HeaderMap> {
+    async fn build_mcp_headers(
+        &self,
+        mode: HeaderMode<'_>,
+        identity_key: Option<&str>,
+    ) -> Result<header::HeaderMap> {
         let version = self
             .protocol_version
             .read()
@@ -404,9 +420,17 @@ impl HttpTransport {
             }
         }
 
-        // Session ID — send_request logs whether session is present or absent;
-        // notify includes the header silently; SSE skips it entirely.
-        if let Some(ref session_id) = *self.session_id.read() {
+        // Session ID — selected from the caller's identity bucket (MIK-6784)
+        // so one caller's upstream session is never stamped onto another's
+        // request. `None` selects the shared default bucket (`""`). send_request
+        // logs whether session is present or absent; notify includes the header
+        // silently; SSE skips it entirely.
+        let session = self
+            .sessions
+            .read()
+            .get(Self::bucket_key(identity_key))
+            .cloned();
+        if let Some(session_id) = session {
             match mode {
                 HeaderMode::Request { method } => {
                     debug!(session_id = %session_id, method = %method, "Sending request with session ID");
@@ -485,7 +509,7 @@ impl HttpTransport {
     async fn establish_sse_connection(&self) -> Result<String> {
         use futures::StreamExt;
 
-        let headers = self.build_mcp_headers(HeaderMode::Sse).await?;
+        let headers = self.build_mcp_headers(HeaderMode::Sse, None).await?;
 
         debug!(url = %self.base_url, "Establishing SSE connection");
 
@@ -532,13 +556,18 @@ impl HttpTransport {
                     if event_type.as_deref() == Some("endpoint") {
                         debug!(endpoint = %data, "Received message endpoint from SSE");
 
-                        // Extract session_id from the endpoint URL if present
+                        // Extract session_id from the endpoint URL if present.
+                        // The SSE handshake is connection-level (not per-caller),
+                        // so an endpoint-embedded session lands in the shared
+                        // default bucket (MIK-6784).
                         if let Ok(url) = Url::parse(data)
                             .or_else(|_| Url::parse(&format!("http://localhost{data}")))
                         {
                             for (key, value) in url.query_pairs() {
                                 if key == "session_id" {
-                                    *self.session_id.write() = Some(value.to_string());
+                                    self.sessions
+                                        .write()
+                                        .insert(String::new(), value.to_string());
                                     debug!(session_id = %value, "Extracted session ID");
                                 }
                             }
@@ -585,24 +614,34 @@ impl HttpTransport {
 
     /// Send a raw request to the message endpoint
     async fn send_request(&self, request: &JsonRpcRequest) -> Result<JsonRpcResponse> {
-        self.send_request_with_headers(request, &[]).await
+        self.send_request_with_headers(request, &[], None).await
     }
 
     /// Send a raw request, merging `extra_headers` into the outbound header set
     /// after the standard headers are built. Used for per-request identity
     /// credentials (MIK-6704): the credential is applied here, on the value
     /// passed down the call stack, never on shared `&self` state.
+    ///
+    /// `identity_key` selects the caller's `MCP-Session-Id` bucket (MIK-6784):
+    /// the request is stamped with — and the response's session id is stored
+    /// under — that caller's key, so a stateful upstream cannot serve one
+    /// user's session-bound data to another. `None` uses the shared default
+    /// bucket, preserving single-tenant behavior.
     async fn send_request_with_headers(
         &self,
         request: &JsonRpcRequest,
         extra_headers: &[(String, String)],
+        identity_key: Option<&str>,
     ) -> Result<JsonRpcResponse> {
         let message_url = self.get_message_url();
 
         let mut headers = self
-            .build_mcp_headers(HeaderMode::Request {
-                method: &request.method,
-            })
+            .build_mcp_headers(
+                HeaderMode::Request {
+                    method: &request.method,
+                },
+                identity_key,
+            )
             .await?;
         // Per-request identity credential headers (e.g. Authorization: Bearer
         // <assertion>) override any static header of the same name for this call.
@@ -624,23 +663,27 @@ impl HttpTransport {
             .await
             .map_err(|e| Error::Transport(format!("Request failed: {e}")))?;
 
-        // Extract session ID from response headers if not already set
-        if self.session_id.read().is_none() {
-            if let Some(session_id) = response.headers().get("mcp-session-id") {
-                if let Ok(id) = session_id.to_str() {
-                    info!(session_id = %id, url = %message_url, "Stored session ID from response");
-                    *self.session_id.write() = Some(id.to_string());
-                }
-            } else {
-                // Debug: log all headers to find session ID
-                debug!(url = %message_url, "No session ID in response. Headers: {:?}",
-                    response.headers().iter()
-                        .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("?")))
-                        .collect::<Vec<_>>()
-                );
+        // Extract session ID from response headers if this caller's bucket is
+        // empty (MIK-6784: store under the caller's identity key, never a shared
+        // slot). The first request for a new identity has no session; the
+        // upstream mints one and we bind it to that identity for reuse.
+        let bucket = Self::bucket_key(identity_key);
+        if self.sessions.read().contains_key(bucket) {
+            debug!("Using existing session ID for caller bucket");
+        } else if let Some(session_id) = response.headers().get("mcp-session-id") {
+            if let Ok(id) = session_id.to_str() {
+                info!(session_id = %id, url = %message_url, "Stored session ID from response");
+                self.sessions
+                    .write()
+                    .insert(bucket.to_string(), id.to_string());
             }
         } else {
-            debug!(session_id = %self.session_id.read().as_ref().unwrap(), "Using existing session ID");
+            // Debug: log all headers to find session ID
+            debug!(url = %message_url, "No session ID in response. Headers: {:?}",
+                response.headers().iter()
+                    .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("?")))
+                    .collect::<Vec<_>>()
+            );
         }
 
         let status = response.status();
@@ -686,12 +729,21 @@ impl HttpTransport {
     fn next_id(&self) -> RequestId {
         RequestId::Number(self.request_id.fetch_add(1, Ordering::Relaxed) as i64)
     }
+
+    /// Map an optional caller identity key to its session-bucket key (MIK-6784).
+    ///
+    /// `None` (the no-identity static path) maps to the shared default bucket
+    /// (`""`), so single-tenant behavior is byte-for-byte unchanged; a present
+    /// key selects that caller's private bucket.
+    fn bucket_key(identity_key: Option<&str>) -> &str {
+        identity_key.unwrap_or("")
+    }
 }
 
 #[async_trait]
 impl Transport for HttpTransport {
     async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse> {
-        self.request_with_headers(method, params, &[]).await
+        self.request_with_headers(method, params, &[], None).await
     }
 
     async fn request_with_headers(
@@ -699,6 +751,7 @@ impl Transport for HttpTransport {
         method: &str,
         params: Option<Value>,
         extra_headers: &[(String, String)],
+        identity_key: Option<&str>,
     ) -> Result<JsonRpcResponse> {
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -708,7 +761,7 @@ impl Transport for HttpTransport {
         };
 
         let result = self
-            .send_request_with_headers(&request, extra_headers)
+            .send_request_with_headers(&request, extra_headers, identity_key)
             .await;
 
         // MIK-5982 / MIK-6040: when the backend's session expires (daemon restart,
@@ -726,9 +779,12 @@ impl Transport for HttpTransport {
         //      found"), classified by `is_session_expired_response` (MIK-6040, #247).
         //
         // On either signature: drop the session, re-run the initialize handshake,
-        // and retry the original request exactly once. `initialize()` calls
-        // `send_request` directly (not `request`), so this cannot recurse.
-        let had_session = self.session_id.read().is_some();
+        // and retry the original request exactly once. Only this caller's session
+        // bucket is dropped (MIK-6784) — one identity's expiry must not evict
+        // another's live session. `initialize()` calls `send_request` directly
+        // (not `request`), so this cannot recurse.
+        let bucket = Self::bucket_key(identity_key);
+        let had_session = self.sessions.read().contains_key(bucket);
         let session_expired = match &result {
             Err(err) => is_session_expired_error(err),
             Ok(resp) => is_session_expired_response(resp),
@@ -739,10 +795,10 @@ impl Transport for HttpTransport {
                 method = %method,
                 "Backend session expired; re-initializing and retrying once"
             );
-            *self.session_id.write() = None;
+            self.sessions.write().remove(bucket);
             self.initialize().await?;
             return self
-                .send_request_with_headers(&request, extra_headers)
+                .send_request_with_headers(&request, extra_headers, identity_key)
                 .await;
         }
 
@@ -766,7 +822,7 @@ impl Transport for HttpTransport {
             params,
         };
 
-        let headers = self.build_mcp_headers(HeaderMode::Notify).await?;
+        let headers = self.build_mcp_headers(HeaderMode::Notify, None).await?;
 
         let response = self
             .client
@@ -808,12 +864,22 @@ impl Transport for HttpTransport {
             handle.abort();
         }
 
-        // Send session termination if we have a session ID
-        let session_id = self.session_id.read().clone();
+        // Send session termination for every per-identity session (MIK-6784).
+        // Each caller negotiated its own upstream session, so closing the
+        // transport must terminate all of them, not just one shared slot.
+        let sessions: Vec<(String, String)> = self
+            .sessions
+            .read()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let message_url = self.get_message_url();
 
-        if let Some(ref id) = session_id {
-            let request = match self.build_mcp_headers(HeaderMode::Close).await {
+        for (bucket, id) in sessions {
+            let request = match self
+                .build_mcp_headers(HeaderMode::Close, Some(&bucket))
+                .await
+            {
                 Ok(headers) => self.client.delete(&message_url).headers(headers),
                 Err(error) => {
                     warn!(
@@ -823,7 +889,7 @@ impl Transport for HttpTransport {
                     );
                     self.client
                         .delete(&message_url)
-                        .header("MCP-Session-Id", id)
+                        .header("MCP-Session-Id", &id)
                 }
             };
 

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -15,6 +15,17 @@ fn make_transport_with_headers(url: &str, hdrs: HashMap<String, String>) -> Arc<
     HttpTransport::new(url, hdrs, Duration::from_secs(30), true).unwrap()
 }
 
+/// Set the shared default-bucket (no-identity) session id, mirroring the
+/// pre-MIK-6784 single-session behavior these tests were written against.
+fn set_default_session(t: &HttpTransport, id: &str) {
+    t.sessions.write().insert(String::new(), id.to_string());
+}
+
+/// Read the shared default-bucket session id, if any.
+fn default_session(t: &HttpTransport) -> Option<String> {
+    t.sessions.read().get("").cloned()
+}
+
 // =========================================================================
 // Construction
 // =========================================================================
@@ -26,7 +37,7 @@ fn new_creates_transport_with_defaults() {
     assert!(t.streamable_http);
     assert!(!t.is_connected());
     assert!(t.message_url.read().is_none());
-    assert!(t.session_id.read().is_none());
+    assert!(default_session(&t).is_none());
     assert!(t.oauth_client.is_none());
 }
 
@@ -207,9 +218,9 @@ async fn build_headers_sse_mode_baseline() {
     custom.insert("X-Auth-Token".to_string(), "secret".to_string());
     let t = make_transport_with_headers("http://localhost", custom);
     // Pretend a session was established — SSE must NOT forward it.
-    *t.session_id.write() = Some("should-not-appear".to_string());
+    set_default_session(&t, "should-not-appear");
 
-    let map = t.build_mcp_headers(HeaderMode::Sse).await.unwrap();
+    let map = t.build_mcp_headers(HeaderMode::Sse, None).await.unwrap();
 
     assert!(
         !map.contains_key(header::CONTENT_TYPE),
@@ -247,12 +258,15 @@ async fn build_headers_send_request_with_session_and_trace() {
     let mut custom = HashMap::new();
     custom.insert("X-Custom".to_string(), "val".to_string());
     let t = make_transport_with_headers("http://localhost", custom);
-    *t.session_id.write() = Some("sess-abc".to_string());
+    set_default_session(&t, "sess-abc");
 
     let map = trace::with_trace_id("gw-trace-123".to_string(), async {
-        t.build_mcp_headers(HeaderMode::Request {
-            method: "tools/list",
-        })
+        t.build_mcp_headers(
+            HeaderMode::Request {
+                method: "tools/list",
+            },
+            None,
+        )
         .await
         .unwrap()
     })
@@ -280,9 +294,12 @@ async fn build_headers_send_request_no_session() {
     let t = make_transport("http://localhost");
 
     let map = t
-        .build_mcp_headers(HeaderMode::Request {
-            method: "tools/list",
-        })
+        .build_mcp_headers(
+            HeaderMode::Request {
+                method: "tools/list",
+            },
+            None,
+        )
         .await
         .unwrap();
 
@@ -305,10 +322,10 @@ async fn build_headers_notify_includes_custom_but_excludes_trace() {
     let mut custom = HashMap::new();
     custom.insert("X-Notify-Auth".to_string(), "notify-token".to_string());
     let t = make_transport_with_headers("http://localhost", custom);
-    *t.session_id.write() = Some("notify-sess".to_string());
+    set_default_session(&t, "notify-sess");
 
     let map = trace::with_trace_id("gw-trace-xyz".to_string(), async {
-        t.build_mcp_headers(HeaderMode::Notify).await.unwrap()
+        t.build_mcp_headers(HeaderMode::Notify, None).await.unwrap()
     })
     .await;
 
@@ -333,7 +350,7 @@ async fn build_headers_notify_includes_custom_but_excludes_trace() {
 async fn build_headers_notify_no_session_when_unset() {
     let t = make_transport("http://localhost");
 
-    let map = t.build_mcp_headers(HeaderMode::Notify).await.unwrap();
+    let map = t.build_mcp_headers(HeaderMode::Notify, None).await.unwrap();
 
     assert!(!map.contains_key("mcp-session-id"));
 }
@@ -347,10 +364,10 @@ async fn build_headers_close_includes_session_and_custom_headers() {
     let mut custom = HashMap::new();
     custom.insert("X-Close-Auth".to_string(), "close-token".to_string());
     let t = make_transport_with_headers("http://localhost", custom);
-    *t.session_id.write() = Some("close-sess".to_string());
+    set_default_session(&t, "close-sess");
 
     let map = trace::with_trace_id("gw-close-trace".to_string(), async {
-        t.build_mcp_headers(HeaderMode::Close).await.unwrap()
+        t.build_mcp_headers(HeaderMode::Close, None).await.unwrap()
     })
     .await;
 
@@ -404,7 +421,7 @@ async fn close_sends_shared_close_headers() {
     custom.insert("X-Close-Auth".to_string(), "close-token".to_string());
     let transport = make_transport_with_headers(&format!("http://{addr}/mcp"), custom);
     *transport.message_url.write() = Some(format!("http://{addr}/messages"));
-    *transport.session_id.write() = Some("close-session".to_string());
+    set_default_session(&transport, "close-session");
 
     transport.close().await.unwrap();
 
@@ -442,7 +459,7 @@ async fn build_headers_uses_overridden_protocol_version() {
     )
     .unwrap();
 
-    let map = t.build_mcp_headers(HeaderMode::Sse).await.unwrap();
+    let map = t.build_mcp_headers(HeaderMode::Sse, None).await.unwrap();
 
     assert_eq!(map["mcp-protocol-version"], "2024-11-05");
 }
@@ -456,7 +473,7 @@ async fn build_headers_trace_flag_gates_trace_header() {
 
     // Notify mode must suppress trace propagation even when ambient trace exists.
     let map_no_trace = trace::with_trace_id("gw-abc".to_string(), async {
-        t.build_mcp_headers(HeaderMode::Notify).await.unwrap()
+        t.build_mcp_headers(HeaderMode::Notify, None).await.unwrap()
     })
     .await;
 
@@ -467,7 +484,7 @@ async fn build_headers_trace_flag_gates_trace_header() {
 
     // Request mode must include trace propagation when ambient trace exists.
     let map_with_trace = trace::with_trace_id("gw-abc".to_string(), async {
-        t.build_mcp_headers(HeaderMode::Request { method: "m" })
+        t.build_mcp_headers(HeaderMode::Request { method: "m" }, None)
             .await
             .unwrap()
     })
@@ -576,7 +593,7 @@ async fn request_reinitializes_session_and_retries_on_session_not_found() {
 
     let transport = make_transport(&format!("http://{addr}/mcp"));
     *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
-    *transport.session_id.write() = Some("stale-session-from-before-restart".to_string());
+    set_default_session(&transport, "stale-session-from-before-restart");
 
     // WHEN: a request rides the dead session
     let response = transport.request("tools/list", None).await.unwrap();
@@ -584,7 +601,7 @@ async fn request_reinitializes_session_and_retries_on_session_not_found() {
     // THEN: the transport re-initialized and the retry succeeded
     assert!(response.error.is_none(), "retried request must succeed");
     assert_eq!(
-        transport.session_id.read().as_deref(),
+        default_session(&transport).as_deref(),
         Some(FRESH_SESSION),
         "fresh session ID must replace the stale one"
     );
@@ -682,7 +699,7 @@ async fn request_reinitializes_session_and_retries_on_http_404() {
 
     let transport = make_transport(&format!("http://{addr}/mcp"));
     *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
-    *transport.session_id.write() = Some("stale-session-pre-refresh".to_string());
+    set_default_session(&transport, "stale-session-pre-refresh");
 
     // WHEN: a request rides the session the remote just invalidated
     let response = transport.request("tools/list", None).await.unwrap();
@@ -693,7 +710,7 @@ async fn request_reinitializes_session_and_retries_on_http_404() {
         "retried request must succeed after the 404 triggers a re-initialize"
     );
     assert_eq!(
-        transport.session_id.read().as_deref(),
+        default_session(&transport).as_deref(),
         Some(FRESH_SESSION),
         "fresh session ID must replace the one invalidated on token refresh"
     );
@@ -794,7 +811,7 @@ async fn request_reinitializes_on_jsonrpc_session_error_response() {
 
     let transport = make_transport(&format!("http://{addr}/mcp"));
     *transport.message_url.write() = Some(format!("http://{addr}/mcp"));
-    *transport.session_id.write() = Some("stale-session-before-refresh".to_string());
+    set_default_session(&transport, "stale-session-before-refresh");
 
     // WHEN: a request rides the dead session and the remote answers 200 + error
     let response = transport.request("tools/list", None).await.unwrap();
@@ -805,7 +822,7 @@ async fn request_reinitializes_on_jsonrpc_session_error_response() {
         "retried request after jsonrpc session error must succeed"
     );
     assert_eq!(
-        transport.session_id.read().as_deref(),
+        default_session(&transport).as_deref(),
         Some(FRESH_SESSION),
         "fresh session ID must replace the stale one"
     );
@@ -954,7 +971,7 @@ async fn request_with_headers_injects_and_overrides_on_the_wire() {
         ("X-Idp-Audience".to_string(), "https://mem".to_string()),
     ];
     let _ = transport
-        .request_with_headers("tools/call", None, &extra)
+        .request_with_headers("tools/call", None, &extra, None)
         .await;
 
     let headers = tokio::time::timeout(Duration::from_secs(1), rx)
@@ -1128,4 +1145,175 @@ async fn drop_aborts_refresh_task_without_close() {
             // Sender was dropped by task abort — correct RAII behavior.
         }
     }
+}
+
+// =========================================================================
+// MIK-6784 (GW.1): per-identity MCP-Session-Id partitioning
+// =========================================================================
+
+/// GW.1 unit: `build_mcp_headers` selects the session bound to the caller's
+/// identity bucket, so two identities never share a session and a caller with
+/// no negotiated session gets no session header at all.
+#[tokio::test]
+async fn build_headers_selects_session_per_identity_bucket() {
+    let t = make_transport("http://localhost");
+    t.sessions
+        .write()
+        .insert("alice".to_string(), "sess-alice".to_string());
+    t.sessions
+        .write()
+        .insert("bob".to_string(), "sess-bob".to_string());
+    t.sessions
+        .write()
+        .insert(String::new(), "sess-default".to_string());
+
+    let alice = t
+        .build_mcp_headers(HeaderMode::Request { method: "m" }, Some("alice"))
+        .await
+        .unwrap();
+    let bob = t
+        .build_mcp_headers(HeaderMode::Request { method: "m" }, Some("bob"))
+        .await
+        .unwrap();
+    let anon = t
+        .build_mcp_headers(HeaderMode::Request { method: "m" }, None)
+        .await
+        .unwrap();
+    let absent = t
+        .build_mcp_headers(HeaderMode::Request { method: "m" }, Some("carol"))
+        .await
+        .unwrap();
+
+    assert_eq!(alice["mcp-session-id"], "sess-alice");
+    assert_eq!(bob["mcp-session-id"], "sess-bob");
+    assert_ne!(
+        alice["mcp-session-id"], bob["mcp-session-id"],
+        "two identities must never share a session id"
+    );
+    assert_eq!(
+        anon["mcp-session-id"], "sess-default",
+        "no-identity path uses the shared default bucket"
+    );
+    assert!(
+        !absent.contains_key("mcp-session-id"),
+        "an identity with no negotiated session sends no session header"
+    );
+}
+
+/// Stateful mock backend for the session-partition test: a caller with no
+/// session is minted a fresh unique one (and told which); a caller presenting a
+/// session has it echoed back verbatim. Extracted from the test body to keep
+/// the test under the line cap.
+async fn partition_mock_handler(
+    axum::extract::State(counter): axum::extract::State<Arc<std::sync::atomic::AtomicU32>>,
+    headers: axum::http::HeaderMap,
+    axum::Json(body): axum::Json<Value>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use serde_json::json;
+
+    if body.get("id").is_none() {
+        return StatusCode::ACCEPTED.into_response();
+    }
+    let incoming = headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if incoming.is_empty() {
+        let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let minted = format!("sess-{n}");
+        let mut resp_headers = axum::http::HeaderMap::new();
+        resp_headers.insert("mcp-session-id", minted.parse().unwrap());
+        (
+            StatusCode::OK,
+            resp_headers,
+            axum::Json(json!({"jsonrpc": "2.0", "id": body["id"], "result": {"session": minted}})),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::OK,
+            axum::Json(
+                json!({"jsonrpc": "2.0", "id": body["id"], "result": {"session": incoming}}),
+            ),
+        )
+            .into_response()
+    }
+}
+
+/// GW.1 integration: against a stateful backend that mints a distinct session
+/// per handshake, each caller identity negotiates and reuses its OWN session;
+/// one identity's session is never stamped onto another's request. Regression
+/// test for the Arc-shared single-session slot (MIK-6784).
+#[tokio::test]
+async fn stateful_backend_partitions_sessions_across_identities() {
+    use axum::{Router, routing::post};
+
+    let counter = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/mcp", post(partition_mock_handler))
+        .with_state(Arc::clone(&counter));
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let transport = make_transport(&format!("http://{addr}/mcp"));
+
+    let session_of = |resp: &JsonRpcResponse| -> String {
+        resp.result.as_ref().unwrap()["session"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+
+    // Each identity's first request negotiates its own session.
+    let a1 = transport
+        .request_with_headers("tools/call", None, &[], Some("alice"))
+        .await
+        .unwrap();
+    let b1 = transport
+        .request_with_headers("tools/call", None, &[], Some("bob"))
+        .await
+        .unwrap();
+    let alice_session = session_of(&a1);
+    let bob_session = session_of(&b1);
+    assert_ne!(
+        alice_session, bob_session,
+        "distinct identities must negotiate distinct sessions"
+    );
+
+    // Second round: each identity reuses ITS OWN session — never the other's.
+    let a2 = transport
+        .request_with_headers("tools/call", None, &[], Some("alice"))
+        .await
+        .unwrap();
+    let b2 = transport
+        .request_with_headers("tools/call", None, &[], Some("bob"))
+        .await
+        .unwrap();
+    assert_eq!(
+        session_of(&a2),
+        alice_session,
+        "alice must reuse alice's session, not bob's"
+    );
+    assert_eq!(
+        session_of(&b2),
+        bob_session,
+        "bob must reuse bob's session, not alice's"
+    );
+
+    // The transport's own bucket map reflects the partition.
+    assert_eq!(
+        transport.sessions.read().get("alice").cloned(),
+        Some(alice_session)
+    );
+    assert_eq!(
+        transport.sessions.read().get("bob").cloned(),
+        Some(bob_session)
+    );
+
+    server.abort();
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -20,19 +20,26 @@ pub trait Transport: Send + Sync {
     async fn request(&self, method: &str, params: Option<Value>) -> Result<JsonRpcResponse>;
 
     /// Send a request with additional per-request outbound headers (e.g. a
-    /// propagated end-user identity credential, MIK-6704).
+    /// propagated end-user identity credential, MIK-6704) plus the caller's
+    /// identity key that partitions upstream session state (MIK-6784).
     ///
     /// The headers are passed by value down the call stack — never stashed on
     /// the shared transport — so concurrent requests from different users cannot
-    /// cross-contaminate (tenant isolation, IDP.3). Transports that carry no
-    /// HTTP headers (stdio, websocket) ignore `extra_headers` and behave exactly
-    /// like [`Transport::request`]; only HTTP-header-bearing transports apply
-    /// them. Default impl ignores the headers.
+    /// cross-contaminate (tenant isolation, IDP.3). `identity_key` is the stable
+    /// per-caller binding (see [`crate::identity_propagation::PropagatedCredential`]
+    /// `::cache_binding`); an HTTP-header-bearing transport uses it to select and
+    /// store an `MCP-Session-Id` bucket unique to that caller, so a stateful
+    /// upstream cannot serve one user's session-bound data to another (MIK-6784).
+    /// `None` selects the shared default bucket, preserving single-tenant
+    /// behavior byte-for-byte. Transports that carry no HTTP headers (stdio,
+    /// websocket) ignore both `extra_headers` and `identity_key` and behave
+    /// exactly like [`Transport::request`]. Default impl ignores them.
     async fn request_with_headers(
         &self,
         method: &str,
         params: Option<Value>,
         _extra_headers: &[(String, String)],
+        _identity_key: Option<&str>,
     ) -> Result<JsonRpcResponse> {
         self.request(method, params).await
     }


### PR DESCRIPTION
# Fix cross-user upstream session sharing (MIK-6784)

## Summary

Patch fix for a cross-user isolation gap found in the post-3.1.0 identity-propagation audit. A single `HttpTransport` instance is shared across all gateway users for a given backend. The upstream `MCP-Session-Id` was held in one shared slot, written from the first caller's response and then attached to every other caller's outbound request. Against a stateful upstream that binds data to the session id rather than the bearer token, one user's session-bound data could be served to another.

## Fix

Partition upstream session state by the caller's stable identity binding (the existing `cache_binding`, which distinguishes user and audience). The binding is threaded end-to-end as `identity_key` and never stored on shared transport state, preserving the per-request tenant isolation established in 3.1.0.

- Transport session storage moves from one `Option<String>` to a per-identity map. Each identity negotiates and reuses its own upstream session; the empty-string key is the shared default bucket used by the no-identity static path, so single-tenant behavior is unchanged.
- Session expiry evicts only the affected caller bucket; transport close terminates every per-identity session.

## Also folded in (audit footguns)

- Startup warning when single-user mode coexists with a backend that has OAuth enabled and is not a shared account.
- Config-load rejection of an enabled OIDC provider with an empty audience list, mirroring the non-empty-audience enforcement already in the identity-propagation validator.

## Acceptance criteria

- MIK.GW.1 upstream session id partitioned per caller identity; two identities never share one. Covered by a per-identity header-selection unit test and an axum stateful-backend integration test.
- MIK.GW.2 stateful plus multi-user plus identity-propagation supported safely via per-identity sessions; no-identity path uses the default bucket.
- MIK.GW.3 startup warning predicate covered by three cases.
- MIK.GW.4 empty and whitespace-only audience rejection covered by five validation cases.

## Evidence

- cargo fmt check clean.
- cargo clippy all-targets -D warnings clean.
- cargo test: lib 3294 passed, 0 failed; all suites and doctests green.
- unsafe still forbidden; no new unwrap on fallible external input.

## Known follow-up

Passthrough mode still uses the shared default session bucket. That is the trusted-internal path the audit scoped out of this finding; tracked separately.

## Source

MIK-6784, cross-user isolation audit 2026-07-05.
