### PR TITLE
license(ee): mark multi-user identity/grant files PolyForm-Noncommercial + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: tests/public_repo_hygiene.sh
       - name: Validate tracked public docs boundary
         run: scripts/dev/check-public-repo-hygiene.sh
+      - name: Enforce EE (PolyForm-Noncommercial) headers on multi-user files
+        run: scripts/ci/check-ee-license-headers.sh
 
   service-template-smoke:
     name: Service template smoke

--- a/LICENSE-EE.md
+++ b/LICENSE-EE.md
@@ -28,7 +28,16 @@ are licensed under the **PolyForm Noncommercial** license (version 1.0.0). All o
 - `src/cost_accounting/`
 - `src/key_server/`
 - `src/transparency_log/` (new in v2.11, per MIK-3034)
+- `src/identity_propagation/` (v3.1, ADR-007 — end-user identity propagation to backends, a multi-user/multitenant feature)
+- `src/identity_grants.rs` and `src/identity_grants_tests.rs` (MIK-6553 — identity-scoped capability grants, a multi-user access-control feature)
+- `src/cli/identity.rs` and `src/commands/identity.rs` (grant administration surface for the above)
 - Future EE features per `docs/plans/`
+
+All multi-user / multitenant features (per-user identity, per-user capability
+grants, per-user OAuth isolation, and their administration surfaces) are
+Enterprise Edition and carry the PolyForm-Noncommercial SPDX header. This has
+applied since those features were introduced; the header/coverage-list entries
+above were reconciled to match that intent.
 
 ## Summary of PolyForm Noncommercial terms
 

--- a/scripts/ci/check-ee-license-headers.sh
+++ b/scripts/ci/check-ee-license-headers.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check-ee-license-headers.sh
+#
+# Enforce that every Enterprise Edition (EE) source file carries the
+# PolyForm-Noncommercial SPDX header. EE = the multi-user / multitenant and
+# security-governance features designated in LICENSE-EE.md.
+#
+# Why this exists: multi-user features (identity propagation, per-user
+# capability grants, per-user OAuth isolation, and their admin surfaces) are
+# EE by policy. A file that implements one of them but ships without the SPDX
+# header leaks EE code under the repo's MIT default. This guard fails CI so
+# that can't happen silently again.
+#
+# Adding a new EE file: give it the header AND add its path below (keep this
+# list in sync with LICENSE-EE.md).
+set -euo pipefail
+
+HEADER='// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0'
+
+# EE-designated directories (every *.rs under them must carry the header).
+EE_DIRS=(
+  src/security/firewall
+  src/cost_accounting
+  src/key_server
+  src/transparency_log
+  src/identity_propagation
+)
+
+# EE-designated individual files.
+EE_FILES=(
+  src/security/agent_identity.rs
+  src/security/data_flow.rs
+  src/security/message_signing.rs
+  src/security/policy.rs
+  src/security/response_inspect.rs
+  src/security/response_scanner.rs
+  src/security/scope_collision.rs
+  src/security/tool_integrity.rs
+  src/identity_grants.rs
+  src/identity_grants_tests.rs
+  src/cli/identity.rs
+  src/commands/identity.rs
+)
+
+missing=()
+
+check() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  if [ "$(head -n 1 "$f")" != "$HEADER" ]; then
+    missing+=("$f")
+  fi
+}
+
+for d in "${EE_DIRS[@]}"; do
+  if [ -d "$d" ]; then
+    while IFS= read -r f; do check "$f"; done < <(find "$d" -name '*.rs')
+  fi
+done
+for f in "${EE_FILES[@]}"; do check "$f"; done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "error: the following EE files are missing the PolyForm-Noncommercial SPDX header:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "" >&2
+  echo "Add '$HEADER' as the first line. See LICENSE-EE.md. Multi-user/multitenant" >&2
+  echo "and security-governance features are Enterprise Edition, not MIT." >&2
+  exit 1
+fi
+
+echo "ok: all ${#EE_FILES[@]} designated EE files + EE directories carry the PolyForm-Noncommercial header"

--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 //! Identity and local grant administration CLI definitions.
 
 use std::path::PathBuf;

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 //! Identity and local grant administration command handlers.
 
 use std::{

--- a/src/identity_grants.rs
+++ b/src/identity_grants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 //! Identity-scoped capability grants for personal MCP tools.
 //!
 //! This module is the MIK-6553 grant contract. It models who may use a

--- a/src/identity_grants_tests.rs
+++ b/src/identity_grants_tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 use chrono::{Duration, TimeZone};
 
 use super::*;


### PR DESCRIPTION
## Problem
The multi-user capability-grant engine (`identity_grants.rs`, MIK-6553) and its CLI/command surface shipped under the repo's **MIT default** when they should have been **Enterprise Edition (PolyForm-Noncommercial)** from the start — the same class as the already-EE `identity_propagation/` module. Multi-user / multitenant features are EE by policy.

## Fix
- Add the `SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0` header to:
  - `src/identity_grants.rs`, `src/identity_grants_tests.rs`
  - `src/cli/identity.rs`, `src/commands/identity.rs`
- **LICENSE-EE.md**: reconcile the coverage list — it was missing `identity_propagation/` (already header-marked) and the grant engine. Added them + the blanket rule that all multi-user features are EE.
- **New CI guard** `scripts/ci/check-ee-license-headers.sh` (wired into `public-repo-hygiene`): fails if any EE-designated file lacks the header, so a future multi-user file can't leak under MIT again.

Headers are comments — no behaviour change.

## One boundary call for you
`src/mtls/identity.rs` is X.509 **certificate identity extraction** — a generic parser that serves multi-user mTLS auth but is arguably a shared primitive. I left it **MIT** pending your call. If mTLS client identity counts as a multi-user feature under the blanket rule, I'll add it to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)