### PR TITLE
fix(ci): drop forbidden OCI package version field for MCP Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,7 +127,7 @@ jobs:
           IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}:${VERSION}"
           jq --arg version "$VERSION" --arg image "$IMAGE" \
             '.version = $version
-             | .packages[0].version = $version
+             | del(.packages[0].version)
              | .packages[0].identifier = $image' \
             server.json > server.tmp
           mv server.tmp server.json

--- a/server.json
+++ b/server.json
@@ -14,7 +14,6 @@
     {
       "registryType": "oci",
       "identifier": "ghcr.io/mikkoparkkola/mcp-gateway:2.11.0",
-      "version": "2.11.0",
       "runtimeHint": "docker",
       "packageArguments": [
         {


### PR DESCRIPTION
## Problem
The MCP Registry tightened validation: OCI packages must not carry a `version` field (version belongs in `identifier`). The `publish-mcp-registry` job in `docker.yml` re-injected it via jq (`.packages[0].version = $version`), so publishing failed **400 Bad Request** on the v3.1.3 tag — and would fail on every future `v*` tag.

> registry validation failed: OCI packages must not have 'version' field - include version in 'identifier' instead

This job is skipped on PRs and only runs on tag push, so it wasn't caught pre-merge.

## Fix
- `docker.yml`: replace `.packages[0].version = $version` with `del(.packages[0].version)`
- `server.json`: remove the stale package-level `version` field

## Verification
Simulated the workflow rewrite for 3.1.3 locally:
```
version = 3.1.3
packages[0].identifier = ghcr.io/mikkoparkkola/mcp-gateway:3.1.3
packages[0].hasVersion = false
```
`jq empty server.json` → valid.

## Scope note
v3.1.3's registry catalog entry lags by design (fix-forward — not moving a published tag). It self-heals on the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)