### PR TITLE
fix(release): commit Cargo.lock 3.3.0 bump + correct license-header docs wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
 mcp-gateway uses mixed, per-file licensing.
 
-- Files whose first line is `// SPDX-License-Identifier: MIT` are licensed under
-  the MIT License: see LICENSE-MIT.
+- Files whose header carries `// SPDX-License-Identifier: MIT` (on the line
+  immediately following the SPDX-FileCopyrightText copyright line) are licensed
+  under the MIT License: see LICENSE-MIT.
 - Every other file is licensed under the PolyForm Noncommercial License 1.0.0:
   see LICENSE-NONCOMMERCIAL. This is the default; absence of an MIT header means
   PolyForm-Noncommercial.

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -4,8 +4,9 @@ mcp-gateway uses **mixed, per-file licensing**.
 
 ## The rule
 
-- Files whose first line is `// SPDX-License-Identifier: MIT` are licensed under
-  the **MIT License** (see [`LICENSE-MIT`](LICENSE-MIT)).
+- Files whose header carries `// SPDX-License-Identifier: MIT` (on the line
+  immediately following the `SPDX-FileCopyrightText` copyright line) are licensed
+  under the **MIT License** (see [`LICENSE-MIT`](LICENSE-MIT)).
 - **Every other file is licensed under the PolyForm Noncommercial License 1.0.0**
   (see [`LICENSE-NONCOMMERCIAL`](LICENSE-NONCOMMERCIAL)). This is the
   **default** — absence of an MIT header means PolyForm-Noncommercial.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -5,19 +5,22 @@ metadata and artifacts indicating the **MIT License**.
 
 Beginning with version **3.3.0**, mcp-gateway uses a **mixed, per-file
 licensing** model: the repository default is **PolyForm Noncommercial 1.0.0**,
-and only files whose first content line is `// SPDX-License-Identifier: MIT`
-are MIT-licensed. See [`LICENSES.md`](LICENSES.md) for the full model.
+and only files whose header carries `// SPDX-License-Identifier: MIT`
+(immediately below the copyright line) are MIT-licensed. See
+[`LICENSES.md`](LICENSES.md) for the full model.
 
 **Rights already granted under MIT are not revoked.** The MIT License is
 irrevocable and perpetual for copies already distributed. If you obtained
 mcp-gateway 3.0.0–3.2.1 under MIT, your rights to **those exact artifacts, as
 distributed in those versions,** are unchanged.
 
-That MIT grant covers only the code as it existed in those releases. Combining
-or updating any of that code with v3.3.0 or later subjects the combined or
-updated work to the current per-file licensing (see `LICENSES.md`). The "MIT
-core" carve-out introduced in v3.3.0 did not exist in the same form in
-3.0.0–3.2.1.
+That MIT grant covers the code as distributed in those releases; you may
+continue to use, modify, and combine that code under MIT, and combining it with
+other work does not retroactively change its license. The MIT grant does not,
+however, extend to v3.3.0-or-later code: any file taken from v3.3.0 or later is
+governed by its own per-file license (see `LICENSES.md`), whatever it is
+combined with. The "MIT core" carve-out introduced in v3.3.0 did not exist in
+the same form in 3.0.0–3.2.1.
 
 Versions 3.0.0–3.2.1 are **deprecated** and are provided **AS IS**, without
 warranty, support, security updates, or maintenance. As part of the v3.3.0
@@ -28,8 +31,8 @@ no longer the recommended or supported versions.
 
 **Starting with version 3.3.0:**
 
-- Files whose first content line is `// SPDX-License-Identifier: MIT` are
-  MIT-licensed, and carry a copyright line above it.
+- Files whose header carries `// SPDX-License-Identifier: MIT` immediately below
+  the copyright line are MIT-licensed.
 - Every other first-party file is licensed under PolyForm Noncommercial 1.0.0
   and carries an explicit `// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0`
   header.

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ mcp-gateway uses **mixed, per-file licensing**, and the default is Noncommercial
 
 | Scope | License |
 |-------|---------|
-| Files whose first line is `// SPDX-License-Identifier: MIT` | MIT ([LICENSE-MIT](LICENSE-MIT)) |
+| Files whose header carries `// SPDX-License-Identifier: MIT` (below the copyright line) | MIT ([LICENSE-MIT](LICENSE-MIT)) |
 | Everything else (the default) | PolyForm Noncommercial 1.0.0 ([LICENSE-NONCOMMERCIAL](LICENSE-NONCOMMERCIAL)) |
 
 If a file is not explicitly marked MIT, it is Noncommercial. The MIT core is a


### PR DESCRIPTION
## What

Follow-up to the v3.3.0 relicense (#349). Three fixes, one release-blocking.

### 1. Release fix (blocking)
Commit the Cargo.lock `mcp-gateway` version bump `3.2.1 -> 3.3.0`. The tag
shipped `Cargo.toml` at 3.3.0 but a stale lockfile still pinning 3.2.1. On a
clean CI checkout cargo rewrites that line during resolution, leaving the
worktree dirty, so `cargo publish --locked --dry-run` in the Release `verify`
job aborts (exit 101) and every downstream job — build, release, npm-publish,
publish, homebrew — is skipped. Net effect: v3.3.0 published to no registry.

### 2. Header-format wording
The license docs described an MIT file's "first line" as
`// SPDX-License-Identifier: MIT`. The enforced header actually places the
`SPDX-FileCopyrightText` copyright line first and the identifier on the line
immediately below it. NOTICE.md also contradicted itself. Reworded LICENSE,
LICENSES.md, README.md, and NOTICE.md to match the enforced format.

### 3. Combination claim
NOTICE.md stated that combining or updating 3.0.0–3.2.1 MIT code with v3.3.0+
subjects the combined work to the current per-file licensing. MIT is
irrevocable and combination does not retroactively change a file's license.
Reworded to the accurate position: the prior MIT grant persists; any file taken
from v3.3.0+ is governed by its own per-file license whatever it is combined
with.

## Evidence

- V: Release run 29171384334 `verify` job — `error: 1 files in the working
  directory contain changes that were not yet committed into git: Cargo.lock`
  → exit 101, downstream jobs skipped.
- V: enforced header format — `scripts/ci/check-license-headers.sh` reads the
  copyright line first and the SPDX identifier second.
- I: Cargo.lock diff is a single line (`3.2.1 -> 3.3.0`), no dependency churn.
- A: after this change a fresh checkout is clean, so the verify gate passes and
  the release can proceed.

No code or enforced-header logic changed.
