### PR TITLE
fix(transport): partition upstream session for passthrough callers (MIK-6785)

### DIFF
--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -9,6 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use tracing::{debug, error, warn};
 
 use super::AppState;
@@ -26,6 +27,11 @@ use crate::trust::project_tool_descriptors_trust_cards;
 
 type BackendRejection = (StatusCode, Json<Value>);
 type BackendSecurityResult = Option<Result<Option<Value>, BackendRejection>>;
+
+/// Forwarded passthrough headers paired with the caller's stable upstream-session
+/// bucket key (MIK-6785): `Some(sha256_hex(credential))` when a credential is
+/// forwarded, `None` on the no-credential path. See [`resolve_passthrough_headers`].
+type PassthroughResolution = (Vec<(String, String)>, Option<String>);
 
 #[derive(Clone, Copy)]
 struct BackendAuthContext<'a> {
@@ -171,6 +177,29 @@ fn normalize_tools_list_response(backend_name: &str, response: &mut JsonRpcRespo
     }
 }
 
+/// Stable, collision-safe upstream-session bucket key for a passthrough caller
+/// (MIK-6785). On the passthrough route the forwarded backend credential is the
+/// only value that distinguishes one caller from another (there is usually no
+/// gateway-verified identity), so the caller's `MCP-Session-Id` bucket is keyed
+/// by the SHA-256 hex digest of that credential.
+///
+/// Privacy is load-bearing: the raw credential is hashed HERE, at the single
+/// point it is read from the inbound header, and the digest — never the token —
+/// becomes the in-memory `HttpTransport::sessions` map key. SHA-256 is one-way,
+/// so a leaked bucket key cannot recover the credential, and the raw token is
+/// never logged or stored anywhere else.
+///
+/// Correctness: distinct credentials produce distinct 64-char hex digests, hence
+/// distinct session buckets (isolation); the same credential always produces the
+/// same digest, hence a reused bucket (session continuity). A 64-char lowercase
+/// hex digest can never collide with the minting path's `idp:`-prefixed bindings
+/// nor with the shared default (`""`) bucket.
+fn passthrough_identity_key(credential: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(credential.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
 /// Resolve passthrough headers for the direct backend route (ADR-008 rung 2,
 /// MIK-6746). Reads the caller's own backend credential from a fixed,
 /// gateway-specific inbound header and forwards it to the backend under
@@ -181,6 +210,15 @@ fn normalize_tools_list_response(backend_name: &str, response: &mut JsonRpcRespo
 /// the caller); a non-required backend with none returns an empty vec (static
 /// path, after which the INV-2 guard decides whether a shared token may serve).
 ///
+/// Returns `(headers, identity_key)`. `identity_key` (MIK-6785) is the caller's
+/// stable upstream-session bucket key — `Some(sha256_hex(credential))` when a
+/// credential is forwarded, so each distinct passthrough caller gets its own
+/// `MCP-Session-Id` bucket and a stateful upstream cannot serve one caller's
+/// session-bound data to another; `None` on the no-credential path (shared
+/// default bucket, behavior unchanged). The credential is hashed at this single
+/// read point (see [`passthrough_identity_key`]) so the raw token is never
+/// re-extracted from the header vec downstream.
+///
 /// Also fails closed (MIK-6710) BEFORE reading the inbound header when
 /// `transport_carries_headers` is `false` for a `required` backend — a stdio
 /// or websocket backend would otherwise accept the caller's credential here
@@ -190,7 +228,7 @@ fn resolve_passthrough_headers(
     cfg: &crate::identity_propagation::IdentityPropagationConfig,
     inbound: &axum::http::HeaderMap,
     transport_carries_headers: bool,
-) -> Result<Vec<(String, String)>, String> {
+) -> Result<PassthroughResolution, String> {
     // The inbound header a capable client attaches its backend credential in
     // (advertised via RFC 9728 protected-resource metadata, MIK-6750). Distinct
     // from `Authorization` so the gateway-auth token is never forwarded.
@@ -207,7 +245,10 @@ fn resolve_passthrough_headers(
                     .to_string(),
             )
         } else {
-            Ok(Vec::new())
+            // No credential on a non-required backend: static path, and no
+            // per-caller session bucket — the shared default bucket is used,
+            // exactly as before MIK-6785.
+            Ok((Vec::new(), None))
         }
     };
     match inbound
@@ -216,7 +257,13 @@ fn resolve_passthrough_headers(
         .map(str::trim)
         .filter(|v| !v.is_empty())
     {
-        Some(v) => Ok(vec![("Authorization".to_string(), v.to_string())]),
+        Some(v) => Ok((
+            vec![("Authorization".to_string(), v.to_string())],
+            // Hash the credential at its single read point (MIK-6785): the raw
+            // token stays in the forwarded header vec only; the digest is the
+            // caller's per-identity upstream session bucket key.
+            Some(passthrough_identity_key(v)),
+        )),
         None => missing(),
     }
 }
@@ -434,11 +481,22 @@ pub(super) async fn backend_handler(
             c.strategy == crate::identity_propagation::PropagationStrategyKind::Passthrough
         });
         let resolved = if let Some(cfg) = passthrough_cfg {
-            resolve_passthrough_headers(
+            match resolve_passthrough_headers(
                 &cfg,
                 &inbound_headers,
                 backend.transport_carries_identity_headers(),
-            )
+            ) {
+                Ok((headers, binding)) => {
+                    // Bind the upstream session bucket to this passthrough caller
+                    // (MIK-6785): keyed by the SHA-256 of the forwarded
+                    // credential, so distinct callers never share a stateful
+                    // upstream's session-bound data. `None` on the no-credential
+                    // path keeps the shared default bucket (behavior unchanged).
+                    identity_key = binding;
+                    Ok(headers)
+                }
+                Err(e) => Err(e),
+            }
         } else {
             match state
                 .meta_mcp

--- a/src/gateway/router/backend_handlers/tests.rs
+++ b/src/gateway/router/backend_handlers/tests.rs
@@ -35,11 +35,12 @@ mod passthrough {
     // is pure over its inputs, so it cannot persist a token (INV-4).
     #[test]
     fn present_credential_is_forwarded_as_authorization() {
-        let out = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer caller-tok"), true)
-            .expect("present credential resolves");
+        let (headers, _key) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-caller-tok"), true)
+                .expect("present credential resolves");
         assert_eq!(
-            out,
-            vec![("Authorization".to_string(), "Bearer caller-tok".to_string())]
+            headers,
+            vec![("Authorization".to_string(), "cred-caller-tok".to_string())]
         );
     }
 
@@ -47,12 +48,67 @@ mod passthrough {
     // own header value; there is no shared/mutable state between calls.
     #[test]
     fn concurrent_callers_are_isolated() {
-        let a =
-            resolve_passthrough_headers(&cfg(true), &headers_with("Bearer alice"), true).unwrap();
-        let b = resolve_passthrough_headers(&cfg(true), &headers_with("Bearer bob"), true).unwrap();
-        assert_eq!(a[0].1, "Bearer alice");
-        assert_eq!(b[0].1, "Bearer bob");
+        let (a, _) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-alice"), true).unwrap();
+        let (b, _) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-bob"), true).unwrap();
+        assert_eq!(a[0].1, "cred-alice");
+        assert_eq!(b[0].1, "cred-bob");
         assert_ne!(a[0].1, b[0].1);
+    }
+
+    // MIK.PT.1 — two DISTINCT passthrough credentials against one stateful
+    // backend resolve to DISTINCT upstream session buckets. `identity_key` is
+    // the bucket selector fed to `HttpTransport::bucket_key` (which is just
+    // `identity_key.unwrap_or("")`), so distinct `Some` keys ==> distinct
+    // `MCP-Session-Id` buckets ==> no cross-caller session-bound data leak
+    // (MIK-6785). Verified at the cheapest network-free seam.
+    #[test]
+    fn distinct_credentials_get_distinct_session_buckets() {
+        let (_, key_a) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-alice"), true).unwrap();
+        let (_, key_b) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-bob"), true).unwrap();
+        assert!(key_a.is_some() && key_b.is_some(), "both must key a bucket");
+        assert_ne!(
+            key_a, key_b,
+            "distinct credentials must select distinct upstream session buckets"
+        );
+    }
+
+    // MIK.PT.2 — the SAME passthrough credential reuses the SAME bucket, so a
+    // caller keeps its own negotiated upstream session across requests.
+    #[test]
+    fn same_credential_reuses_same_session_bucket() {
+        let (_, first) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-alice"), true).unwrap();
+        let (_, second) =
+            resolve_passthrough_headers(&cfg(true), &headers_with("cred-alice"), true).unwrap();
+        assert!(first.is_some(), "credential must key a bucket");
+        assert_eq!(
+            first, second,
+            "the same credential must select the same upstream session bucket"
+        );
+    }
+
+    // MIK-6785 privacy invariant — the bucket key is the SHA-256 hex digest of
+    // the credential, NOT the raw credential. The raw token must never appear
+    // in the key that is stored as the in-memory session-map key.
+    #[test]
+    fn identity_key_is_sha256_hex_not_raw_credential() {
+        const CRED: &str = "cred-super-secret-token-value";
+        let (_, key) = resolve_passthrough_headers(&cfg(true), &headers_with(CRED), true).unwrap();
+        let key = key.expect("credential must key a bucket");
+        // 64 lowercase hex chars — a SHA-256 digest, never the token.
+        assert_eq!(key.len(), 64, "SHA-256 hex is 64 chars");
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()), "hex only");
+        assert!(!key.contains(CRED), "raw credential must not appear in key");
+        assert!(
+            !key.contains("super-secret-token-value"),
+            "raw token bytes must not appear in key"
+        );
+        // Exactly the digest `passthrough_identity_key` computes.
+        assert_eq!(key, passthrough_identity_key(CRED));
     }
 
     // D.3 — a required backend with no caller credential fails closed.
@@ -63,12 +119,19 @@ mod passthrough {
         assert!(resolve_passthrough_headers(&cfg(true), &headers_with("   "), true).is_err());
     }
 
-    // A non-required backend with no caller credential yields the static
-    // path (empty), after which the INV-2 shared-token guard decides.
+    // MIK.PT.3 — a non-required backend with no caller credential yields the
+    // static path (empty headers) AND no per-caller session bucket (`None`), so
+    // `HttpTransport::bucket_key` returns the shared default (`""`) bucket
+    // exactly as before MIK-6785. The INV-2 shared-token guard then decides.
     #[test]
     fn optional_and_absent_is_empty() {
-        let out = resolve_passthrough_headers(&cfg(false), &HeaderMap::new(), true).unwrap();
-        assert!(out.is_empty());
+        let (headers, key) =
+            resolve_passthrough_headers(&cfg(false), &HeaderMap::new(), true).unwrap();
+        assert!(headers.is_empty());
+        assert!(
+            key.is_none(),
+            "no credential must select the shared default (\"\") bucket"
+        );
     }
 
     // MIK-6710 — a `required` backend on a transport that cannot carry
@@ -77,9 +140,8 @@ mod passthrough {
     // supplied a well-formed credential.
     #[test]
     fn required_and_transport_incapable_refuses_even_with_credential() {
-        let err =
-            resolve_passthrough_headers(&cfg(true), &headers_with("Bearer caller-tok"), false)
-                .expect_err("incapable transport must refuse regardless of credential");
+        let err = resolve_passthrough_headers(&cfg(true), &headers_with("cred-caller-tok"), false)
+            .expect_err("incapable transport must refuse regardless of credential");
         assert!(err.contains("MIK-6710"), "error: {err}");
     }
 
@@ -87,8 +149,9 @@ mod passthrough {
     // proceeds with the static path — best-effort, unaffected by MIK-6710.
     #[test]
     fn optional_and_transport_incapable_is_unaffected() {
-        let out = resolve_passthrough_headers(&cfg(false), &HeaderMap::new(), false).unwrap();
-        assert!(out.is_empty());
+        let (headers, _key) =
+            resolve_passthrough_headers(&cfg(false), &HeaderMap::new(), false).unwrap();
+        assert!(headers.is_empty());
     }
 }
 
@@ -274,7 +337,7 @@ mod identity_propagation_audit {
             "x-mcp-passthrough-authorization",
             CANARY_SECRET.parse().unwrap(),
         );
-        let headers = resolve_passthrough_headers(&cfg, &inbound, true)
+        let (headers, _key) = resolve_passthrough_headers(&cfg, &inbound, true)
             .expect("canary credential resolves into forwarded headers");
         assert!(
             headers.iter().any(|(_, v)| v.contains(CANARY_SECRET)),


### PR DESCRIPTION
## Passthrough upstream-session partitioning (MIK-6785)

Closes the second code path of the same session-sharing class fixed for the minting path in MIK-6784 (#327).

### Problem
MIK-6784 partitioned the upstream `MCP-Session-Id` per caller identity, but only the credential-minting path threaded an identity key. In Passthrough mode (MIK-6746) the direct backend route left the identity key unset, so every passthrough caller shared the empty-key (`""`) default session bucket. Against a stateful upstream that binds data to the session id rather than to the bearer token, one passthrough caller could be served another caller's session-bound data.

### Fix
- `resolve_passthrough_headers` now returns `(headers, Option<String>)`. The forwarded backend credential is hashed at its single read point via SHA-256 hex (`passthrough_identity_key`) into a stable, collision-safe per-caller bucket key. The raw token stays only in the forwarded `Authorization` header; it is never logged and never stored except as the one-way in-memory session-map key.
- The direct route assigns that key to `identity_key`, symmetric with the minting path, so each distinct passthrough credential selects its own session bucket and the same credential reuses its bucket.
- The no-credential, non-required path keeps `identity_key = None` (shared default bucket) — single-tenant behavior unchanged.
- Fail-closed / `ensure_transport_carries_identity_headers` logic untouched.

### Tests
- `MIK.PT.1` distinct credentials produce distinct session buckets.
- `MIK.PT.2` the same credential reuses the same bucket.
- `MIK.PT.3` no-credential non-required path uses the default (`""`) bucket.
- Unit test asserts the key is the 64-char SHA-256 hex digest, never the raw token.

### Verification
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --lib`: `test result: ok. 3297 passed; 0 failed; 2 ignored`.
- `backend_handlers` module incl. new tests: 16 passed, 0 failed.
- `#![deny(unsafe_code)]` intact; no `unsafe` in either changed file.

Files: `src/gateway/router/backend_handlers.rs`, `src/gateway/router/backend_handlers/tests.rs` (+145/-24).
