### PR TITLE
fix(oauth): persist dynamically-registered client_id across restarts

### DIFF
--- a/src/control_plane/store.rs
+++ b/src/control_plane/store.rs
@@ -40,6 +40,7 @@ use crate::control_plane::{
     ControlPlaneAction, ControlPlaneAuditEvent, ControlPlaneGrant, ControlPlaneGrantStatus,
     ControlPlanePolicy, ControlPlaneRollbackPlan,
 };
+use crate::fs_lock::ExclusiveFileLock;
 use crate::security::TransparencyLogger;
 
 /// On-disk schema version for a persisted collection.
@@ -858,43 +859,10 @@ fn force_owner_only(_f: &std::fs::File) -> std::io::Result<()> {
 }
 
 // ── OS advisory file lock ────────────────────────────────────────────────────────
-
-/// An exclusive advisory lock on a dedicated lock file, released on drop.
-///
-/// On unix this is a real `flock`; the lock file's fd holds the lock across the
-/// collection file's atomic rename. On non-unix it degrades to opening the file
-/// with no advisory lock.
-struct ExclusiveFileLock {
-    _file: std::fs::File,
-}
-
-impl ExclusiveFileLock {
-    fn acquire(lock_path: &Path) -> std::io::Result<Self> {
-        let mut opts = std::fs::OpenOptions::new();
-        opts.create(true).write(true).read(true);
-        set_owner_only(&mut opts);
-        let file = opts.open(lock_path)?;
-        lock_exclusive(&file)?;
-        Ok(Self { _file: file })
-    }
-}
-
-/// Take an exclusive `flock` on unix. `rustix` is an already-present dependency
-/// (promoted to direct with the `fs` feature); no new crate is compiled.
-#[cfg(unix)]
-fn lock_exclusive(file: &std::fs::File) -> std::io::Result<()> {
-    rustix::fs::flock(file, rustix::fs::FlockOperation::LockExclusive)
-        .map_err(|e| std::io::Error::from_raw_os_error(e.raw_os_error()))
-}
-
-/// ponytail: cross-process advisory locking on non-unix is out of scope for the
-/// single-node file backend. Atomic rename still prevents torn files, and the
-/// generation compare-and-swap still rejects an in-process lost update. Upgrade
-/// to `LockFileEx` if a Windows multi-process deployment ever needs it.
-#[cfg(not(unix))]
-fn lock_exclusive(_file: &std::fs::File) -> std::io::Result<()> {
-    Ok(())
-}
+//
+// `ExclusiveFileLock` moved to `crate::fs_lock` (2026-07-07, MIK-6750 r7) so the
+// oauth client_id self-heal path can share the same flock primitive instead of
+// duplicating it. See `crate::fs_lock` for the implementation.
 
 // ── Tests ────────────────────────────────────────────────────────────────────────
 

