### PR TITLE
chore(release): v3.1.1 (MIK-6784 session partitioning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-07-06
+
+### Security
+
+- **Upstream MCP session id is now partitioned per caller identity (MIK-6784).**
+  One `HttpTransport` instance is shared across all gateway users for a given
+  backend, and the upstream `MCP-Session-Id` was held in a single shared slot.
+  It was written from the first caller's response and then attached to every
+  other caller's outbound request. Against a stateful upstream that binds data
+  to the session id rather than the bearer token, one user's session-bound data
+  could be served to another. Session state is now keyed by the caller's stable
+  identity binding and never stored on shared transport state; the empty-key
+  default bucket keeps single-tenant behavior unchanged. Session expiry evicts
+  only the affected caller, and transport close terminates every per-identity
+  session. Also folded in: a startup warning when single-user mode coexists with
+  an OAuth-enabled backend, and config-load rejection of an enabled OIDC
+  provider that has an empty audience list. Passthrough mode still uses the
+  shared default bucket (the trusted-internal path the audit scoped out) and is
+  tracked as a follow-up.
+
 ### Fixed
 
 - **stdio serve boots without a mounted config (Glama build).** An explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
## Release v3.1.1

Patch release. Cuts the MIK-6784 cross-user session-isolation fix (merged in `e1620126`) and the previously unreleased stdio-config fix, and bumps the version.

### Changes
- `Cargo.toml` / `Cargo.lock`: `3.1.0` -> `3.1.1`.
- `CHANGELOG.md`: the `Unreleased` block is promoted to `[3.1.1]` and a Security entry documents the per-identity upstream session partitioning.

### Included fixes
- **Per-identity upstream session partitioning (MIK-6784).** The upstream `MCP-Session-Id` was held in a single shared slot on a transport instance shared across all callers, so against a stateful upstream that keys data on the session id, one caller's session-bound data could reach another. Session state is now keyed by the caller's stable identity binding and is never stored on shared transport state. The empty-key default bucket keeps single-tenant behavior unchanged. Already on `main` via #327; this release ships it.
- **stdio serve boots without a mounted config (Glama build).** A missing explicit `--config` now downgrades to the normal no-config resolution on the stdio path, with a stderr warning. The HTTP path stays fail-loud.

### Follow-up
Passthrough propagation still uses the shared default session bucket, the trusted-internal path scoped out of MIK-6784. Tracked in MIK-6785.

### Verification
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --lib`: 3294 passed, 0 failed.
- No code change in this PR beyond the version bump and changelog; the fix itself already passed full CI on #327.
