### PR TITLE
chore(release): v3.1.2 — passthrough upstream-session partitioning (MIK-6785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2026-07-06
+
+### Security
+
+- **Passthrough upstream session id is now partitioned per caller identity
+  (MIK-6785).** This closes the second code path of the session-sharing class
+  fixed for the minting path in 3.1.1 (MIK-6784). In Passthrough mode the direct
+  backend route left the caller identity key unset, so every passthrough caller
+  shared the empty-key default upstream-session bucket. Against a stateful
+  upstream that binds data to the `MCP-Session-Id` rather than the bearer token,
+  one passthrough caller could be served another caller's session-bound data.
+  The forwarded backend credential is now hashed at its single read point via
+  SHA-256 into a stable, collision-safe per-caller bucket key; the raw token is
+  never logged or stored except as that one-way in-memory session-map key. Each
+  distinct passthrough credential selects its own session bucket, the same
+  credential reuses its bucket, and the no-credential non-required path keeps the
+  shared default bucket, so single-tenant behavior is unchanged. With this the
+  entire upstream session-sharing class is closed across both code paths and no
+  follow-up remains.
+
 ## [3.1.1] - 2026-07-06
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
## Release v3.1.2

Patch release. Ships the MIK-6785 passthrough session-partitioning fix (merged to `main` in `1845885f`) and bumps the version.

### Included fix
- **Passthrough upstream session partitioning (MIK-6785).** Closes the second code path of the session-sharing class first fixed for the minting path in 3.1.1 (MIK-6784). The forwarded backend credential is hashed at its single read point (SHA-256) into a stable per-caller upstream-session bucket key, so a stateful upstream can no longer serve one passthrough caller's session-bound data to another. Raw token is never logged or stored except as the one-way in-memory session-map key. No-credential non-required path keeps the shared default bucket (single-tenant behavior unchanged).

### Closure
With both the minting path (3.1.1) and the passthrough path (3.1.2) partitioned per caller identity, the entire upstream session-sharing class is closed. **No follow-up remains** — the "tracked as a follow-up" note in the 3.1.1 changelog is resolved by this release.

### Changes
- `Cargo.toml` / `Cargo.lock`: `3.1.1` -> `3.1.2`.
- `CHANGELOG.md`: `[3.1.2]` Security entry.

### Verification
- Fix itself passed full CI on #329 before merge. This PR is the version bump + changelog only.
- `cargo fmt --check` / `cargo clippy --lib -D warnings` clean via pre-push gate.