--- a/src/fs_lock.rs
+++ b/src/fs_lock.rs
@@ -1,0 +1,130 @@
+//! Cross-process advisory file locking, shared by every on-disk store that
+//! needs to serialize a read-repair-write (or read-modify-write) critical
+//! section across independent OS processes sharing a directory.
+//!
+//! On unix this is a real `flock` held on a dedicated `.lock` sidecar file,
+//! released automatically when the returned guard drops. On non-unix
+//! platforms it degrades to opening (and creating) the sidecar file with no
+//! actual advisory lock — single-node collection stores still rely on atomic
+//! rename / hard-link for torn-write safety, so the only gap is cross-process
+//! interleaving on Windows, which no current deployment target exercises.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+/// An exclusive advisory lock on a dedicated lock file, released on drop.
+///
+/// On unix this is a real `flock`; the lock file's fd holds the lock across
+/// whatever atomic rename/hard-link the caller performs while holding the
+/// guard. On non-unix it degrades to opening the file with no advisory lock.
+pub(crate) struct ExclusiveFileLock {
+    _file: File,
+}
+
+impl ExclusiveFileLock {
+    /// Block until an exclusive lock on `lock_path` is acquired, creating the
+    /// sidecar file (owner-only, `0600` on unix) if it does not exist yet.
+    pub(crate) fn acquire(lock_path: &Path) -> io::Result<Self> {
+        let mut opts = OpenOptions::new();
+        opts.create(true).write(true).read(true);
+        set_owner_only(&mut opts);
+        let file = opts.open(lock_path)?;
+        lock_exclusive(&file)?;
+        Ok(Self { _file: file })
+    }
+}
+
+/// Restrict a newly-created lock file to owner read/write (`0600`) on unix.
+#[cfg(unix)]
+fn set_owner_only(opts: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt as _;
+    opts.mode(0o600);
+}
+
+/// No-op on non-unix: file permissions are managed by the platform ACLs.
+#[cfg(not(unix))]
+fn set_owner_only(_opts: &mut OpenOptions) {}
+
+/// Take an exclusive `flock` on unix. `rustix` is an already-present
+/// dependency (promoted to direct with the `fs` feature); no new crate is
+/// compiled to get this.
+#[cfg(unix)]
+fn lock_exclusive(file: &File) -> io::Result<()> {
+    rustix::fs::flock(file, rustix::fs::FlockOperation::LockExclusive)
+        .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
+}
+
+/// ponytail: cross-process advisory locking on non-unix is out of scope for
+/// the single-node file backends that use this lock today. Upgrade to
+/// `LockFileEx` if a Windows multi-process deployment ever needs it.
+#[cfg(not(unix))]
+fn lock_exclusive(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acquire_creates_sidecar_and_releases_on_drop() {
+        // GIVEN: a lock path that does not exist yet.
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join(".test.lock");
+        assert!(!lock_path.exists());
+
+        // WHEN: a lock is acquired and immediately dropped.
+        {
+            let _lock = ExclusiveFileLock::acquire(&lock_path).expect("acquire");
+        }
+
+        // THEN: the sidecar file now exists and a second acquire succeeds
+        // (proves the first guard released the lock on drop).
+        assert!(lock_path.exists());
+        let _second = ExclusiveFileLock::acquire(&lock_path).expect("re-acquire after drop");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn acquire_serializes_concurrent_threads() {
+        // GIVEN: many threads racing to acquire the same lock and record
+        // whether they ever observed another thread inside the critical
+        // section concurrently.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = Arc::new(dir.path().join(".contended.lock"));
+        let inside = Arc::new(AtomicUsize::new(0));
+        let max_inside = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(8));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let lock_path = Arc::clone(&lock_path);
+                let inside = Arc::clone(&inside);
+                let max_inside = Arc::clone(&max_inside);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    let _lock = ExclusiveFileLock::acquire(&lock_path).expect("acquire");
+                    let now = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_inside.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    inside.fetch_sub(1, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // THEN: at most one thread was ever inside the critical section.
+        assert_eq!(
+            max_inside.load(Ordering::SeqCst),
+            1,
+            "flock failed to serialize concurrent critical sections"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod cost_accounting;
 pub mod discovery;
 pub mod error;
 pub mod failsafe;
+mod fs_lock;
 pub mod gateway;
 mod hashing;
 pub mod idempotency;

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -21,6 +21,24 @@ use super::metadata::{self, AuthorizationServerMetadata, ProtectedResourceMetada
 use super::storage::{TokenInfo, TokenStorage};
 use crate::{Error, Result};
 
+/// Provenance of a `client_id` (MIK-6750 r7, Defect 2).
+///
+/// `purge_client_id_if_invalid` must never clear a [`Configured`](Self::Configured)
+/// id: it is operator-supplied config (Slack, Figma, …) and erasing it on an
+/// `invalid_client` rejection would delete valid configuration and guarantee
+/// every subsequent attempt also fails, using a generated/DCR id the operator
+/// never intended. Only a [`Registered`](Self::Registered) id — obtained via
+/// Dynamic Client Registration, generated as a DCR fallback, or loaded from a
+/// prior registration's persisted record — is safe to purge and re-register.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientIdSource {
+    /// Came from `OAuthClientConfig.client_id`. Never purgeable.
+    Configured,
+    /// Obtained via Dynamic Client Registration, a generated fallback, or a
+    /// load of a previously dynamically-registered id from storage.
+    Registered,
+}
+
 /// OAuth client for a specific backend
 pub struct OAuthClient {
     /// HTTP client for token requests
@@ -52,6 +70,11 @@ pub struct OAuthClient {
 
     /// Client ID (registered or generated)
     client_id: RwLock<Option<String>>,
+
+    /// Provenance of `client_id`. Invariant: `Some` exactly when `client_id`
+    /// is `Some` — every write site that sets `client_id` sets this alongside
+    /// it. See [`ClientIdSource`] for why this exists.
+    client_id_source: RwLock<Option<ClientIdSource>>,
 
     /// Pre-configured client secret (for providers like Slack / Figma).
     client_secret: Option<String>,
@@ -120,6 +143,13 @@ impl OAuthClient {
         storage: Arc<TokenStorage>,
         cfg: OAuthClientConfig,
     ) -> Self {
+        // A pre-configured client_id is operator config, not a dynamic
+        // registration — record its provenance up front so a later
+        // `invalid_client` rejection never purges it (Defect 2, MIK-6750 r7).
+        let client_id_source = cfg
+            .client_id
+            .is_some()
+            .then_some(ClientIdSource::Configured);
         Self {
             http_client,
             backend_name,
@@ -131,6 +161,7 @@ impl OAuthClient {
             current_token: RwLock::new(None),
             scopes,
             client_id: RwLock::new(cfg.client_id),
+            client_id_source: RwLock::new(client_id_source),
             client_secret: cfg.client_secret,
             callback_host: cfg.callback_host,
             callback_port: cfg.callback_port,
@@ -191,16 +222,33 @@ impl OAuthClient {
         // Restore a previously-registered dynamic client id so we do NOT
         // re-register (and pop a fresh browser authorize tab) every time the
         // process restarts or a connection is re-established.
-        if self.client_id.read().is_none()
-            && let Some(cid) = self
-                .storage
-                .load_client_id(&self.backend_name, &self.resource_url)
-        {
-            *self.client_id.write() = Some(cid);
-        }
+        self.restore_persisted_client_id();
 
         info!(backend = %self.backend_name, "OAuth client initialized");
         Ok(())
+    }
+
+    /// Load a previously-registered dynamic `client_id` from storage into
+    /// memory, tagging its provenance as [`ClientIdSource::Registered`].
+    ///
+    /// A no-op when a `client_id` is already set: that only happens when
+    /// `OAuthClientConfig.client_id` was supplied, i.e. operator config that
+    /// must never be overwritten by (or conflated with) a stale disk record.
+    /// Because of that guard, any id loaded here is necessarily a prior
+    /// Dynamic Client Registration, never operator config (Defect 2,
+    /// MIK-6750 r7) — safe to mark `Registered` so a later `invalid_client`
+    /// rejection may purge it.
+    fn restore_persisted_client_id(&self) {
+        if self.client_id.read().is_some() {
+            return;
+        }
+        if let Some(cid) = self
+            .storage
+            .load_client_id(&self.backend_name, &self.resource_url)
+        {
+            *self.client_id.write() = Some(cid);
+            *self.client_id_source.write() = Some(ClientIdSource::Registered);
+        }
     }
 
     /// Get a valid access token, refreshing or re-authorizing as needed
@@ -678,6 +726,7 @@ impl OAuthClient {
                             // registered concurrently; adopt the authoritative
                             // on-disk id so both instances converge on one.
                             *self.client_id.write() = Some(persisted.clone());
+                            *self.client_id_source.write() = Some(ClientIdSource::Registered);
                             return Ok(persisted);
                         }
                         Err(e) => {
@@ -697,6 +746,7 @@ impl OAuthClient {
                                  on next restart (auth churn until the write path is fixed)"
                             );
                             *self.client_id.write() = Some(client_id.clone());
+                            *self.client_id_source.write() = Some(ClientIdSource::Registered);
                             return Ok(client_id);
                         }
                     }
@@ -710,6 +760,7 @@ impl OAuthClient {
         // Generate a client ID
         let generated = generate_client_id();
         *self.client_id.write() = Some(generated.clone());
+        *self.client_id_source.write() = Some(ClientIdSource::Registered);
         Ok(generated)
     }
 
@@ -724,16 +775,18 @@ impl OAuthClient {
         if !response_body.contains("invalid_client") {
             return;
         }
-        // A configured client (client_secret present) is a pre-registered
-        // static client (Slack, Figma, …), NOT a dynamically-registered one.
-        // Its client_id is operator-supplied config, not something we can or
-        // should re-register. Purging it would delete valid configuration and
-        // guarantee the next attempt also fails. Only dynamically-registered
-        // (no-secret) clients are safe to purge and re-register.
-        if self.client_secret.is_some() {
+        // Guard on provenance, not `client_secret` presence: a PUBLIC
+        // operator-configured client (client_id set, no secret — e.g. a
+        // native/PKCE-only app registration) is just as much operator config
+        // as a confidential one, and the old `client_secret.is_some()` guard
+        // did not protect it (Defect 2, MIK-6750 r7). Only a client_id whose
+        // provenance is positively known to be `Registered` — Dynamic Client
+        // Registration, a generated DCR fallback, or a loaded prior
+        // registration — is safe to purge and re-register.
+        if *self.client_id_source.read() != Some(ClientIdSource::Registered) {
             warn!(
                 backend = %self.backend_name,
-                "Configured client rejected with invalid_client; not purging (client_id is static config, not a dynamic registration)"
+                "Client rejected with invalid_client; not purging (client_id provenance is not a dynamic registration)"
             );
             return;
         }
@@ -742,6 +795,7 @@ impl OAuthClient {
             "Server rejected client_id (invalid_client); purging stored registration so the next attempt re-registers"
         );
         *self.client_id.write() = None;
+        *self.client_id_source.write() = None;
         if let Err(e) = self
             .storage
             .delete_client_id(&self.backend_name, &self.resource_url)

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -13,7 +13,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex as TokioMutex;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use url::Url;
 
 use super::callback;
@@ -554,6 +554,7 @@ impl OAuthClient {
                 http_status = status.as_u16(),
                 "OAuth token exchange failed"
             );
+            self.purge_client_id_if_invalid(&body);
             return Err(Error::OAuth(format!(
                 "Token exchange failed: HTTP {status} - {body}"
             )));
@@ -615,6 +616,7 @@ impl OAuthClient {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
+            self.purge_client_id_if_invalid(&body);
             return Err(Error::OAuth(format!(
                 "Token refresh failed: HTTP {status} - {body}"
             )));
@@ -658,18 +660,41 @@ impl OAuthClient {
         if let Some(ref reg_endpoint) = auth_meta.registration_endpoint {
             match self.register_client(reg_endpoint, redirect_uri).await {
                 Ok(client_id) => {
-                    *self.client_id.write() = Some(client_id.clone());
                     // Persist immediately: registration succeeded even if the
                     // browser authorize step below never completes. Without this
                     // every connection re-registers and opens a new OAuth tab.
-                    if let Err(e) = self.storage.save_client_id(
+                    match self.storage.save_client_id(
                         &self.backend_name,
                         &self.resource_url,
                         &client_id,
                     ) {
-                        warn!(error = %e, "Failed to persist registered client_id");
+                        Ok(persisted) => {
+                            // First-writer-wins: a co-located instance may have
+                            // registered concurrently; adopt the authoritative
+                            // on-disk id so both instances converge on one.
+                            *self.client_id.write() = Some(persisted.clone());
+                            return Ok(persisted);
+                        }
+                        Err(e) => {
+                            // Do NOT silently swallow: a lost write re-opens the
+                            // "new client_id every restart" churn bug. The
+                            // in-memory id is still valid for THIS session, so
+                            // the live auth proceeds, but the operator must see
+                            // that persistence failed.
+                            let client_file = self
+                                .storage
+                                .client_path(&self.backend_name, &self.resource_url);
+                            error!(
+                                backend = %self.backend_name,
+                                error = %e,
+                                path = %client_file.display(),
+                                "Failed to persist registered client_id; it will be re-registered \
+                                 on next restart (auth churn until the write path is fixed)"
+                            );
+                            *self.client_id.write() = Some(client_id.clone());
+                            return Ok(client_id);
+                        }
                     }
-                    return Ok(client_id);
                 }
                 Err(e) => {
                     debug!(error = %e, "Dynamic registration failed, using generated ID");
@@ -681,6 +706,30 @@ impl OAuthClient {
         let generated = generate_client_id();
         *self.client_id.write() = Some(generated.clone());
         Ok(generated)
+    }
+
+    /// Purge a stored `client_id` when the authorization server rejects it.
+    ///
+    /// OAuth 2.0 signals an unrecognized client with an `invalid_client` error
+    /// in the token-endpoint response body. When that happens the persisted
+    /// registration is stale (revoked, expired, garbage-collected); we drop it
+    /// from memory and disk so the next attempt re-registers rather than looping
+    /// on `invalid_client` forever with no recovery inside the product.
+    fn purge_client_id_if_invalid(&self, response_body: &str) {
+        if !response_body.contains("invalid_client") {
+            return;
+        }
+        warn!(
+            backend = %self.backend_name,
+            "Server rejected client_id (invalid_client); purging stored registration so the next attempt re-registers"
+        );
+        *self.client_id.write() = None;
+        if let Err(e) = self
+            .storage
+            .delete_client_id(&self.backend_name, &self.resource_url)
+        {
+            warn!(backend = %self.backend_name, error = %e, "Failed to delete stale client_id file");
+        }
     }
 
     /// Register a new client dynamically with the specified redirect URI

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -188,6 +188,17 @@ impl OAuthClient {
             *self.current_token.write() = Some(token);
         }
 
+        // Restore a previously-registered dynamic client id so we do NOT
+        // re-register (and pop a fresh browser authorize tab) every time the
+        // process restarts or a connection is re-established.
+        if self.client_id.read().is_none()
+            && let Some(cid) = self
+                .storage
+                .load_client_id(&self.backend_name, &self.resource_url)
+        {
+            *self.client_id.write() = Some(cid);
+        }
+
         info!(backend = %self.backend_name, "OAuth client initialized");
         Ok(())
     }
@@ -648,6 +659,16 @@ impl OAuthClient {
             match self.register_client(reg_endpoint, redirect_uri).await {
                 Ok(client_id) => {
                     *self.client_id.write() = Some(client_id.clone());
+                    // Persist immediately: registration succeeded even if the
+                    // browser authorize step below never completes. Without this
+                    // every connection re-registers and opens a new OAuth tab.
+                    if let Err(e) = self.storage.save_client_id(
+                        &self.backend_name,
+                        &self.resource_url,
+                        &client_id,
+                    ) {
+                        warn!(error = %e, "Failed to persist registered client_id");
+                    }
                     return Ok(client_id);
                 }
                 Err(e) => {

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -322,6 +322,11 @@ impl OAuthClient {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
+            // Mirror the exchange_code/refresh_token paths: a rejected
+            // dynamic registration must be purged so the next attempt
+            // re-registers. Fix 1's guard makes this a no-op for
+            // configured-secret (static) clients.
+            self.purge_client_id_if_invalid(&body);
             return Err(Error::OAuth(format!(
                 "Client credentials failed: HTTP {status} - {body}"
             )));
@@ -717,6 +722,19 @@ impl OAuthClient {
     /// on `invalid_client` forever with no recovery inside the product.
     fn purge_client_id_if_invalid(&self, response_body: &str) {
         if !response_body.contains("invalid_client") {
+            return;
+        }
+        // A configured client (client_secret present) is a pre-registered
+        // static client (Slack, Figma, …), NOT a dynamically-registered one.
+        // Its client_id is operator-supplied config, not something we can or
+        // should re-register. Purging it would delete valid configuration and
+        // guarantee the next attempt also fails. Only dynamically-registered
+        // (no-secret) clients are safe to purge and re-register.
+        if self.client_secret.is_some() {
+            warn!(
+                backend = %self.backend_name,
+                "Configured client rejected with invalid_client; not purging (client_id is static config, not a dynamic registration)"
+            );
             return;
         }
         warn!(

--- a/src/oauth/client/tests.rs
+++ b/src/oauth/client/tests.rs
@@ -350,8 +350,49 @@ fn purge_keeps_configured_static_client_on_invalid_client() {
 }
 
 #[test]
-fn purge_clears_dynamic_client_on_invalid_client() {
-    // GIVEN: a dynamically-registered client (no configured secret).
+fn purge_keeps_public_configured_client_without_secret_on_invalid_client() {
+    // GIVEN: an operator-configured PUBLIC client -- client_id set via
+    // config, no client_secret (e.g. a native/PKCE-only app registration).
+    // Defect 2 (MIK-6750 r7): the old `client_secret.is_some()` guard did
+    // NOT protect this case -- an invalid_client rejection erased the
+    // operator's configured id and the next auth attempt used a
+    // generated/DCR id instead of the one the operator configured.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    let client = OAuthClient::new(
+        Client::new(),
+        "public-app".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_id: Some("configured-public-id".to_string()),
+            client_secret: None,
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+
+    // WHEN: the server rejects the token request with invalid_client.
+    client.purge_client_id_if_invalid(r#"{"error":"invalid_client"}"#);
+
+    // THEN: the configured id survives -- it is operator config, not a
+    // dynamic registration, regardless of client_secret presence.
+    assert_eq!(
+        client.client_id.read().clone(),
+        Some("configured-public-id".to_string()),
+        "configured public (no-secret) client_id must NOT be purged"
+    );
+}
+
+#[test]
+fn purge_clears_dynamically_registered_client_on_invalid_client() {
+    // GIVEN: a client_id obtained via Dynamic Client Registration -- set the
+    // way `ensure_client_id_with_redirect`/`restore_persisted_client_id`
+    // would (client_id + `ClientIdSource::Registered` together), NOT via
+    // `OAuthClientConfig`. Driving this through config (as the pre-fix test
+    // did) is indistinguishable from the Defect 2 scenario above and no
+    // longer represents "dynamic" after the provenance fix.
     let dir = tempfile::tempdir().unwrap();
     let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
     let client = OAuthClient::new(
@@ -361,7 +402,6 @@ fn purge_clears_dynamic_client_on_invalid_client() {
         vec![],
         Arc::clone(&storage),
         OAuthClientConfig {
-            client_id: Some("dynamic-id".to_string()),
             client_secret: None,
             token_refresh_buffer_secs: 300,
             ..Default::default()
@@ -370,6 +410,8 @@ fn purge_clears_dynamic_client_on_invalid_client() {
     storage
         .save_client_id("dyn", "http://localhost", "dynamic-id")
         .unwrap();
+    *client.client_id.write() = Some("dynamic-id".to_string());
+    *client.client_id_source.write() = Some(ClientIdSource::Registered);
 
     // WHEN: the server rejects the token request with invalid_client.
     client.purge_client_id_if_invalid("error=invalid_client&error_description=rejected");
@@ -384,6 +426,89 @@ fn purge_clears_dynamic_client_on_invalid_client() {
         storage.load_client_id("dyn", "http://localhost"),
         None,
         "dynamic client_id file must be deleted"
+    );
+}
+
+#[test]
+fn restore_persisted_client_id_tags_loaded_id_as_registered_and_purgeable() {
+    // GIVEN: no operator-configured client_id, but a prior Dynamic Client
+    // Registration persisted to disk (as `ensure_client_id_with_redirect`
+    // would have done on an earlier run).
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    storage
+        .save_client_id("dyn", "http://localhost", "persisted-dyn-id")
+        .unwrap();
+    let client = OAuthClient::new(
+        Client::new(),
+        "dyn".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_secret: None,
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+    assert!(
+        client.client_id.read().is_none(),
+        "precondition: no operator-configured client_id"
+    );
+
+    // WHEN: `initialize()`'s restore step loads the persisted id.
+    client.restore_persisted_client_id();
+
+    // THEN: the loaded id is tagged Registered, not Configured, so a later
+    // invalid_client rejection can purge and re-register it.
+    assert_eq!(
+        client.client_id.read().clone(),
+        Some("persisted-dyn-id".to_string())
+    );
+    client.purge_client_id_if_invalid(r#"{"error":"invalid_client"}"#);
+    assert!(
+        client.client_id.read().is_none(),
+        "an id restored from a prior DCR must be purgeable"
+    );
+}
+
+#[test]
+fn restore_persisted_client_id_never_overwrites_configured_id() {
+    // GIVEN: an operator-configured client_id, AND (pathologically) a
+    // different id sitting in the client_id storage file.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    storage
+        .save_client_id("cfg", "http://localhost", "stale-on-disk-id")
+        .unwrap();
+    let client = OAuthClient::new(
+        Client::new(),
+        "cfg".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_id: Some("configured-id".to_string()),
+            client_secret: None,
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+
+    // WHEN: `initialize()`'s restore step runs.
+    client.restore_persisted_client_id();
+
+    // THEN: the configured id is untouched -- restore is a no-op when a
+    // client_id is already set -- and it remains non-purgeable.
+    assert_eq!(
+        client.client_id.read().clone(),
+        Some("configured-id".to_string())
+    );
+    client.purge_client_id_if_invalid(r#"{"error":"invalid_client"}"#);
+    assert_eq!(
+        client.client_id.read().clone(),
+        Some("configured-id".to_string()),
+        "configured client_id must survive purge even with a stale disk record"
     );
 }
 

--- a/src/oauth/client/tests.rs
+++ b/src/oauth/client/tests.rs
@@ -301,6 +301,114 @@ fn needs_proactive_refresh_false_when_outside_buffer() {
     let token = TokenInfo::from_response("tok".to_string(), None, None, Some(3600), None);
     *client.current_token.write() = Some(token);
 
-    // WHEN / THEN: 3600s remaining >> 300s buffer → no refresh yet
+    // WHEN / THEN: 3600s remaining >> 300s buffer -> no refresh yet
     assert!(!client.needs_proactive_refresh());
+}
+
+// =========================================================================
+// purge_client_id_if_invalid -- static vs dynamic clients
+// =========================================================================
+
+#[test]
+fn purge_keeps_configured_static_client_on_invalid_client() {
+    // GIVEN: a client with a configured client_secret. Its client_id is
+    // operator-supplied static config (Slack/Figma style), NOT a dynamic
+    // registration -- purging it would delete valid config.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    let client = OAuthClient::new(
+        Client::new(),
+        "slack".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_id: Some("configured-static-id".to_string()),
+            client_secret: Some("configured-secret".to_string()),
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+    storage
+        .save_client_id("slack", "http://localhost", "configured-static-id")
+        .unwrap();
+
+    // WHEN: the server rejects the token request with invalid_client.
+    client.purge_client_id_if_invalid(r#"{"error":"invalid_client"}"#);
+
+    // THEN: the configured id survives in memory AND on disk.
+    assert_eq!(
+        client.client_id.read().clone(),
+        Some("configured-static-id".to_string()),
+        "configured static client_id must NOT be purged from memory"
+    );
+    assert_eq!(
+        storage.load_client_id("slack", "http://localhost"),
+        Some("configured-static-id".to_string()),
+        "configured static client_id file must NOT be deleted"
+    );
+}
+
+#[test]
+fn purge_clears_dynamic_client_on_invalid_client() {
+    // GIVEN: a dynamically-registered client (no configured secret).
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    let client = OAuthClient::new(
+        Client::new(),
+        "dyn".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_id: Some("dynamic-id".to_string()),
+            client_secret: None,
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+    storage
+        .save_client_id("dyn", "http://localhost", "dynamic-id")
+        .unwrap();
+
+    // WHEN: the server rejects the token request with invalid_client.
+    client.purge_client_id_if_invalid("error=invalid_client&error_description=rejected");
+
+    // THEN: the stale dynamic registration is purged from memory AND disk so
+    // the next attempt re-registers.
+    assert!(
+        client.client_id.read().is_none(),
+        "dynamic client_id must be purged from memory"
+    );
+    assert_eq!(
+        storage.load_client_id("dyn", "http://localhost"),
+        None,
+        "dynamic client_id file must be deleted"
+    );
+}
+
+#[test]
+fn purge_is_noop_without_invalid_client_marker() {
+    // GIVEN: any client with a persisted id.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    let client = OAuthClient::new(
+        Client::new(),
+        "dyn".to_string(),
+        "http://localhost".to_string(),
+        vec![],
+        Arc::clone(&storage),
+        OAuthClientConfig {
+            client_id: Some("keep-me".to_string()),
+            client_secret: None,
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    );
+
+    // WHEN: the error body is unrelated (e.g. invalid_grant).
+    client.purge_client_id_if_invalid(r#"{"error":"invalid_grant"}"#);
+
+    // THEN: nothing is purged.
+    assert_eq!(client.client_id.read().clone(), Some("keep-me".to_string()));
 }

--- a/src/oauth/storage.rs
+++ b/src/oauth/storage.rs
@@ -270,6 +270,15 @@ impl TokenStorage {
         self.base_dir.join(format!("{key}_client.json"))
     }
 
+    /// Path to the advisory-lock sidecar guarding a backend's `client_id`
+    /// corrupt-final repair (see [`repair_corrupt_final`](Self::repair_corrupt_final)).
+    /// Never renamed or linked itself, so the held fd's lock survives the
+    /// final file's remove/relink underneath it.
+    fn client_lock_path(&self, backend_name: &str, resource_url: &str) -> PathBuf {
+        let key = Self::storage_key(backend_name, resource_url);
+        self.base_dir.join(format!(".{key}_client.lock"))
+    }
+
     /// Load a previously-registered dynamic client id for a backend.
     ///
     /// Returns `None` if no client has been registered yet or the record is
@@ -304,21 +313,25 @@ impl TokenStorage {
     ///
     /// The write is atomic and never exposes a world-readable window: content
     /// goes to a per-process temp file created with `O_EXCL` and mode `0600`
-    /// (on unix) *before* it is linked into place. Creating with `O_EXCL` also
+    /// (on unix) before it is linked into place. Creating with `O_EXCL` also
     /// guarantees a leftover temp from a crashed run is never truncated/reused.
     /// `hard_link` fails with `AlreadyExists` when the final path is already
     /// present, so a concurrent second instance adopts the existing id instead
-    /// of clobbering it (last-write-wins would churn the id across instances —
-    /// the very bug this persistence exists to prevent). If the existing final
-    /// file is corrupt/unreadable, it is removed and the link retried once so a
-    /// validated id becomes authoritative rather than silently diverging.
+    /// of clobbering it (last-write-wins would churn the id across instances,
+    /// the very bug this persistence exists to prevent). A corrupt/unreadable
+    /// final file is repaired under an exclusive advisory lock (see
+    /// [`repair_corrupt_final`](Self::repair_corrupt_final)) so two processes
+    /// that both observe the corruption can never race to remove each other's
+    /// freshly-written valid file.
     ///
     /// # Errors
     ///
-    /// Returns an error when the id cannot be serialized, a unique temp file
-    /// cannot be created or written, the existing final file is unreadable and
-    /// cannot be self-healed, or the atomic link fails for any reason other than
-    /// the final path already existing.
+    /// Returns an error when the id cannot be serialized, when a unique temp
+    /// file cannot be created, when the temp file cannot be written (in which
+    /// case the temp file is removed before the error is returned -- see
+    /// [`write_client_tmp`](Self::write_client_tmp)), when the existing final
+    /// file is unreadable and cannot be self-healed, or when the atomic link
+    /// fails for a reason other than the final path already existing.
     pub fn save_client_id(
         &self,
         backend_name: &str,
@@ -340,58 +353,140 @@ impl TokenStorage {
         // On unix the 0600 mode is applied atomically at creation, closing the
         // world-readable window that a post-write chmod would otherwise leave.
         let tmp = self.create_client_tmp(file_name)?;
-
-        #[cfg(unix)]
-        let write_result = {
-            use std::io::Write as _;
-            let (mut file, tmp) = tmp;
-            file.write_all(content.as_bytes())
-                .and_then(|()| file.sync_all())
-                .map(|()| tmp)
-        };
-        #[cfg(not(unix))]
-        let write_result = { fs::write(&tmp, &content).map(|()| tmp) };
-
-        let tmp = write_result
-            .map_err(|e| Error::OAuth(format!("Failed to write client_id temp file: {e}")))?;
+        let tmp = Self::write_client_tmp(tmp, &content)?;
 
         // First-writer-wins: `hard_link` fails with `AlreadyExists` when the
         // final path already exists, so a concurrent instance adopts the
         // existing id instead of clobbering it. A corrupt/unreadable existing
-        // file, however, is unusable — self-heal by removing it and retrying
-        // the link once so our validated temp becomes authoritative.
-        let mut heal_attempts = 0u8;
-        let result = loop {
-            match fs::hard_link(&tmp, &path) {
-                Ok(()) => {
-                    info!(backend = %backend_name, "Saved registered OAuth client_id");
-                    break Ok(client_id.to_string());
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    match self.load_client_id(backend_name, resource_url) {
-                        Some(existing) => {
-                            info!(backend = %backend_name, "client_id already persisted by another instance; adopting it");
-                            break Ok(existing);
-                        }
-                        None if heal_attempts < 1 => {
-                            // On-disk file is corrupt/unreadable; remove it and
-                            // retry the link so our validated temp wins.
-                            heal_attempts += 1;
-                            warn!(backend = %backend_name, "Existing client_id file is unreadable; removing and re-persisting from validated temp");
-                            let _ = fs::remove_file(&path);
-                        }
-                        None => {
-                            break Err(Error::OAuth(
-                                "client_id file exists but is unreadable and could not be self-healed".to_string(),
-                            ));
-                        }
-                    }
-                }
-                Err(e) => break Err(Error::OAuth(format!("Failed to persist client_id: {e}"))),
+        // file is unusable and gets repaired under a cross-process lock (see
+        // `repair_corrupt_final` for why the repair must be serialized).
+        let result = match fs::hard_link(&tmp, &path) {
+            Ok(()) => {
+                info!(backend = %backend_name, "Saved registered OAuth client_id");
+                Ok(client_id.to_string())
             }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                match self.load_client_id(backend_name, resource_url) {
+                    Some(existing) => {
+                        info!(backend = %backend_name, "client_id already persisted by another instance; adopting it");
+                        Ok(existing)
+                    }
+                    None => self.repair_corrupt_final(
+                        backend_name,
+                        resource_url,
+                        &path,
+                        &tmp,
+                        client_id,
+                    ),
+                }
+            }
+            Err(e) => Err(Error::OAuth(format!("Failed to persist client_id: {e}"))),
         };
         let _ = fs::remove_file(&tmp);
         result
+    }
+
+    /// Repair a corrupt/unreadable final `client_id` file under an exclusive
+    /// advisory lock (MIK-6750 r7).
+    ///
+    /// Without serialization, two processes that both observe
+    /// `load_client_id` return `None` for the same corrupt final can race:
+    /// process A reads `None`, process B repairs the file with a valid id and
+    /// returns, then process A — still acting on its stale `None` read —
+    /// removes B's freshly-written file and links its own, so the disk ends
+    /// up authoritative for A's id while B has already adopted its own. This
+    /// takes an exclusive `flock` on a `.lock` sidecar (never renamed, so the
+    /// held fd's lock survives the final file's remove/relink) across
+    /// re-read → remove → `hard_link`, so only one process repairs at a time
+    /// and a final that has become valid while we waited is never removed.
+    fn repair_corrupt_final(
+        &self,
+        backend_name: &str,
+        resource_url: &str,
+        path: &std::path::Path,
+        tmp: &std::path::Path,
+        client_id: &str,
+    ) -> Result<String> {
+        let lock_path = self.client_lock_path(backend_name, resource_url);
+        let _lock = crate::fs_lock::ExclusiveFileLock::acquire(&lock_path)
+            .map_err(|e| Error::OAuth(format!("Failed to acquire client_id repair lock: {e}")))?;
+
+        // Re-read under the lock: another process may have healed the file
+        // between our caller's unlocked read (which found it corrupt) and
+        // this call acquiring the lock. Never remove a final that now parses.
+        if let Some(existing) = self.load_client_id(backend_name, resource_url) {
+            info!(backend = %backend_name, "client_id healed by another instance while waiting for the repair lock; adopting it");
+            return Ok(existing);
+        }
+
+        warn!(backend = %backend_name, "Existing client_id file is unreadable; removing and re-persisting from validated temp");
+        let _ = fs::remove_file(path);
+
+        match fs::hard_link(tmp, path) {
+            Ok(()) => {
+                info!(backend = %backend_name, "Saved registered OAuth client_id (self-healed corrupt final)");
+                Ok(client_id.to_string())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // An unlocked fast-path writer (a fresh, non-repair save)
+                // won the link in the gap between our remove and this retry.
+                // Adopt whatever it left if valid; this is the same
+                // first-writer-wins contract as the normal case above.
+                self.load_client_id(backend_name, resource_url)
+                    .ok_or_else(|| {
+                        Error::OAuth(
+                            "client_id file exists but is unreadable and could not be self-healed"
+                                .to_string(),
+                        )
+                    })
+            }
+            Err(e) => Err(Error::OAuth(format!(
+                "Failed to persist client_id during self-heal: {e}"
+            ))),
+        }
+    }
+
+    /// Write `content` into the just-created temp file and return its path on
+    /// success.
+    ///
+    /// On any write or `fsync` failure (e.g. `ENOSPC`, `EIO`) the temp file is
+    /// removed (best-effort) before the error propagates, so a transient
+    /// write failure never leaks a private `0600` temp file under `base_dir`
+    /// (MIK-6750 r8, minor -- the previous code returned early via `?`
+    /// without cleanup, orphaning the temp on every such error).
+    #[cfg(unix)]
+    fn write_client_tmp(tmp: (fs::File, PathBuf), content: &str) -> Result<PathBuf> {
+        use std::io::Write as _;
+        let (mut file, tmp_path) = tmp;
+        match file
+            .write_all(content.as_bytes())
+            .and_then(|()| file.sync_all())
+        {
+            Ok(()) => Ok(tmp_path),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(Error::OAuth(format!(
+                    "Failed to write client_id temp file: {e}"
+                )))
+            }
+        }
+    }
+
+    /// Non-unix counterpart of [`write_client_tmp`](Self::write_client_tmp)
+    /// (see its docs for the cleanup-on-failure contract). `fs::write` opens,
+    /// writes, and closes the file in one call, so there is no separate
+    /// [`File`] handle to thread through.
+    #[cfg(not(unix))]
+    fn write_client_tmp(tmp: PathBuf, content: &str) -> Result<PathBuf> {
+        match fs::write(&tmp, content) {
+            Ok(()) => Ok(tmp),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp);
+                Err(Error::OAuth(format!(
+                    "Failed to write client_id temp file: {e}"
+                )))
+            }
+        }
     }
 
     /// Atomically create a private (`0600` on unix) temp file for a `client_id`
@@ -648,6 +743,114 @@ mod tests {
         assert_eq!(
             store.load_client_id(backend, resource),
             Some("cid".to_string())
+        );
+    }
+
+    #[test]
+    fn repair_corrupt_final_adopts_valid_final_without_removing_it() {
+        // GIVEN: the final file was corrupt when the *caller* first checked
+        // it, but has since become valid — as if another process repaired it
+        // between the caller's unlocked read and this call acquiring the
+        // repair lock. This is exactly the MIK-6750 r7 Defect 1 race: without
+        // a re-read-under-lock guard, this call would remove the other
+        // repairer's freshly-written valid file and overwrite it with our
+        // own, so a caller that already adopted "winner-id" would diverge
+        // from what ends up on disk.
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+        let path = store.client_path(backend, resource);
+
+        // The final is now VALID (as if another process just healed it).
+        fs::write(&path, serde_json::to_string("winner-id").unwrap()).unwrap();
+
+        // Our own (in this scenario, redundant) validated temp.
+        let tmp = dir.path().join("our.tmp");
+        fs::write(&tmp, serde_json::to_string("our-id").unwrap()).unwrap();
+
+        // WHEN: we attempt to repair what we believed (from a stale read)
+        // was corrupt.
+        let result = store.repair_corrupt_final(backend, resource, &path, &tmp, "our-id");
+
+        // THEN: we adopt the winner instead of overwriting it...
+        assert_eq!(result.unwrap(), "winner-id");
+        // ...and the final file was never removed/replaced.
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("winner-id".to_string()),
+            "a final that became valid under the lock must never be removed"
+        );
+    }
+
+    #[test]
+    fn save_client_id_self_heal_converges_under_thread_contention() {
+        // GIVEN: a corrupt final, and many threads racing to self-heal it
+        // with DIFFERENT ids at once (MIK-6750 r7, Defect 1).
+        use std::sync::Arc;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+        let (backend, resource) = ("b", "http://localhost");
+        fs::write(store.client_path(backend, resource), b"\x00corrupt").unwrap();
+
+        let barrier = Arc::new(std::sync::Barrier::new(16));
+        let handles: Vec<_> = (0..16)
+            .map(|i| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store
+                        .save_client_id(backend, resource, &format!("heal-{i}"))
+                        .expect("self-heal save")
+                })
+            })
+            .collect();
+        let returned: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // THEN: every caller converged on the SAME id, and it matches disk —
+        // the advisory lock serializes repair so no two threads can diverge.
+        let on_disk = store
+            .load_client_id(backend, resource)
+            .expect("healed and persisted");
+        assert!(
+            returned.iter().all(|r| *r == on_disk),
+            "callers disagreed with disk after self-heal race: returned={returned:?} disk={on_disk}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_client_tmp_removes_leaked_temp_on_write_failure() {
+        // GIVEN: a temp file opened read-only, so writing through it fails
+        // with EBADF -- simulating a real write/fsync failure (ENOSPC, EIO)
+        // deterministically, without exhausting real disk space (MIK-6750
+        // r8, minor -- Defect 3: the write path used to return early via `?`
+        // on failure without removing the temp, leaking a private 0600 file
+        // under `base_dir` on every such error).
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("client.tmp.leak-check");
+        // Create the file first (needs write access to create), then close
+        // and reopen it read-only so the fd we hand to `write_client_tmp`
+        // has no write access at all.
+        fs::File::create(&tmp_path).unwrap();
+        let file = fs::OpenOptions::new().read(true).open(&tmp_path).unwrap();
+        assert!(
+            tmp_path.exists(),
+            "precondition: temp file exists before the write attempt"
+        );
+
+        // WHEN: the write fails (the fd has no write permission).
+        let result = TokenStorage::write_client_tmp((file, tmp_path.clone()), "some-content");
+
+        // THEN: the error propagates AND the temp file is gone -- nothing is
+        // left behind on disk for an operator to notice weeks later.
+        assert!(
+            result.is_err(),
+            "expected the write to fail on a read-only fd"
+        );
+        assert!(
+            !tmp_path.exists(),
+            "temp file must be removed when the write/fsync fails, not leaked"
         );
     }
 

--- a/src/oauth/storage.rs
+++ b/src/oauth/storage.rs
@@ -264,7 +264,7 @@ impl TokenStorage {
     }
 
     /// Get the file path for a backend's dynamically-registered client id.
-    fn client_path(&self, backend_name: &str, resource_url: &str) -> PathBuf {
+    pub(crate) fn client_path(&self, backend_name: &str, resource_url: &str) -> PathBuf {
         let key = Self::storage_key(backend_name, resource_url);
         self.base_dir.join(format!("{key}_client.json"))
     }
@@ -297,29 +297,92 @@ impl TokenStorage {
 
     /// Persist a dynamically-registered client id for a backend.
     ///
+    /// Returns the id that is now authoritative on disk: the one passed in when
+    /// this call won the first-registration race, and a pre-existing one when
+    /// another gateway instance sharing this directory registered first.
+    ///
+    /// The write is atomic and never exposes a world-readable window: content
+    /// goes to a per-process temp file locked to `0600` *before* it is linked
+    /// into place. `hard_link` fails with `AlreadyExists` when the final path is
+    /// already present, so a concurrent second instance adopts the existing id
+    /// instead of clobbering it (last-write-wins would churn the id across
+    /// instances — the very bug this persistence exists to prevent).
+    ///
     /// # Errors
     ///
-    /// Returns an error if the id cannot be serialized or written to disk.
+    /// Returns an error when the id cannot be serialized, the temp file cannot
+    /// be written, its permissions cannot be tightened, and when the atomic link
+    /// fails for any reason other than the final path already existing.
     pub fn save_client_id(
         &self,
         backend_name: &str,
         resource_url: &str,
         client_id: &str,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let path = self.client_path(backend_name, resource_url);
         let content = serde_json::to_string(client_id)
             .map_err(|e| Error::OAuth(format!("Failed to serialize client_id: {e}")))?;
-        fs::write(&path, content)
-            .map_err(|e| Error::OAuth(format!("Failed to write client_id file: {e}")))?;
 
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("client");
+        let tmp = self
+            .base_dir
+            .join(format!("{file_name}.tmp.{}", std::process::id()));
+        fs::write(&tmp, &content)
+            .map_err(|e| Error::OAuth(format!("Failed to write client_id temp file: {e}")))?;
+
+        // Lock down permissions on the inode BEFORE it becomes reachable at the
+        // final path. A swallowed chmod would leave a public client_id file, so
+        // the error is propagated (after cleaning up the temp file).
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let perms = fs::Permissions::from_mode(0o600);
-            let _ = fs::set_permissions(&path, perms);
+            if let Err(e) = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600)) {
+                let _ = fs::remove_file(&tmp);
+                return Err(Error::OAuth(format!(
+                    "Failed to set client_id permissions: {e}"
+                )));
+            }
         }
 
-        info!(backend = %backend_name, "Saved registered OAuth client_id");
+        let result = match fs::hard_link(&tmp, &path) {
+            Ok(()) => {
+                info!(backend = %backend_name, "Saved registered OAuth client_id");
+                Ok(client_id.to_string())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Another instance won the race; adopt whatever is on disk.
+                let existing = self
+                    .load_client_id(backend_name, resource_url)
+                    .unwrap_or_else(|| client_id.to_string());
+                info!(backend = %backend_name, "client_id already persisted by another instance; adopting it");
+                Ok(existing)
+            }
+            Err(e) => Err(Error::OAuth(format!("Failed to persist client_id: {e}"))),
+        };
+        let _ = fs::remove_file(&tmp);
+        result
+    }
+
+    /// Delete a stored client id so the next connection re-registers.
+    ///
+    /// Called when the authorization server rejects the persisted id with
+    /// `invalid_client` (e.g. the registration was revoked or garbage-collected
+    /// server-side). Without this there is no in-product recovery from a stale
+    /// registration short of manual file deletion.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file exists but cannot be deleted.
+    pub fn delete_client_id(&self, backend_name: &str, resource_url: &str) -> Result<()> {
+        let path = self.client_path(backend_name, resource_url);
+        if path.exists() {
+            fs::remove_file(&path)
+                .map_err(|e| Error::OAuth(format!("Failed to delete client_id file: {e}")))?;
+            info!(backend = %backend_name, "Deleted stored OAuth client_id");
+        }
         Ok(())
     }
 }
@@ -330,17 +393,18 @@ mod tests {
 
     #[test]
     fn client_id_round_trips_and_is_absent_before_registration() {
-        let dir = std::env::temp_dir().join(format!("mcpgw-oauth-test-{}", std::process::id()));
-        let store = TokenStorage::new(dir.clone()).expect("create store");
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).expect("create store");
         let (backend, resource) = ("beeper", "http://127.0.0.1:23373/v0/mcp");
 
         // No client registered yet -> None (would trigger DCR + browser tab).
         assert_eq!(store.load_client_id(backend, resource), None);
 
         // Persist then reload -> stable id, so the next connection reuses it.
-        store
+        let persisted = store
             .save_client_id(backend, resource, "persisted-client-123")
             .expect("save client_id");
+        assert_eq!(persisted, "persisted-client-123");
         assert_eq!(
             store.load_client_id(backend, resource),
             Some("persisted-client-123".to_string())
@@ -348,8 +412,61 @@ mod tests {
 
         // A different backend must not collide.
         assert_eq!(store.load_client_id("other", resource), None);
+    }
 
-        let _ = fs::remove_dir_all(&dir);
+    #[cfg(unix)]
+    #[test]
+    fn save_client_id_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+
+        store.save_client_id(backend, resource, "cid").unwrap();
+        let path = store.client_path(backend, resource);
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "client_id file must be owner-only, got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn save_client_id_is_first_writer_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+
+        // First write wins and is returned verbatim.
+        assert_eq!(
+            store.save_client_id(backend, resource, "first").unwrap(),
+            "first"
+        );
+        // A concurrent second write does NOT clobber; it adopts the existing id.
+        assert_eq!(
+            store.save_client_id(backend, resource, "second").unwrap(),
+            "first"
+        );
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("first".to_string())
+        );
+
+        // After deletion, the next write wins again (re-registration path).
+        store.delete_client_id(backend, resource).unwrap();
+        assert_eq!(store.load_client_id(backend, resource), None);
+        assert_eq!(
+            store.save_client_id(backend, resource, "third").unwrap(),
+            "third"
+        );
+    }
+
+    #[test]
+    fn delete_client_id_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        // Deleting a non-existent record is a no-op, not an error.
+        store.delete_client_id("nope", "http://localhost").unwrap();
     }
 
     // =========================================================================

--- a/src/oauth/storage.rs
+++ b/src/oauth/storage.rs
@@ -4,6 +4,7 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -319,6 +320,12 @@ impl TokenStorage {
         resource_url: &str,
         client_id: &str,
     ) -> Result<String> {
+        // Per-call unique temp name: a static nonce plus the pid keeps two
+        // concurrent same-process registrations for the same backend from
+        // stomping on each other's temp file (which would let one call return
+        // an id that disagrees with the authoritative on-disk value).
+        static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
+
         let path = self.client_path(backend_name, resource_url);
         let content = serde_json::to_string(client_id)
             .map_err(|e| Error::OAuth(format!("Failed to serialize client_id: {e}")))?;
@@ -327,9 +334,10 @@ impl TokenStorage {
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("client");
+        let nonce = TMP_NONCE.fetch_add(1, Ordering::Relaxed);
         let tmp = self
             .base_dir
-            .join(format!("{file_name}.tmp.{}", std::process::id()));
+            .join(format!("{file_name}.tmp.{}.{nonce}", std::process::id()));
         fs::write(&tmp, &content)
             .map_err(|e| Error::OAuth(format!("Failed to write client_id temp file: {e}")))?;
 
@@ -467,6 +475,46 @@ mod tests {
         let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
         // Deleting a non-existent record is a no-op, not an error.
         store.delete_client_id("nope", "http://localhost").unwrap();
+    }
+
+    #[test]
+    fn save_client_id_concurrent_same_backend_converges() {
+        use std::sync::Arc;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+        let (backend, resource) = ("b", "http://localhost");
+
+        // Many threads register distinct ids for the SAME backend at once.
+        let barrier = Arc::new(std::sync::Barrier::new(16));
+        let handles: Vec<_> = (0..16)
+            .map(|i| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store
+                        .save_client_id(backend, resource, &format!("cid-{i}"))
+                        .expect("save")
+                })
+            })
+            .collect();
+        let returned: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Every caller must observe the SAME authoritative id (first wins), and
+        // it must match what is on disk.
+        let on_disk = store.load_client_id(backend, resource).expect("persisted");
+        assert!(
+            returned.iter().all(|r| *r == on_disk),
+            "callers disagreed with disk: returned={returned:?} disk={on_disk}"
+        );
+
+        // No temp files leaked.
+        let leaked = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .count();
+        assert_eq!(leaked, 0, "temp files leaked");
     }
 
     // =========================================================================

--- a/src/oauth/storage.rs
+++ b/src/oauth/storage.rs
@@ -303,29 +303,28 @@ impl TokenStorage {
     /// another gateway instance sharing this directory registered first.
     ///
     /// The write is atomic and never exposes a world-readable window: content
-    /// goes to a per-process temp file locked to `0600` *before* it is linked
-    /// into place. `hard_link` fails with `AlreadyExists` when the final path is
-    /// already present, so a concurrent second instance adopts the existing id
-    /// instead of clobbering it (last-write-wins would churn the id across
-    /// instances — the very bug this persistence exists to prevent).
+    /// goes to a per-process temp file created with `O_EXCL` and mode `0600`
+    /// (on unix) *before* it is linked into place. Creating with `O_EXCL` also
+    /// guarantees a leftover temp from a crashed run is never truncated/reused.
+    /// `hard_link` fails with `AlreadyExists` when the final path is already
+    /// present, so a concurrent second instance adopts the existing id instead
+    /// of clobbering it (last-write-wins would churn the id across instances —
+    /// the very bug this persistence exists to prevent). If the existing final
+    /// file is corrupt/unreadable, it is removed and the link retried once so a
+    /// validated id becomes authoritative rather than silently diverging.
     ///
     /// # Errors
     ///
-    /// Returns an error when the id cannot be serialized, the temp file cannot
-    /// be written, its permissions cannot be tightened, and when the atomic link
-    /// fails for any reason other than the final path already existing.
+    /// Returns an error when the id cannot be serialized, a unique temp file
+    /// cannot be created or written, the existing final file is unreadable and
+    /// cannot be self-healed, or the atomic link fails for any reason other than
+    /// the final path already existing.
     pub fn save_client_id(
         &self,
         backend_name: &str,
         resource_url: &str,
         client_id: &str,
     ) -> Result<String> {
-        // Per-call unique temp name: a static nonce plus the pid keeps two
-        // concurrent same-process registrations for the same backend from
-        // stomping on each other's temp file (which would let one call return
-        // an id that disagrees with the authoritative on-disk value).
-        static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
-
         let path = self.client_path(backend_name, resource_url);
         let content = serde_json::to_string(client_id)
             .map_err(|e| Error::OAuth(format!("Failed to serialize client_id: {e}")))?;
@@ -334,44 +333,132 @@ impl TokenStorage {
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("client");
-        let nonce = TMP_NONCE.fetch_add(1, Ordering::Relaxed);
-        let tmp = self
-            .base_dir
-            .join(format!("{file_name}.tmp.{}.{nonce}", std::process::id()));
-        fs::write(&tmp, &content)
+
+        // Create the temp file with O_EXCL so a leftover temp from a crashed
+        // prior run is never truncated/reused: `create_new` fails with
+        // `AlreadyExists` rather than opening (and emptying) an existing path.
+        // On unix the 0600 mode is applied atomically at creation, closing the
+        // world-readable window that a post-write chmod would otherwise leave.
+        let tmp = self.create_client_tmp(file_name)?;
+
+        #[cfg(unix)]
+        let write_result = {
+            use std::io::Write as _;
+            let (mut file, tmp) = tmp;
+            file.write_all(content.as_bytes())
+                .and_then(|()| file.sync_all())
+                .map(|()| tmp)
+        };
+        #[cfg(not(unix))]
+        let write_result = { fs::write(&tmp, &content).map(|()| tmp) };
+
+        let tmp = write_result
             .map_err(|e| Error::OAuth(format!("Failed to write client_id temp file: {e}")))?;
 
-        // Lock down permissions on the inode BEFORE it becomes reachable at the
-        // final path. A swallowed chmod would leave a public client_id file, so
-        // the error is propagated (after cleaning up the temp file).
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Err(e) = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600)) {
-                let _ = fs::remove_file(&tmp);
-                return Err(Error::OAuth(format!(
-                    "Failed to set client_id permissions: {e}"
-                )));
+        // First-writer-wins: `hard_link` fails with `AlreadyExists` when the
+        // final path already exists, so a concurrent instance adopts the
+        // existing id instead of clobbering it. A corrupt/unreadable existing
+        // file, however, is unusable — self-heal by removing it and retrying
+        // the link once so our validated temp becomes authoritative.
+        let mut heal_attempts = 0u8;
+        let result = loop {
+            match fs::hard_link(&tmp, &path) {
+                Ok(()) => {
+                    info!(backend = %backend_name, "Saved registered OAuth client_id");
+                    break Ok(client_id.to_string());
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    match self.load_client_id(backend_name, resource_url) {
+                        Some(existing) => {
+                            info!(backend = %backend_name, "client_id already persisted by another instance; adopting it");
+                            break Ok(existing);
+                        }
+                        None if heal_attempts < 1 => {
+                            // On-disk file is corrupt/unreadable; remove it and
+                            // retry the link so our validated temp wins.
+                            heal_attempts += 1;
+                            warn!(backend = %backend_name, "Existing client_id file is unreadable; removing and re-persisting from validated temp");
+                            let _ = fs::remove_file(&path);
+                        }
+                        None => {
+                            break Err(Error::OAuth(
+                                "client_id file exists but is unreadable and could not be self-healed".to_string(),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => break Err(Error::OAuth(format!("Failed to persist client_id: {e}"))),
             }
-        }
-
-        let result = match fs::hard_link(&tmp, &path) {
-            Ok(()) => {
-                info!(backend = %backend_name, "Saved registered OAuth client_id");
-                Ok(client_id.to_string())
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                // Another instance won the race; adopt whatever is on disk.
-                let existing = self
-                    .load_client_id(backend_name, resource_url)
-                    .unwrap_or_else(|| client_id.to_string());
-                info!(backend = %backend_name, "client_id already persisted by another instance; adopting it");
-                Ok(existing)
-            }
-            Err(e) => Err(Error::OAuth(format!("Failed to persist client_id: {e}"))),
         };
         let _ = fs::remove_file(&tmp);
         result
+    }
+
+    /// Atomically create a private (`0600` on unix) temp file for a `client_id`
+    /// write, retrying with a fresh nonce if a stale temp path collides.
+    ///
+    /// Returns the open [`File`] handle plus its path on unix (so the caller
+    /// writes through the same fd the mode was set on), and just the path on
+    /// other platforms.
+    #[cfg(unix)]
+    fn create_client_tmp(&self, file_name: &str) -> Result<(fs::File, PathBuf)> {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
+        for _ in 0..8 {
+            let nonce = TMP_NONCE.fetch_add(1, Ordering::Relaxed);
+            let tmp = self
+                .base_dir
+                .join(format!("{file_name}.tmp.{}.{nonce}", std::process::id()));
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&tmp)
+            {
+                Ok(file) => return Ok((file, tmp)),
+                // Stale temp collided; try the next nonce.
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(Error::OAuth(format!(
+                        "Failed to create client_id temp file: {e}"
+                    )));
+                }
+            }
+        }
+        Err(Error::OAuth(
+            "Failed to create a unique client_id temp file after 8 attempts".to_string(),
+        ))
+    }
+
+    /// Non-unix fallback: pick a fresh temp path via `create_new`, closing the
+    /// handle immediately so the caller can `fs::write` it (no unix mode bits).
+    #[cfg(not(unix))]
+    fn create_client_tmp(&self, file_name: &str) -> Result<PathBuf> {
+        static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
+        for _ in 0..8 {
+            let nonce = TMP_NONCE.fetch_add(1, Ordering::Relaxed);
+            let tmp = self
+                .base_dir
+                .join(format!("{file_name}.tmp.{}.{nonce}", std::process::id()));
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp)
+            {
+                Ok(_) => return Ok(tmp),
+                // Stale temp collided; try the next nonce.
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(Error::OAuth(format!(
+                        "Failed to create client_id temp file: {e}"
+                    )));
+                }
+            }
+        }
+        Err(Error::OAuth(
+            "Failed to create a unique client_id temp file after 8 attempts".to_string(),
+        ))
     }
 
     /// Delete a stored client id so the next connection re-registers.
@@ -515,6 +602,100 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
             .count();
         assert_eq!(leaked, 0, "temp files leaked");
+    }
+
+    #[test]
+    fn save_client_id_self_heals_corrupt_final_file() {
+        // GIVEN: an existing client_id file whose contents are corrupt
+        // (not a valid JSON string), so load_client_id() returns None.
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+        let final_path = store.client_path(backend, resource);
+        fs::write(&final_path, b"\x00\x00not json at all").unwrap();
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            None,
+            "precondition: corrupt file must be unreadable"
+        );
+
+        // WHEN: we persist a fresh id over the corrupt file.
+        let returned = store
+            .save_client_id(backend, resource, "healed-id")
+            .expect("self-heal should succeed");
+
+        // THEN: the validated id is authoritative and readable from disk,
+        // instead of silently diverging from a broken on-disk record.
+        assert_eq!(returned, "healed-id");
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("healed-id".to_string()),
+            "disk must match the returned id after self-heal"
+        );
+    }
+
+    #[test]
+    fn save_client_id_self_heals_zero_byte_final_file() {
+        // GIVEN: a zero-byte final file (empty => not a valid JSON string).
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+        fs::write(store.client_path(backend, resource), b"").unwrap();
+
+        // WHEN / THEN: save self-heals and returns a readable id.
+        let returned = store.save_client_id(backend, resource, "cid").unwrap();
+        assert_eq!(returned, "cid");
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("cid".to_string())
+        );
+    }
+
+    #[test]
+    fn save_client_id_never_truncates_a_leftover_tmp() {
+        // GIVEN: leftover temp files (as if a prior run crashed mid-write),
+        // seeded with sentinel content. O_EXCL create_new must never open —
+        // and therefore never truncate — an existing path, whether or not the
+        // nonce collides with one the writer picks.
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStorage::new(dir.path().to_path_buf()).unwrap();
+        let (backend, resource) = ("b", "http://localhost");
+
+        let file_name = store
+            .client_path(backend, resource)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap()
+            .to_string();
+        let sentinel = b"DO-NOT-TRUNCATE";
+        let leftovers: Vec<PathBuf> = (0..4)
+            .map(|n| {
+                let p = dir
+                    .path()
+                    .join(format!("{file_name}.tmp.{}.{n}", std::process::id()));
+                fs::write(&p, sentinel).unwrap();
+                p
+            })
+            .collect();
+
+        // WHEN: we persist a client_id.
+        let returned = store.save_client_id(backend, resource, "safe-id").unwrap();
+
+        // THEN: the save produced a valid, readable authoritative id...
+        assert_eq!(returned, "safe-id");
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("safe-id".to_string())
+        );
+        // ...and every seeded leftover is byte-for-byte intact (never emptied).
+        for p in &leftovers {
+            assert_eq!(
+                fs::read(p).unwrap(),
+                sentinel,
+                "leftover temp file was truncated/overwritten: {}",
+                p.display()
+            );
+        }
     }
 
     // =========================================================================

--- a/src/oauth/storage.rs
+++ b/src/oauth/storage.rs
@@ -262,11 +262,95 @@ impl TokenStorage {
 
         Ok(())
     }
+
+    /// Get the file path for a backend's dynamically-registered client id.
+    fn client_path(&self, backend_name: &str, resource_url: &str) -> PathBuf {
+        let key = Self::storage_key(backend_name, resource_url);
+        self.base_dir.join(format!("{key}_client.json"))
+    }
+
+    /// Load a previously-registered dynamic client id for a backend.
+    ///
+    /// Returns `None` if no client has been registered yet or the record is
+    /// unreadable. Persisting this is what prevents a fresh Dynamic Client
+    /// Registration (and its browser authorize tab) on every connection.
+    #[must_use]
+    pub fn load_client_id(&self, backend_name: &str, resource_url: &str) -> Option<String> {
+        let path = self.client_path(backend_name, resource_url);
+        if !path.exists() {
+            return None;
+        }
+        match fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<String>(&content) {
+                Ok(id) => Some(id),
+                Err(e) => {
+                    warn!(backend = %backend_name, error = %e, "Failed to parse stored client_id");
+                    None
+                }
+            },
+            Err(e) => {
+                warn!(backend = %backend_name, error = %e, "Failed to read client_id file");
+                None
+            }
+        }
+    }
+
+    /// Persist a dynamically-registered client id for a backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the id cannot be serialized or written to disk.
+    pub fn save_client_id(
+        &self,
+        backend_name: &str,
+        resource_url: &str,
+        client_id: &str,
+    ) -> Result<()> {
+        let path = self.client_path(backend_name, resource_url);
+        let content = serde_json::to_string(client_id)
+            .map_err(|e| Error::OAuth(format!("Failed to serialize client_id: {e}")))?;
+        fs::write(&path, content)
+            .map_err(|e| Error::OAuth(format!("Failed to write client_id file: {e}")))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o600);
+            let _ = fs::set_permissions(&path, perms);
+        }
+
+        info!(backend = %backend_name, "Saved registered OAuth client_id");
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_id_round_trips_and_is_absent_before_registration() {
+        let dir = std::env::temp_dir().join(format!("mcpgw-oauth-test-{}", std::process::id()));
+        let store = TokenStorage::new(dir.clone()).expect("create store");
+        let (backend, resource) = ("beeper", "http://127.0.0.1:23373/v0/mcp");
+
+        // No client registered yet -> None (would trigger DCR + browser tab).
+        assert_eq!(store.load_client_id(backend, resource), None);
+
+        // Persist then reload -> stable id, so the next connection reuses it.
+        store
+            .save_client_id(backend, resource, "persisted-client-123")
+            .expect("save client_id");
+        assert_eq!(
+            store.load_client_id(backend, resource),
+            Some("persisted-client-123".to_string())
+        );
+
+        // A different backend must not collide.
+        assert_eq!(store.load_client_id("other", resource), None);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 
     // =========================================================================
     // TokenInfo::from_response


### PR DESCRIPTION
## Problem

The gateway's OAuth client performs Dynamic Client Registration (RFC 7591) against a backend, but keeps the resulting `client_id` in an in-memory lock only — it is never written to disk. Every process restart or reconnect without a live cached token starts at `client_id = None`, re-registers a brand-new client, and opens a fresh browser authorize tab. The loop cannot converge.

Observed live against the Beeper backend: three consecutive connections produced three distinct `client_id`s and three localhost OAuth popups.

This affects the released line too — `src/oauth/client/mod.rs` in `v3.1.3` has the identical defect (verified: files byte-identical between the tag and this fix's base).

## Fix

- **storage**: add `save_client_id` / `load_client_id` — a `<key>_client.json` sidecar, `0600` perms, same sha256 keying as the existing token sidecar.
- **client**: restore the persisted `client_id` on `init()`; persist it the instant dynamic registration succeeds (before the browser step, so a half-finished flow still can't trigger a re-register).
- **test**: `client_id` round-trip, absence before registration, no cross-backend collision.

Register once, reuse across restarts.

## Validation

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` zero warnings
- `cargo test` — 137 oauth-scope tests pass, 0 fail (incl. new test)
- pre-push hook (fmt + clippy + full test) passed

## Scope / release

No version bump, no tag, no release in this PR. Held for CI + operator sign-off per instruction: no new release until confident all issues are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)