### PR TITLE
chore(release): 3.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.1.3"
+version = "3.1.4"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
Patch release cut from the current main tip (ba492d2f).

## Scope
Two-line version bump (Cargo manifest + lockfile, 3.1.3 to 3.1.4). Ships the #341 fix (persist dynamically-registered client_id across restarts, an OAuth reconnect-loop fix) that is already merged to main.

## Security posture (verified)
3.1.3 already contains the full multi-user OAuth isolation stack: the INV-2 fail-closed guard wired into the live tool-call dispatch path, RFC 9728 protected-resource metadata, and identity propagation. No cross-user token-leak exposure in any deployment. The stale multi-user hold branch carried zero unique code and was removed.

## Semver
Patch. No new API or config surface; bugfix plus already-shipped hardening.

Release pipeline is tag-driven: OSV scan, then fmt and clippy and test, then five-platform build, then GitHub release, then crates and npm and Homebrew. Tag v3.1.4 pushed after merge.

Generated with Claude Code
