### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes the release blocker on the v3.1.4 tag: the OSV dependency-vulnerability gate flagged a newly-disclosed advisory (RUSTSEC-2026-0204) in the transitive crate crossbeam-epoch 0.9.18, fixed in 0.9.20.

## Change
Lockfile-only bump crossbeam-epoch 0.9.18 to 0.9.20. No manifest or source change.

## Why now
3.1.3 released clean yesterday; this advisory landed after. The release-time OSV re-scan is exactly the backstop that caught it before publish. No 3.1.4 artifact was ever published (every publish job was skipped when the gate failed), so v3.1.4 will be re-cut on the fixed commit.

Generated with Claude Code
