### PR TITLE
fix(release): Cargo.lock mcp-gateway 3.2.1 -> 3.3.0 (unblocks publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
The v3.3.0 tag ships Cargo.toml at 3.3.0 but Cargo.lock still pinned the
mcp-gateway package at 3.2.1. On a clean CI checkout cargo rewrites that line
during resolution, leaving the worktree dirty, so cargo publish --locked
--dry-run in the Release verify job aborts (exit 101) and every downstream
publish job is skipped. Result: v3.3.0 published to no registry (runs
29171384334 and 29171781731 both failed here).

This commits the one-line lockfile bump so a fresh checkout is clean and verify
passes.

V: Release run 29171781731 verify log — dirty Cargo.lock, exit 101.
I: single-line diff, no dependency churn.
A: with the committed lock at 3.3.0 the dirty check passes and the release can
publish.