### PR TITLE
fix(ci): bump npm-publish Node to 22 (npm@12 needs Node >=22)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,10 +236,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Node 20 bundles npm 10.x; OIDC trusted publishing requires npm >= 11.5.1.
+      # Node 22 bundles npm 10.x; OIDC trusted publishing requires npm >= 11.5.1,
+      # and current npm@latest (12.x) requires Node >= 22.22.2, so pin Node 22.
       - name: Upgrade npm CLI for OIDC trusted publishing
         run: npm install -g npm@latest
 


### PR DESCRIPTION
npm-publish pinned Node 20 then `npm install -g npm@latest`. npm@latest is now 12.0.1 (engines: Node ^22.22.2||^24||>=26), so the upgrade aborted EBADENGINE on the Node 20 runner — the only failing job in Release run 29172330065, while crates.io, Docker, Homebrew, and the GitHub release all published v3.3.0. Pin Node 22 so the npm upgrade installs. Dispatched against v3.3.0 to publish the missing npm package; this PR makes the fix durable on main.