### PR TITLE
ci(security): add CWE-532 secret-leak lint gate and wire into release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Test the leak-lint parser (fail on parser regression)
+        run: python3 scripts/dev/test_cwe532_leak_lint.py
       - name: Run CWE-532 leak lint
         run: python3 scripts/dev/cwe532-leak-lint.py src crates
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,11 +270,30 @@ jobs:
         with:
           extra_args: --only-verified
 
+  secret-leak-lint:
+    name: Secret-leak lint (CWE-532)
+    # Semantic check that trufflehog/osv-scanner don't cover: a struct that
+    # derives Debug (or a log/print macro) over a field/variable whose name
+    # is secret-shaped leaks *structure*, not a matched credential string —
+    # trufflehog only flags verified live secret VALUES it can see in the
+    # diff. This is the class of bug fixed in #323 (redact credentials from
+    # Debug output). Pure stdlib Python, no extra deps, so it stays fast.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run CWE-532 leak lint
+        run: python3 scripts/dev/cwe532-leak-lint.py src crates
+
   docker:
     name: Docker
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, test, fmt, audit, public-claims, public-repo-hygiene, service-template-smoke, usability-smoke, helm-chart-smoke, helm-oci-roundtrip, helm-supply-chain, helm-airgap]
+    # secrets-scan + secret-leak-lint added so the container image release
+    # path can't ship on a tag whose push already failed a security check —
+    # previously this job's needs: covered clippy/test/fmt/audit but not the
+    # security jobs, so a red secrets-scan or leak-lint would not have
+    # blocked ghcr.io publish.
+    needs: [check, test, fmt, audit, secrets-scan, secret-leak-lint, public-claims, public-repo-hygiene, service-template-smoke, usability-smoke, helm-chart-smoke, helm-oci-roundtrip, helm-supply-chain, helm-airgap]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,33 @@ jobs:
             --recursive
             ./
 
+  # Second release backstop, alongside security-gate: the semantic CWE-532
+  # leak lint (ci.yml's secret-leak-lint job re-implemented as a dependency
+  # here rather than a cross-workflow needs:, since GitHub Actions has no
+  # native "wait for a different workflow on the same ref" primitive short
+  # of workflow_run, which would desync from this workflow's own tag
+  # trigger). Same script, same baseline file — see scripts/dev/
+  # cwe532-leak-lint.py and scripts/dev/cwe532-baseline.txt.
+  #
+  # NOTE (manual release-checklist item, not automated here): before tagging
+  # a release, also check for open P0/P1 security tickets in the tracker —
+  # this gate only catches what static analysis can see, not triaged/known
+  # issues awaiting a fix.
+  #
+  # NOTE: this repo has no CodeQL workflow as of this gate's introduction
+  # (verified: no `.github/workflows/*codeql*` and no
+  # `github/codeql-action/analyze` step anywhere in .github/workflows/).
+  # If CodeQL is added later, wire it into this same needs: chain.
+  secret-leak-lint:
+    name: Secret-leak lint (CWE-532)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run CWE-532 leak lint
+        run: python3 scripts/dev/cwe532-leak-lint.py src crates
+
   verify:
-    needs: security-gate
+    needs: [security-gate, secret-leak-lint]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Test the leak-lint parser (fail on parser regression)
+        run: python3 scripts/dev/test_cwe532_leak_lint.py
       - name: Run CWE-532 leak lint
         run: python3 scripts/dev/cwe532-leak-lint.py src crates
 

--- a/scripts/dev/cwe532-baseline.txt
+++ b/scripts/dev/cwe532-baseline.txt
@@ -1,0 +1,46 @@
+# cwe532-leak-lint baseline — pre-existing, NOT-YET-FIXED CWE-532 risk.
+#
+# These 21 entries are genuine findings, not false positives. PR #323
+# (fix(security): redact credentials from Debug output) fixed 6 structs
+# across 4 files (gateway/auth.rs, security/message_signing.rs,
+# key_server/handler.rs, key_server/store.rs) with manual `impl Debug`
+# redaction. This gate was introduced afterward and found this list of
+# additional structs with the same shape of risk (secret-named field under
+# `#[derive(Debug)]`) that PR #323 did not touch.
+#
+# This file exists so the gate can go live today without (a) silently
+# `ci-allow`-ing real secrets as if they were false positives — dishonest —
+# or (b) requiring an unscoped src/ remediation pass bundled into an
+# unrelated CI-tooling change. It grandfathers ONLY these exact
+# (file, struct, field) triples. Any NEW secret-shaped Debug-derived field,
+# anywhere, still fails the build immediately — this file does not widen to
+# cover future code.
+#
+# Remediation path per entry (same pattern as PR #323): replace
+# `#[derive(Debug)]` with a manual `impl std::fmt::Debug` that redacts the
+# named field (e.g. via a fingerprint/hash helper, or a fixed
+# "<redacted>" literal), then delete the corresponding line below.
+#
+# Follow-up: file a tracking issue enumerating this list before relying on
+# this baseline long-term — it is a bootstrap aid, not a permanent waiver.
+src/capability/definition/mod.rs|debug|WebhookDefinition.secret
+src/capability/executor/credentials.rs|debug|RefreshTokenResponse.access_token
+src/capability/executor/credentials.rs|debug|RefreshTokenResponse.refresh_token
+src/config/features/auth.rs|debug|AuthConfig.bearer_token
+src/config/features/auth.rs|debug|AuthConfig.api_keys
+src/config/features/auth.rs|debug|AgentDefinitionConfig.hs256_secret
+src/config/features/key_server.rs|debug|KeyServerConfig.admin_token
+src/config/features/security.rs|debug|TransparencyLogConfig.shared_secret
+src/config/features/security.rs|debug|MessageSigningConfig.shared_secret
+src/config/features/security.rs|debug|MessageSigningConfig.previous_secret
+src/config/mod.rs|debug|BackendConfig.secrets
+src/config/mod.rs|debug|OAuthConfig.client_secret
+src/gateway/oauth/agents.rs|debug|AgentDefinition.hs256_secret
+src/oauth/client/mod.rs|debug|TokenResponse.access_token
+src/oauth/client/mod.rs|debug|TokenResponse.refresh_token
+src/oauth/client/mod.rs|debug|ClientRegistrationResponse.client_secret
+src/oauth/client/mod.rs|debug|OAuthClientConfig.client_secret
+src/oauth/storage.rs|debug|TokenInfo.access_token
+src/oauth/storage.rs|debug|TokenInfo.refresh_token
+src/oauth/storage.rs|debug|TokenInfo.client_secret
+src/security/transparency_log.rs|debug|TransparencyLogConfig.shared_secret

--- a/scripts/dev/cwe532-baseline.txt
+++ b/scripts/dev/cwe532-baseline.txt
@@ -1,46 +1,20 @@
-# cwe532-leak-lint baseline — pre-existing, NOT-YET-FIXED CWE-532 risk.
+# cwe532-leak-lint baseline — CLEAN RATCHET AT ZERO.
 #
-# These 21 entries are genuine findings, not false positives. PR #323
-# (fix(security): redact credentials from Debug output) fixed 6 structs
-# across 4 files (gateway/auth.rs, security/message_signing.rs,
-# key_server/handler.rs, key_server/store.rs) with manual `impl Debug`
-# redaction. This gate was introduced afterward and found this list of
-# additional structs with the same shape of risk (secret-named field under
-# `#[derive(Debug)]`) that PR #323 did not touch.
+# This file intentionally contains ZERO entries. It is retained (not deleted)
+# so the gate still loads a baseline and the ratchet stays wired: any NEW
+# secret-shaped Debug-derived field or secret-shaped log/trace value, anywhere,
+# fails the build immediately.
 #
-# This file exists so the gate can go live today without (a) silently
-# `ci-allow`-ing real secrets as if they were false positives — dishonest —
-# or (b) requiring an unscoped src/ remediation pass bundled into an
-# unrelated CI-tooling change. It grandfathers ONLY these exact
-# (file, struct, field) triples. Any NEW secret-shaped Debug-derived field,
-# anywhere, still fails the build immediately — this file does not widen to
-# cover future code.
+# History: this baseline once grandfathered 21 pre-existing (file, struct,
+# field) triples — genuine CWE-532 risks that PR #323 (fix(security): redact
+# credentials from Debug output) had not yet reached. All 21 have since been
+# remediated with manual `impl std::fmt::Debug` redactions that mask the secret
+# field(s) while keeping non-secret fields visible (same pattern as PR #323 in
+# gateway/auth.rs, security/message_signing.rs, oauth/storage.rs). The baseline
+# was then emptied — the honest end state: no real secret is `ci-allow`-ed as a
+# false positive, and no debt is parked here.
 #
-# Remediation path per entry (same pattern as PR #323): replace
-# `#[derive(Debug)]` with a manual `impl std::fmt::Debug` that redacts the
-# named field (e.g. via a fingerprint/hash helper, or a fixed
-# "<redacted>" literal), then delete the corresponding line below.
-#
-# Follow-up: file a tracking issue enumerating this list before relying on
-# this baseline long-term — it is a bootstrap aid, not a permanent waiver.
-src/capability/definition/mod.rs|debug|WebhookDefinition.secret
-src/capability/executor/credentials.rs|debug|RefreshTokenResponse.access_token
-src/capability/executor/credentials.rs|debug|RefreshTokenResponse.refresh_token
-src/config/features/auth.rs|debug|AuthConfig.bearer_token
-src/config/features/auth.rs|debug|AuthConfig.api_keys
-src/config/features/auth.rs|debug|AgentDefinitionConfig.hs256_secret
-src/config/features/key_server.rs|debug|KeyServerConfig.admin_token
-src/config/features/security.rs|debug|TransparencyLogConfig.shared_secret
-src/config/features/security.rs|debug|MessageSigningConfig.shared_secret
-src/config/features/security.rs|debug|MessageSigningConfig.previous_secret
-src/config/mod.rs|debug|BackendConfig.secrets
-src/config/mod.rs|debug|OAuthConfig.client_secret
-src/gateway/oauth/agents.rs|debug|AgentDefinition.hs256_secret
-src/oauth/client/mod.rs|debug|TokenResponse.access_token
-src/oauth/client/mod.rs|debug|TokenResponse.refresh_token
-src/oauth/client/mod.rs|debug|ClientRegistrationResponse.client_secret
-src/oauth/client/mod.rs|debug|OAuthClientConfig.client_secret
-src/oauth/storage.rs|debug|TokenInfo.access_token
-src/oauth/storage.rs|debug|TokenInfo.refresh_token
-src/oauth/storage.rs|debug|TokenInfo.client_secret
-src/security/transparency_log.rs|debug|TransparencyLogConfig.shared_secret
+# Do NOT add entries to re-grandfather new findings. Fix the code instead: give
+# the struct a manual redacting `impl Debug`, or — only for a provable false
+# positive — annotate the site with `// ci-allow-secret-debug: <reason>` /
+# `// ci-allow-secret-log: <reason>`.

--- a/scripts/dev/cwe532-leak-lint.py
+++ b/scripts/dev/cwe532-leak-lint.py
@@ -197,6 +197,53 @@ BARE_TAIL_RE = re.compile(
     r"(?:\.(?:clone|to_string|as_str|as_ref|as_deref|to_owned)\(\))*$"
 )
 
+# A "simple accessor chain" VALUE: a base identifier followed by any number of
+# field accesses (`.field`) or no-arg-ish method calls (`.method()`), with an
+# optional leading `&`/`*` and a trailing `?`. This is broader than
+# BARE_TAIL_RE (which whitelists only a handful of no-op accessors) and exists
+# to catch a secret-shaped VALUE wrapped in accessors on a *neutral*-named
+# structured field, e.g. `value = %access_token.expose_secret()` or
+# `v = %token.as_deref().unwrap()` — both leak the secret bytes to the sink
+# while the field NAME check and BARE_TAIL_RE stay blind. Method arguments are
+# constrained to a single non-paren group so genuine expressions (closures,
+# nested calls, arithmetic) are NOT treated as simple chains and do not widen
+# the false-positive surface.
+SIMPLE_ACCESSOR_CHAIN_RE = re.compile(
+    r"^&?\**[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:\.\s*[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^()]*\))?)*"
+    r"\??$"
+)
+
+# Method-call accessors that PRESERVE the secret value: the credential (or a
+# trivial re-wrapping of it — a slice, an owned copy, the inner `Option`
+# payload) still reaches the log sink. A chain built only of these over a
+# secret-shaped base is a genuine CWE-532 leak.
+#
+# Any method call OUTSIDE this set (`.is_some()`, `.len()`, `.count()`,
+# `.time_until_expiry()`, `.hash()`, `.fingerprint()`) transforms the secret
+# into a derived NON-secret — a bool, count, Duration, or digest — which is not
+# a leak. Excluding those preserves the existing numeric / bool / Duration
+# exclusions on the value side of the accessor chain.
+SECRET_PRESERVING_ACCESSORS = frozenset(
+    {
+        "clone",
+        "to_string",
+        "to_owned",
+        "as_str",
+        "as_ref",
+        "as_deref",
+        "as_bytes",
+        "as_slice",
+        "expose_secret",
+        "expose",
+        "unwrap",
+        "unwrap_or_default",
+        "borrow",
+        "deref",
+        "trim",
+    }
+)
+
 
 @dataclass
 class Finding:
@@ -500,6 +547,66 @@ def value_is_provably_safe(value: str) -> bool:
     return False
 
 
+def accessor_chain_secret(value: str) -> str | None:
+    """Return a secret-shaped identifier if `value` is a simple accessor chain
+    that EXPOSES a secret-shaped base/field, else None.
+
+    Catches a secret VALUE wrapped in a secret-preserving accessor chain on a
+    NEUTRAL-named structured field — `value = %access_token.expose_secret()`,
+    `v = %token.as_deref().unwrap()` — which the field-NAME check and
+    BARE_TAIL_RE (narrow accessor whitelist) both miss.
+
+    Two conditions must both hold, keeping the false-positive surface narrow:
+
+    1. Every `.method(...)` segment is in `SECRET_PRESERVING_ACCESSORS`. A
+       single transforming call (`.is_some()`, `.len()`, `.time_until_expiry()`)
+       means the logged value is a derived bool / count / Duration, not the
+       secret — so the chain is NOT flagged (preserves the existing
+       numeric/bool/Duration exclusions on the value side).
+    2. The TERMINAL data segment — the last field/base identifier the chain
+       actually yields (trailing preserving-method calls don't change which
+       value is logged) — is secret-shaped and not safe-by-name. Checking the
+       terminal, not the base, is what separates `token.expose_secret()` (logs
+       the secret → flag) from `token_response.expires_in` (logs a numeric
+       field of a secret-*named* container → safe).
+    """
+    v = value.strip()
+    if not v or v.startswith('"'):
+        return None
+    # A terminal count / label / duration accessor (`config.secrets.len()`,
+    # `rule.name.clone()`) logs a number or label, never the secret bytes —
+    # reuse the same provably-safe guard the field-name branch applies so this
+    # broader chain scan does not regress those benign audit-log call sites.
+    if value_is_provably_safe(v):
+        return None
+    if not SIMPLE_ACCESSOR_CHAIN_RE.match(v):
+        return None
+    body = v.lstrip("&*").rstrip("?")
+    terminal_data: str | None = None
+    for seg in body.split("."):
+        seg = seg.strip().rstrip("?").strip()
+        if not seg:
+            continue
+        if "(" in seg:
+            # A `.method(...)` call. If it transforms the secret into a derived
+            # non-secret, the whole value is safe — bail out. Preserving calls
+            # (`.expose_secret()`, `.unwrap()`, `.clone()`) leave the logged
+            # value equal to the preceding data expression, so they do not
+            # change `terminal_data`.
+            method = seg.split("(", 1)[0].strip()
+            if method not in SECRET_PRESERVING_ACCESSORS:
+                return None
+            continue
+        # A data-access segment (base identifier or `.field`): this is now the
+        # value the chain yields unless a later data/method segment follows.
+        terminal_data = seg
+    if terminal_data and SECRET_RE.search(terminal_data) and not is_safe_by_name(
+        terminal_data
+    ):
+        return terminal_data
+    return None
+
+
 def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     # Join with a joined-text + per-char line map so a macro call spanning
@@ -547,6 +654,15 @@ def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
                 bare = is_bare_secret_arg(fval)
                 if bare:
                     flagged_names.append(bare)
+                    continue
+                # A secret-shaped value wrapped in a simple accessor chain is
+                # still a leak even when the field NAME is neutral:
+                # `value = %access_token.expose_secret()`,
+                # `v = %token.as_deref().unwrap()`. BARE_TAIL_RE's narrow
+                # accessor whitelist and the field-name check both miss this.
+                chained = accessor_chain_secret(fval)
+                if chained:
+                    flagged_names.append(chained)
                     continue
                 # Otherwise flag on the field NAME — but only when the value is
                 # not provably a benign label/count/duration. This catches a

--- a/scripts/dev/cwe532-leak-lint.py
+++ b/scripts/dev/cwe532-leak-lint.py
@@ -79,6 +79,30 @@ SAFE_FIELD_SUFFIXES = (
     "_fingerprint",
     "_type",
     "_types",
+    # An OAuth/RFC-8693 `scope` is a permission identifier advertised in
+    # authorization requests and consent screens (e.g. `api://backend/.default`).
+    # It is public by construction, never live credential material — unlike an
+    # access_token or client_secret. Covers `token_exchange_scope`, `oauth_scope`.
+    "_scope",
+    "_scopes",
+    # Time quantities (TTL / durations / timestamps). A `token_ttl_secs` or
+    # `token_expiry_ms` is a NUMBER, never credential material — same rationale
+    # as NUMERIC_OR_BOOL_TYPE_RE, applied by name where no type is available
+    # (e.g. structured log fields).
+    "_secs",
+    "_seconds",
+    "_ms",
+    "_millis",
+    "_ttl",
+    "_duration",
+)
+
+# Bare identifier names that are labels / counts / sizes, never secret values.
+# Used chiefly to classify the VALUE of a structured log field: logging
+# `credential = %rule.name` writes the rule's human-readable *name*, not the
+# secret bytes, so it is not a CWE-532 leak.
+SAFE_EXACT_NAMES = frozenset(
+    {"name", "names", "id", "ids", "count", "counts", "len", "length", "index"}
 )
 
 # Substring (not just suffix) exclusions: OAuth discovery metadata
@@ -138,10 +162,29 @@ LOG_MACROS = (
     "println",
     "eprintln",
     "print",
+    # `dbg!` prints its expression to stderr (Debug-formatted) — a classic
+    # accidental-leak sink left in after debugging. `panic!`/`unimplemented!`/
+    # `todo!` interpolate their format args into a panic message that lands in
+    # logs, backtraces, and crash reporters. All are CWE-532 sinks.
+    "dbg",
+    "panic",
+    "unimplemented",
+    "todo",
 )
 MACRO_CALL_RE = re.compile(r"\b(" + "|".join(LOG_MACROS) + r")!\s*\(")
 
 INLINE_CAPTURE_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_.]*)(?::[^}]*)?\}")
+
+# Structured tracing field: `ident = expr`, `ident = %expr`, `ident = ?expr`
+# (Display/Debug sigils). This is the IDIOMATIC `tracing` form —
+# `warn!(access_token = %access_token, "auth failed")` — and is the dominant
+# real-world leak vector the bare-positional scan was blind to. The `=(?![=>])`
+# guard rejects `==` comparisons and `=>` match arms; `!=`/`<=`/`>=` never
+# match because their leading punctuation is not part of the field-name class.
+# re.S so a value spanning physical lines (multiline macro call) still parses.
+STRUCTURED_FIELD_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_.]*)\s*=(?![=>])\s*(.*)$", re.S
+)
 
 # A "bare" argument: an identifier or a simple field-access / method chain
 # with only no-op accessors, e.g. `token`, `self.bearer_token`,
@@ -171,6 +214,8 @@ class Finding:
 
 def is_safe_by_name(name: str) -> bool:
     lname = name.lower()
+    if lname in SAFE_EXACT_NAMES:
+        return True
     if any(lname.endswith(suf) for suf in SAFE_FIELD_SUFFIXES):
         return True
     if any(sub in lname for sub in SAFE_FIELD_CONTAINS):
@@ -215,14 +260,30 @@ def scan_struct_debug(path: str, lines: list[str], manual_impls: set[str]) -> li
     i = 0
     while i < n:
         line = lines[i]
-        dm = DERIVE_RE.search(line)
+        # A `#[derive(...)]` attribute may span multiple physical lines:
+        #   #[derive(
+        #       Debug,
+        #       Clone,
+        #   )]
+        # Accumulate lines until the closing `)]` so the multiline form is
+        # parsed as one derive. `[^)]` already spans newlines in DERIVE_RE.
+        dm = None
+        derive_end_idx = i
+        if "#[derive(" in line:
+            combined = line
+            k = i
+            while ")]" not in combined and k + 1 < n and k < i + 12:
+                k += 1
+                combined += "\n" + lines[k]
+            derive_end_idx = k
+            dm = DERIVE_RE.search(combined)
         if dm and "Debug" in [p.strip() for p in dm.group(1).split(",")]:
             derive_line_idx = i
             # Walk forward past any further attributes/doc comments to the
             # struct declaration.
-            j = i + 1
+            j = derive_end_idx + 1
             struct_name = None
-            while j < n and j < i + 12:
+            while j < n and j < derive_end_idx + 12:
                 sm = STRUCT_RE.search(lines[j])
                 if sm:
                     struct_name = sm.group(1)
@@ -376,6 +437,69 @@ def is_bare_secret_arg(arg: str) -> str | None:
     return None
 
 
+def is_string_literal(arg: str) -> bool:
+    """True if `arg` is a Rust string literal we should scan for inline
+    `{ident}` captures: plain `"..."`, raw `r"..."`, or raw-hash
+    `r#"..."#` / `r##"..."##` forms."""
+    a = arg.lstrip()
+    if a.startswith('"') or a.startswith('r"'):
+        return True
+    # r#"..."#, r##"..."##, ...
+    return bool(re.match(r'r#+"', a))
+
+
+def parse_structured_field(arg: str) -> tuple[str, str] | None:
+    """Parse an idiomatic `tracing` structured field argument.
+
+    Handles `ident = expr`, `ident = %expr`, `ident = ?expr`, and the
+    sigil-shorthand forms `%ident` / `?ident` (where the field name is the
+    identifier itself). Returns `(field_name, value_expr)` with any leading
+    `%`/`?` sigil stripped from the value, or None if `arg` is not a
+    structured field.
+    """
+    arg = arg.strip()
+    if not arg:
+        return None
+    # Sigil-shorthand: `%token` / `?token` — field name is the identifier.
+    if arg[0] in ("%", "?"):
+        inner = arg[1:].strip()
+        # Only shorthand if there's no explicit `=` (that case is handled by
+        # STRUCTURED_FIELD_RE below via the `ident = %expr` form).
+        if inner and STRUCTURED_FIELD_RE.match(inner) is None:
+            return inner, inner
+        return None
+    m = STRUCTURED_FIELD_RE.match(arg)
+    if not m:
+        return None
+    name = m.group(1)
+    value = m.group(2).strip()
+    if value[:1] in ("%", "?"):
+        value = value[1:].strip()
+    return name, value
+
+
+def value_is_provably_safe(value: str) -> bool:
+    """True if a structured-field VALUE cannot carry a secret: a numeric /
+    bool literal, or a bare accessor whose tail is a label/count/duration
+    (e.g. `rule.name`, `injected_names`, `token_ttl_secs`). What reaches the
+    log sink is the value; a benign value means no CWE-532 leak even when the
+    field NAME is secret-shaped. A value that is an expression / call / bare
+    secret ident is NOT provably safe and remains subject to the name check."""
+    v = value.strip()
+    if not v:
+        return True
+    if re.match(r"^-?\d", v) or v in ("true", "false"):
+        return True
+    # Terminal count / emptiness accessors return a number or bool, never a
+    # plaintext secret: `config.secrets.len()`, `rules.count()`, `.is_empty()`.
+    if re.search(r"\.(len|count|is_empty|size|capacity)\(\)\s*$", v):
+        return True
+    m = BARE_TAIL_RE.match(v)
+    if m and is_safe_by_name(m.group(1)):
+        return True
+    return False
+
+
 def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     # Join with a joined-text + per-char line map so a macro call spanning
@@ -410,25 +534,44 @@ def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
         if not args:
             continue
 
-        # First arg is conventionally the format string for these macros.
-        fmt_arg = args[0]
-        rest_args = args[1:]
-
         flagged_names: list[str] = []
 
-        if fmt_arg.startswith('"') or fmt_arg.startswith('r"'):
-            for cm in INLINE_CAPTURE_RE.finditer(fmt_arg):
-                ident = cm.group(1).split(".")[-1]
-                if SECRET_RE.search(ident) and not is_safe_by_name(ident):
-                    flagged_names.append(ident)
-        else:
-            # No literal format string (e.g. a single non-string arg to
-            # println!-style macros isn't valid Rust, but be defensive).
-            bare = is_bare_secret_arg(fmt_arg)
-            if bare:
-                flagged_names.append(bare)
+        for a in args:
+            # 1. Idiomatic tracing structured field: `ident = [%|?]? expr`.
+            field = parse_structured_field(a)
+            if field is not None:
+                fname, fval = field
+                short = fname.split(".")[-1]
+                # A bare secret-named VALUE is always a leak (the secret bytes
+                # reach the sink): `access_token = %access_token`.
+                bare = is_bare_secret_arg(fval)
+                if bare:
+                    flagged_names.append(bare)
+                    continue
+                # Otherwise flag on the field NAME — but only when the value is
+                # not provably a benign label/count/duration. This catches a
+                # secret assigned from an expression (`token = %get_token()`)
+                # while sparing audit logs of labels (`credential = %rule.name`,
+                # `token_ttl_secs = <number>`), where the logged value carries
+                # no secret.
+                if (
+                    SECRET_RE.search(fname)
+                    and not is_safe_by_name(short)
+                    and not value_is_provably_safe(fval)
+                ):
+                    flagged_names.append(fname)
+                continue
 
-        for a in rest_args:
+            # 2. String literal (incl. raw `r"..."` / `r#"..."#`): scan for
+            #    inline `{ident}` format captures.
+            if is_string_literal(a):
+                for cm in INLINE_CAPTURE_RE.finditer(a):
+                    ident = cm.group(1).split(".")[-1]
+                    if SECRET_RE.search(ident) and not is_safe_by_name(ident):
+                        flagged_names.append(ident)
+                continue
+
+            # 3. Bare positional argument.
             bare = is_bare_secret_arg(a)
             if bare:
                 flagged_names.append(bare)
@@ -450,10 +593,11 @@ def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
 
 
 def scan_file(path: Path) -> list[Finding]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (UnicodeDecodeError, OSError):
-        return []
+    # Fail CLOSED: read errors propagate to the caller so an unreadable /
+    # undecodable file becomes a non-zero outcome, never a silent "clean"
+    # result. A file the gate cannot inspect is treated as a gate failure,
+    # not as an absence of secrets.
+    text = path.read_text(encoding="utf-8")
     lines = text.splitlines()
     manual_impls = find_manual_debug_impls(lines)
     findings = scan_struct_debug(str(path), lines, manual_impls)
@@ -498,8 +642,25 @@ def main(argv: list[str]) -> int:
         return 2
 
     all_findings: list[Finding] = []
+    read_errors: list[tuple[str, str]] = []
     for f in files:
-        all_findings.extend(scan_file(f))
+        try:
+            all_findings.extend(scan_file(f))
+        except (UnicodeDecodeError, OSError) as exc:
+            read_errors.append((str(f), f"{type(exc).__name__}: {exc}"))
+
+    # Fail CLOSED before any clean/finding reporting: a file the gate could
+    # not read might be exactly where a secret hides. Exit 2 (internal error).
+    if read_errors:
+        print(
+            f"cwe532-leak-lint: {len(read_errors)} file(s) could not be read — "
+            "failing closed (a file the gate cannot inspect is a gate failure, "
+            "not a clean result):",
+            file=sys.stderr,
+        )
+        for p, err in read_errors:
+            print(f"  {p}: {err}", file=sys.stderr)
+        return 2
 
     if not all_findings:
         print(f"cwe532-leak-lint: clean ({len(files)} files scanned, 0 findings)")

--- a/scripts/dev/cwe532-leak-lint.py
+++ b/scripts/dev/cwe532-leak-lint.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Semantic secret-leak lint (CWE-532) — CI Gate 1.
+
+Flags the exact bug class fixed in #323 (fix(security): redact credentials
+from Debug output): a struct that derives `Debug` over a field whose name
+looks like a secret, or a log/print macro that interpolates a variable
+whose name looks like a secret. Both leak plaintext credentials into traces,
+error contexts, or log aggregators.
+
+Two checks:
+
+  1. `#[derive(... Debug ...)]` on a struct with a field matching the
+     secret-keyword regex, unless:
+       - the struct already has a manual `impl ... Debug for <Name>` in the
+         same file (the redaction pattern used by #323), or
+       - a `// ci-allow-secret-debug: <reason>` marker sits on the line
+         immediately above the derive attribute or the flagged field.
+
+  2. A `info!/debug!/trace!/warn!/error!/println!/eprintln!/print!` macro
+     call whose format string interpolates `{ident}` (inline capture) or
+     whose top-level (non-nested) argument is a bare identifier / simple
+     field-access chain matching the secret-keyword regex, unless a
+     `// ci-allow-secret-log: <reason>` marker sits on the same line or the
+     line immediately above.
+
+     `format!` is deliberately NOT in this list — see the LOG_MACROS
+     comment below for why. It builds strings, not log/trace sinks.
+
+     Arguments nested inside a function call (e.g. `fingerprint(token)`,
+     `redact(&self.bearer_token)`) are NOT flagged — that is the documented
+     safe pattern (see gateway/auth.rs bearer_token_fingerprint). Only a
+     *bare* secret-named value reaching the macro is a leak.
+
+Baseline (cwe532-baseline.txt): a checked-in allowlist of pre-existing,
+NOT-YET-FIXED findings, keyed by stable (path, kind, struct.field/macro.ident)
+identity — not by line number, so it doesn't churn on unrelated edits. A
+finding whose key is in the baseline is reported but does not fail the
+build; any finding NOT in the baseline (i.e. newly introduced) fails the
+build immediately. This lets the gate go live on day one against an
+existing codebase without either (a) requiring every pre-existing risk to
+be fixed first, or (b) dishonestly marking real secrets as false positives
+via `ci-allow`. See the comment header in cwe532-baseline.txt.
+
+Exit code 0 = clean, 1 = new findings not covered by baseline, 2 = usage/
+internal error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SECRET_RE = re.compile(
+    # `token(?!s)` deliberately excludes the plural "tokens" — in this
+    # codebase (and most LLM-adjacent Rust code) plural "tokens" is
+    # overwhelmingly an LLM usage COUNT (cached_tokens, total_tokens,
+    # tokens_saved, max_tokens_per_identity), never credential material.
+    # Singular "token" still matches (access_token, bearer_token, token_jti).
+    r"(?i)(token(?!s)|secret|password|passwd|api_?key|bearer|credential|private_key|client_secret)"
+)
+
+# Field/identifier names that are secret-*shaped* by substring but are not,
+# in practice, credential material. Kept intentionally small and each entry
+# justified — prefer a ci-allow marker at the call site for anything not
+# obviously safe by construction. These exist for names where "safe" is
+# true from the name alone: a count, id, label, or well-known OAuth
+# discovery-metadata field (URLs / capability lists, never a live secret
+# value).
+SAFE_FIELD_SUFFIXES = (
+    "_name",
+    "_names",
+    "_id",
+    "_ids",
+    "_count",
+    "_present",
+    "_hash",
+    "_fingerprint",
+    "_type",
+    "_types",
+)
+
+# Substring (not just suffix) exclusions: OAuth discovery metadata
+# (`token_endpoint`, `token_endpoint_auth_methods_supported`,
+# `bearer_methods_supported`, `registration_endpoint`) is URLs / capability
+# lists advertised in a PUBLIC `.well-known` document, not secret values.
+# `jti` is a JWT ID claim, explicitly kept visible for revocation lookups
+# elsewhere in this codebase (see key_server/store.rs TemporaryToken).
+SAFE_FIELD_CONTAINS = (
+    "endpoint",
+    "methods_supported",
+    "jti",
+)
+
+# Boolean-flag naming convention: `has_bearer`, `is_credentialed`, etc. name
+# a presence check, never the secret value itself.
+BOOL_NAME_PREFIX_RE = re.compile(r"(?i)^(has|is|should|use)_")
+
+# Field types that can never hold plaintext credential material worth
+# flagging by this lint (numeric counts, durations, presence flags). A
+# String-typed secret is always the actual risk; a u64 "token count" or a
+# bool "has_bearer" flag is not, regardless of what its name contains.
+NUMERIC_OR_BOOL_TYPE_RE = re.compile(
+    r"^(?:Atomic)?(?:bool|u8|u16|u32|u64|u128|usize|i8|i16|i32|i64|i128|isize|"
+    r"f32|f64|Duration|SystemTime|Instant|NonZero(?:U8|U16|U32|U64|U128|Usize))\b"
+)
+TYPE_WRAPPER_RE = re.compile(
+    r"^(?:Option|Vec|Box|Arc|Rc|RwLock|Mutex)<\s*(.+)\s*>$"
+)
+
+DEBUG_MARKER_RE = re.compile(r"//\s*ci-allow-secret-debug:\s*(\S.*)$")
+LOG_MARKER_RE = re.compile(r"//\s*ci-allow-secret-log:\s*(\S.*)$")
+
+DERIVE_RE = re.compile(r"#\[derive\(([^)]*)\)\]")
+STRUCT_RE = re.compile(r"\b(?:pub(?:\([^)]*\))?\s+)?struct\s+(\w+)")
+MANUAL_DEBUG_IMPL_RE = re.compile(
+    r"impl(?:<[^>]*>)?\s+(?:std::fmt::Debug|fmt::Debug|Debug)\s+for\s+(\w+)"
+)
+FIELD_RE = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(\w+)\s*:\s*([^,{}]+?)\s*,?\s*$"
+)
+
+# `format!` is deliberately excluded. It is used constantly for legitimate
+# secret-*handling* (building an `Authorization: Bearer {token}` header
+# value, constructing an error message, building test fixtures) where the
+# resulting String is never logged — auditing every `format!` call site
+# produced 100% false positives in this codebase (header construction in
+# transport/http/mod.rs, identity_propagation/mod.rs; test fixtures in
+# redactor.rs, key_server/store.rs). The actual CWE-532 risk is a value
+# reaching a tracing/print SINK, which the macros below cover.
+LOG_MACROS = (
+    "info",
+    "debug",
+    "trace",
+    "warn",
+    "error",
+    "println",
+    "eprintln",
+    "print",
+)
+MACRO_CALL_RE = re.compile(r"\b(" + "|".join(LOG_MACROS) + r")!\s*\(")
+
+INLINE_CAPTURE_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_.]*)(?::[^}]*)?\}")
+
+# A "bare" argument: an identifier or a simple field-access / method chain
+# with only no-op accessors, e.g. `token`, `self.bearer_token`,
+# `cfg.api_key.clone()`, `req.token.as_str()`. Nested calls that WRAP the
+# ident (e.g. `hash(token)`) never match this — the ident there is inside
+# the call's argument list, which is a different regex position entirely
+# (see is_bare_secret_arg).
+BARE_TAIL_RE = re.compile(
+    r"^&?\**(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\.(?:clone|to_string|as_str|as_ref|as_deref|to_owned)\(\))*$"
+)
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    kind: str  # "debug" | "log"
+    detail: str
+    # Stable identity independent of line number (line numbers drift on any
+    # unrelated edit to the file). Used to match against the baseline file
+    # so pre-existing, not-yet-fixed findings don't force every future PR
+    # to touch unrelated code, while any *new* secret-shaped Debug/log site
+    # still fails the build immediately.
+    key: str = ""
+
+
+def is_safe_by_name(name: str) -> bool:
+    lname = name.lower()
+    if any(lname.endswith(suf) for suf in SAFE_FIELD_SUFFIXES):
+        return True
+    if any(sub in lname for sub in SAFE_FIELD_CONTAINS):
+        return True
+    if BOOL_NAME_PREFIX_RE.match(name):
+        return True
+    return False
+
+
+def is_numeric_or_bool_type(type_text: str) -> bool:
+    t = type_text.strip().lstrip("&").strip()
+    # Unwrap common container wrappers (Option<Vec<u64>>, etc.) up to a
+    # handful of levels — deep enough for any realistic field declaration.
+    for _ in range(4):
+        m = TYPE_WRAPPER_RE.match(t)
+        if not m:
+            break
+        t = m.group(1).strip()
+    return bool(NUMERIC_OR_BOOL_TYPE_RE.match(t))
+
+
+def has_marker_above_or_on(lines: list[str], idx: int, marker_re: re.Pattern) -> bool:
+    """Check line idx (0-based) and the line immediately above for a marker."""
+    for i in (idx, idx - 1):
+        if 0 <= i < len(lines) and marker_re.search(lines[i]):
+            return True
+    return False
+
+
+def find_manual_debug_impls(lines: list[str]) -> set[str]:
+    names = set()
+    for line in lines:
+        m = MANUAL_DEBUG_IMPL_RE.search(line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def scan_struct_debug(path: str, lines: list[str], manual_impls: set[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i]
+        dm = DERIVE_RE.search(line)
+        if dm and "Debug" in [p.strip() for p in dm.group(1).split(",")]:
+            derive_line_idx = i
+            # Walk forward past any further attributes/doc comments to the
+            # struct declaration.
+            j = i + 1
+            struct_name = None
+            while j < n and j < i + 12:
+                sm = STRUCT_RE.search(lines[j])
+                if sm:
+                    struct_name = sm.group(1)
+                    break
+                # Stop scanning if we hit another item first (not a struct).
+                if re.search(r"\b(fn|enum|impl|trait|mod)\b", lines[j]) and not lines[
+                    j
+                ].strip().startswith("#["):
+                    break
+                j += 1
+
+            if struct_name and struct_name not in manual_impls:
+                if not has_marker_above_or_on(lines, derive_line_idx, DEBUG_MARKER_RE):
+                    # Scan the struct body for secret-shaped fields.
+                    body_start = j
+                    depth = 0
+                    started = False
+                    k = body_start
+                    while k < n:
+                        depth += lines[k].count("{") - lines[k].count("}")
+                        if "{" in lines[k]:
+                            started = True
+                        if started and depth <= 0:
+                            break
+                        k += 1
+                    body_end = k
+
+                    for fline_idx in range(body_start, min(body_end + 1, n)):
+                        fm = FIELD_RE.match(lines[fline_idx])
+                        if not fm:
+                            continue
+                        fname = fm.group(1)
+                        ftype = fm.group(2)
+                        if fname in ("Self",):
+                            continue
+                        if (
+                            SECRET_RE.search(fname)
+                            and not is_safe_by_name(fname)
+                            and not is_numeric_or_bool_type(ftype)
+                        ):
+                            if has_marker_above_or_on(lines, fline_idx, DEBUG_MARKER_RE):
+                                continue
+                            findings.append(
+                                Finding(
+                                    path=path,
+                                    line=fline_idx + 1,
+                                    kind="debug",
+                                    detail=(
+                                        f"struct `{struct_name}` derives Debug over "
+                                        f"secret-shaped field `{fname}` "
+                                        f"(derive at line {derive_line_idx + 1})"
+                                    ),
+                                    key=f"{path}|debug|{struct_name}.{fname}",
+                                )
+                            )
+        i += 1
+    return findings
+
+
+def split_top_level_args(arg_text: str) -> list[str]:
+    """Split on commas at paren/bracket/brace depth 0, respecting string
+    literals so commas inside format strings don't split incorrectly."""
+    args: list[str] = []
+    depth = 0
+    current = []
+    in_string = False
+    escape = False
+    i = 0
+    while i < len(arg_text):
+        c = arg_text[i]
+        if in_string:
+            current.append(c)
+            if escape:
+                escape = False
+            elif c == "\\":
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            current.append(c)
+            i += 1
+            continue
+        if c in "([{":
+            depth += 1
+            current.append(c)
+            i += 1
+            continue
+        if c in ")]}":
+            depth -= 1
+            current.append(c)
+            i += 1
+            continue
+        if c == "," and depth == 0:
+            args.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    if current:
+        args.append("".join(current))
+    return [a.strip() for a in args if a.strip()]
+
+
+def extract_call_args(text: str, open_paren_idx: int) -> tuple[str, int]:
+    """Given text and the index of the opening '(', return (args_text,
+    index_just_after_matching_close_paren)."""
+    depth = 0
+    in_string = False
+    escape = False
+    i = open_paren_idx
+    start = open_paren_idx + 1
+    while i < len(text):
+        c = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif c == "\\":
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start:i], i + 1
+        i += 1
+    return text[start:], len(text)
+
+
+def is_bare_secret_arg(arg: str) -> str | None:
+    """Return the matched identifier if `arg` is a bare identifier / simple
+    field-access chain whose tail matches the secret regex, else None."""
+    arg = arg.strip()
+    if arg.startswith('"'):
+        return None
+    m = BARE_TAIL_RE.match(arg)
+    if not m:
+        return None
+    tail = m.group(1)
+    if SECRET_RE.search(tail) and not is_safe_by_name(tail):
+        return tail
+    return None
+
+
+def scan_log_macros(path: str, lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    # Join with a joined-text + per-char line map so a macro call spanning
+    # multiple physical lines is still parsed as one logical call.
+    joined = "\n".join(lines)
+    offsets = []
+    pos = 0
+    for line in lines:
+        offsets.append(pos)
+        pos += len(line) + 1
+
+    def line_of(idx: int) -> int:
+        lo, hi = 0, len(offsets) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if offsets[mid] <= idx:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
+    for m in MACRO_CALL_RE.finditer(joined):
+        macro_name = m.group(1)
+        open_idx = m.end() - 1  # index of '('
+        args_text, _end_idx = extract_call_args(joined, open_idx)
+        call_line_idx = line_of(m.start())
+
+        if has_marker_above_or_on(lines, call_line_idx, LOG_MARKER_RE):
+            continue
+
+        args = split_top_level_args(args_text)
+        if not args:
+            continue
+
+        # First arg is conventionally the format string for these macros.
+        fmt_arg = args[0]
+        rest_args = args[1:]
+
+        flagged_names: list[str] = []
+
+        if fmt_arg.startswith('"') or fmt_arg.startswith('r"'):
+            for cm in INLINE_CAPTURE_RE.finditer(fmt_arg):
+                ident = cm.group(1).split(".")[-1]
+                if SECRET_RE.search(ident) and not is_safe_by_name(ident):
+                    flagged_names.append(ident)
+        else:
+            # No literal format string (e.g. a single non-string arg to
+            # println!-style macros isn't valid Rust, but be defensive).
+            bare = is_bare_secret_arg(fmt_arg)
+            if bare:
+                flagged_names.append(bare)
+
+        for a in rest_args:
+            bare = is_bare_secret_arg(a)
+            if bare:
+                flagged_names.append(bare)
+
+        if flagged_names:
+            names = ", ".join(sorted(set(flagged_names)))
+            findings.append(
+                Finding(
+                    path=path,
+                    line=call_line_idx + 1,
+                    kind="log",
+                    detail=(
+                        f"`{macro_name}!` interpolates secret-shaped value(s): {names}"
+                    ),
+                    key=f"{path}|log|{macro_name}|{names}",
+                )
+            )
+    return findings
+
+
+def scan_file(path: Path) -> list[Finding]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    lines = text.splitlines()
+    manual_impls = find_manual_debug_impls(lines)
+    findings = scan_struct_debug(str(path), lines, manual_impls)
+    findings += scan_log_macros(str(path), lines)
+    return findings
+
+
+def collect_rs_files(roots: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        rp = Path(root)
+        if not rp.exists():
+            continue
+        for p in rp.rglob("*.rs"):
+            parts = p.parts
+            if "target" in parts:
+                continue
+            files.append(p)
+    return sorted(files)
+
+
+BASELINE_PATH = Path(__file__).resolve().parent / "cwe532-baseline.txt"
+
+
+def load_baseline() -> set[str]:
+    if not BASELINE_PATH.exists():
+        return set()
+    keys = set()
+    for line in BASELINE_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        keys.add(line)
+    return keys
+
+
+def main(argv: list[str]) -> int:
+    roots = argv[1:] if len(argv) > 1 else ["src", "crates"]
+    files = collect_rs_files(roots)
+    if not files:
+        print(f"cwe532-leak-lint: no .rs files found under {roots}", file=sys.stderr)
+        return 2
+
+    all_findings: list[Finding] = []
+    for f in files:
+        all_findings.extend(scan_file(f))
+
+    if not all_findings:
+        print(f"cwe532-leak-lint: clean ({len(files)} files scanned, 0 findings)")
+        return 0
+
+    baseline = load_baseline()
+    new_findings = [fnd for fnd in all_findings if fnd.key not in baseline]
+    baselined_findings = [fnd for fnd in all_findings if fnd.key in baseline]
+
+    all_findings.sort(key=lambda fnd: (fnd.path, fnd.line))
+    new_findings.sort(key=lambda fnd: (fnd.path, fnd.line))
+
+    if new_findings:
+        print(
+            f"cwe532-leak-lint: {len(new_findings)} NEW finding(s) not covered by "
+            f"{BASELINE_PATH.name} (CWE-532 risk)\n"
+        )
+        for fnd in new_findings:
+            print(f"{fnd.path}:{fnd.line}: [{fnd.kind}] {fnd.detail}")
+        if baselined_findings:
+            print(
+                f"\n({len(baselined_findings)} additional pre-existing finding(s) "
+                f"are tracked in {BASELINE_PATH.name} and did not fail the build.)"
+            )
+        print(
+            "\nFix: give the struct a manual `impl Debug` that redacts the field, "
+            "mark a genuine false positive with `// ci-allow-secret-debug: <reason>` "
+            "/ `// ci-allow-secret-log: <reason>` on the line above, or — only for "
+            "pre-existing debt being tracked, not new code — add the finding's key "
+            f"to {BASELINE_PATH.name}."
+        )
+        return 1
+
+    print(
+        f"cwe532-leak-lint: 0 new findings ({len(files)} files scanned, "
+        f"{len(baselined_findings)} pre-existing finding(s) tracked in "
+        f"{BASELINE_PATH.name}, 0 unbaselined)"
+    )
+    stale = baseline - {fnd.key for fnd in all_findings}
+    if stale:
+        print(
+            f"\nNote: {len(stale)} baseline entr{'y is' if len(stale) == 1 else 'ies are'} "
+            "stale (no longer detected) — safe to remove from "
+            f"{BASELINE_PATH.name}:"
+        )
+        for k in sorted(stale):
+            print(f"  {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/dev/test_cwe532_leak_lint.py
+++ b/scripts/dev/test_cwe532_leak_lint.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Tests for cwe532-leak-lint.py (CWE-532 secret-leak lint).
+
+Stdlib-only. Run directly:
+
+    python3 scripts/dev/test_cwe532_leak_lint.py
+
+Covers the structured-field detection (the idiomatic `tracing` leak vector),
+struct-derive detection, baseline handling, multiline derives, raw strings,
+the extra sinks (`dbg!`/`panic!`), and fail-closed behavior on unreadable
+files.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# The linter's filename has hyphens, so it can't be a normal import target.
+_HERE = Path(__file__).resolve().parent
+_LINT_PATH = _HERE / "cwe532-leak-lint.py"
+
+
+def _load_lint():
+    spec = importlib.util.spec_from_file_location("cwe532_leak_lint", _LINT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module namespace.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+lint = _load_lint()
+
+
+def _scan_source(src: str, name: str = "sample.rs"):
+    """Write `src` to a temp .rs file and return its findings."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / name
+        p.write_text(src, encoding="utf-8")
+        return lint.scan_file(p)
+
+
+def _run_main(roots, baseline_text=None):
+    """Run main() over `roots` with an optional temp baseline, returning
+    (exit_code, stdout, stderr). BASELINE_PATH is monkeypatched and restored."""
+    old_baseline = lint.BASELINE_PATH
+    tmp_baseline = None
+    try:
+        if baseline_text is not None:
+            fd, tmp_baseline = tempfile.mkstemp(suffix=".txt")
+            os.write(fd, baseline_text.encode("utf-8"))
+            os.close(fd)
+            lint.BASELINE_PATH = Path(tmp_baseline)
+        else:
+            # Point at a path that does not exist -> empty baseline.
+            lint.BASELINE_PATH = Path(tempfile.gettempdir()) / "no-such-baseline.txt"
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = lint.main(["prog", *roots])
+        return code, out.getvalue(), err.getvalue()
+    finally:
+        lint.BASELINE_PATH = old_baseline
+        if tmp_baseline:
+            os.unlink(tmp_baseline)
+
+
+class TestCwe532Lint(unittest.TestCase):
+    # (1) struct derives Debug over a secret field -> flagged
+    def test_struct_debug_secret_field_flagged(self):
+        src = (
+            "#[derive(Debug, Clone)]\n"
+            "pub struct Creds {\n"
+            "    pub api_key: String,\n"
+            "}\n"
+        )
+        findings = _scan_source(src)
+        debug = [f for f in findings if f.kind == "debug"]
+        self.assertTrue(debug, "expected a debug finding for api_key")
+        self.assertIn("api_key", debug[0].detail)
+
+    # (2) safe-named fields (_count, _id, has_) -> not flagged
+    def test_safe_named_fields_not_flagged(self):
+        src = (
+            "#[derive(Debug)]\n"
+            "pub struct Stats {\n"
+            "    pub token_count: u64,\n"
+            "    pub session_id: String,\n"
+            "    pub has_bearer: bool,\n"
+            "}\n"
+        )
+        findings = _scan_source(src)
+        self.assertEqual(findings, [], f"expected no findings, got {findings}")
+
+    # (3) baselined finding -> not a build failure (exit 0)
+    def test_baselined_finding_does_not_fail_build(self):
+        src = (
+            "#[derive(Debug)]\n"
+            "pub struct T {\n"
+            "    pub access_token: String,\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "sample.rs"
+            p.write_text(src, encoding="utf-8")
+            findings = lint.scan_file(p)
+            self.assertTrue(findings)
+            key = findings[0].key
+
+            # No baseline -> the new finding fails the build (exit 1).
+            code, _, _ = _run_main([d], baseline_text=None)
+            self.assertEqual(code, 1)
+
+            # Same finding baselined -> build passes (exit 0).
+            code, _, _ = _run_main([d], baseline_text=f"# baseline\n{key}\n")
+            self.assertEqual(code, 0)
+
+    # (4) positional log leak -> flagged
+    def test_positional_log_leak_flagged(self):
+        src = 'fn f() {\n    println!("value: {}", api_key);\n}\n'
+        findings = _scan_source(src)
+        logs = [f for f in findings if f.kind == "log"]
+        self.assertTrue(logs, "expected a log finding for positional api_key")
+        self.assertIn("api_key", logs[0].detail)
+
+    # (5) STRUCTURED FIELD leak `warn!(token = %token)` -> flagged (the HIGH)
+    def test_structured_field_leak_flagged(self):
+        cases = [
+            'warn!(access_token = %access_token, "auth failed");',
+            "error!(secret = ?secret);",
+            "info!(api_key = api_key);",
+            "warn!(token = %token);",
+        ]
+        for line in cases:
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertTrue(logs, f"expected structured-field leak flagged: {line}")
+
+    def test_structured_field_safe_value_not_flagged(self):
+        # Field NAME is secret-shaped, but the logged VALUE is a benign label /
+        # count / duration -> no leak. Mirrors the real-tree audit logs.
+        safe = [
+            "info!(credential = %rule.name);",
+            "debug!(credentials = ?injected_names);",
+            "info!(credentials = config.secrets.len());",
+            "info!(token_ttl_secs = self.cfg.token_ttl_secs);",
+            'warn!(server, error = %audit_err, "audit failed");',
+        ]
+        for line in safe:
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertEqual(logs, [], f"benign value wrongly flagged: {line}")
+
+    # (6) multiline derive -> flagged
+    def test_multiline_derive_flagged(self):
+        src = (
+            "#[derive(\n"
+            "    Debug,\n"
+            "    Clone,\n"
+            ")]\n"
+            "pub struct Multi {\n"
+            "    pub client_secret: String,\n"
+            "}\n"
+        )
+        findings = _scan_source(src)
+        debug = [f for f in findings if f.kind == "debug"]
+        self.assertTrue(debug, "expected a debug finding on multiline derive")
+        self.assertIn("client_secret", debug[0].detail)
+
+    # (7) raw-string inline capture -> flagged
+    def test_raw_string_inline_capture_flagged(self):
+        for line in (
+            'error!(r"token is {token}");',
+            'error!(r#"the api_key is {api_key} here"#);',
+        ):
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertTrue(logs, f"expected raw-string capture flagged: {line}")
+
+    # (8) dbg!(secret) / panic!("{token}") -> flagged
+    def test_extra_sinks_flagged(self):
+        for line in (
+            "dbg!(secret);",
+            'panic!("boom {token}");',
+            'todo!("handle {password}");',
+        ):
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertTrue(logs, f"expected extra-sink leak flagged: {line}")
+
+    # (9) unreadable / undecodable file -> fail closed (exit 2)
+    def test_unreadable_file_fails_closed(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "bad.rs"
+            # Invalid UTF-8 -> UnicodeDecodeError on read.
+            p.write_bytes(b"\xff\xfe fn main() { let token = 1; }")
+            code, _out, err = _run_main([d], baseline_text=None)
+            self.assertEqual(code, 2, "unreadable file must fail closed with exit 2")
+            self.assertIn("bad.rs", err)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/dev/test_cwe532_leak_lint.py
+++ b/scripts/dev/test_cwe532_leak_lint.py
@@ -160,6 +160,43 @@ class TestCwe532Lint(unittest.TestCase):
                 logs = [f for f in findings if f.kind == "log"]
                 self.assertEqual(logs, [], f"benign value wrongly flagged: {line}")
 
+    # (5c) secret VALUE wrapped in an accessor chain on a NEUTRAL field NAME ->
+    # flagged. This is the residual gap: `value = %access_token.expose_secret()`
+    # leaks the secret bytes even though the field name (`value`, `v`) is benign
+    # and the accessor (`.expose_secret()`, `.unwrap()`) is outside BARE_TAIL_RE.
+    def test_wrapped_accessor_secret_value_flagged(self):
+        cases = [
+            # explicit neutral field name + secret-shaped wrapped value
+            "info!(value = %access_token.expose_secret());",
+            "warn!(v = %token.as_deref().unwrap());",
+            # sigil-shorthand forms (the exact forms named in the finding)
+            "info!(%access_token.expose_secret());",
+            "warn!(%secret.as_deref().unwrap());",
+        ]
+        for line in cases:
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertTrue(
+                    logs, f"expected wrapped-accessor secret value flagged: {line}"
+                )
+
+    # (5d) genuinely-neutral wrapped VALUE (a count/label) -> NOT flagged, even
+    # though the accessor chain is the same shape as the leak above.
+    def test_wrapped_accessor_neutral_value_not_flagged(self):
+        safe = [
+            "info!(value = %count.to_string());",
+            "debug!(%count.to_string());",
+            "info!(v = %name.clone());",
+        ]
+        for line in safe:
+            with self.subTest(line=line):
+                findings = _scan_source("fn f() {\n    " + line + "\n}\n")
+                logs = [f for f in findings if f.kind == "log"]
+                self.assertEqual(
+                    logs, [], f"neutral wrapped value wrongly flagged: {line}"
+                )
+
     # (6) multiline derive -> flagged
     def test_multiline_derive_flagged(self):
         src = (

--- a/src/capability/definition/mod.rs
+++ b/src/capability/definition/mod.rs
@@ -734,7 +734,7 @@ pub struct WebhookTransform {
 }
 
 /// Webhook endpoint definition
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct WebhookDefinition {
     /// URL path relative to `base_path` (e.g., "/linear/webhook")
     pub path: String,
@@ -753,6 +753,23 @@ pub struct WebhookDefinition {
     /// Payload transform configuration
     #[serde(default)]
     pub transform: WebhookTransform,
+}
+
+// Manual `Debug` that redacts the HMAC verification secret (CWE-532, mirrors
+// PR #323). A derived `Debug` would print the webhook `secret` verbatim into
+// any trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for WebhookDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("WebhookDefinition")
+            .field("path", &self.path)
+            .field("method", &self.method)
+            .field("secret", &redact_opt(&self.secret))
+            .field("signature_header", &self.signature_header)
+            .field("notify", &self.notify)
+            .field("transform", &self.transform)
+            .finish()
+    }
 }
 
 fn default_notify() -> bool {
@@ -997,3 +1014,33 @@ impl CapabilityDefinition {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // WebhookDefinition::Debug must never surface the HMAC verification secret.
+    #[test]
+    fn webhook_definition_debug_redacts_secret() {
+        let w = WebhookDefinition {
+            path: "/linear/webhook".to_string(),
+            method: "POST".to_string(),
+            secret: Some(SENTINEL.to_string()),
+            signature_header: Some("X-Linear-Signature".to_string()),
+            notify: true,
+            transform: WebhookTransform::default(),
+        };
+        let dbg = format!("{w:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked webhook secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("/linear/webhook"),
+            "path should stay visible: {dbg}"
+        );
+    }
+}

--- a/src/capability/executor/credentials.rs
+++ b/src/capability/executor/credentials.rs
@@ -294,13 +294,29 @@ impl CapabilityExecutor {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct RefreshTokenResponse {
     access_token: String,
     token_type: Option<String>,
     refresh_token: Option<String>,
     expires_in: Option<u64>,
     scope: Option<String>,
+}
+
+// Manual `Debug` that redacts the OAuth tokens (CWE-532, mirrors PR #323). A
+// derived `Debug` would print `access_token` / `refresh_token` verbatim into
+// any trace or error context.
+impl std::fmt::Debug for RefreshTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("RefreshTokenResponse")
+            .field("access_token", &"<redacted>")
+            .field("token_type", &self.token_type)
+            .field("refresh_token", &redact_opt(&self.refresh_token))
+            .field("expires_in", &self.expires_in)
+            .field("scope", &self.scope)
+            .finish()
+    }
 }
 
 fn expand_home_dir(path: &str) -> Result<std::path::PathBuf> {
@@ -500,5 +516,34 @@ mod tests {
         let ex = CapabilityExecutor::new();
         let err = ex.fetch_from_file("/path/to/file.json:").unwrap_err();
         assert!(err.to_string().contains("Empty field name"), "{err}");
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // RefreshTokenResponse::Debug must never surface the OAuth tokens.
+    #[test]
+    fn refresh_token_response_debug_redacts_tokens() {
+        let r = RefreshTokenResponse {
+            access_token: SENTINEL.to_string(),
+            token_type: Some("Bearer".to_string()),
+            refresh_token: Some(format!("{SENTINEL}-refresh")),
+            expires_in: Some(3600),
+            scope: Some("read".to_string()),
+        };
+        let dbg = format!("{r:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked token: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("Bearer"),
+            "token_type should stay visible: {dbg}"
+        );
     }
 }

--- a/src/config/features/auth.rs
+++ b/src/config/features/auth.rs
@@ -12,7 +12,7 @@ use crate::{Error, Result};
 // ── Auth ───────────────────────────────────────────────────────────────────────
 
 /// Authentication configuration for gateway access.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AuthConfig {
     /// Enable authentication (default: false for backwards compatibility).
@@ -42,6 +42,24 @@ pub struct AuthConfig {
     /// overrides this hint (see [`AuthConfig::implies_multi_user`]).
     #[serde(default)]
     pub single_user: bool,
+}
+
+// Manual `Debug` that redacts the bearer token and API keys (CWE-532, mirrors
+// PR #323). A derived `Debug` would print the plaintext bearer token and every
+// API key verbatim into any trace or error context. The bearer presence and
+// the API-key count are surfaced so diagnostics stay useful.
+impl std::fmt::Debug for AuthConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("AuthConfig")
+            .field("enabled", &self.enabled)
+            .field("bearer_token", &redact_opt(&self.bearer_token))
+            .field("api_keys", &format!("<{} entries>", self.api_keys.len()))
+            .field("public_paths", &self.public_paths)
+            .field("client_circuit_breaker", &self.client_circuit_breaker)
+            .field("single_user", &self.single_user)
+            .finish()
+    }
 }
 
 fn default_public_paths() -> Vec<String> {
@@ -196,7 +214,7 @@ pub struct AgentAuthConfig {
 }
 
 /// Static agent definition in the configuration file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AgentDefinitionConfig {
     /// Unique client identifier.
     pub client_id: String,
@@ -217,6 +235,24 @@ pub struct AgentDefinitionConfig {
     /// Expected audience (`aud` claim). Optional.
     #[serde(default)]
     pub audience: Option<String>,
+}
+
+// Manual `Debug` that redacts the HS256 shared secret (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the signing secret verbatim; the RSA
+// *public* key is not secret and stays visible.
+impl std::fmt::Debug for AgentDefinitionConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("AgentDefinitionConfig")
+            .field("client_id", &self.client_id)
+            .field("name", &self.name)
+            .field("hs256_secret", &redact_opt(&self.hs256_secret))
+            .field("rs256_public_key", &self.rs256_public_key)
+            .field("scopes", &self.scopes)
+            .field("issuer", &self.issuer)
+            .field("audience", &self.audience)
+            .finish()
+    }
 }
 
 impl AgentDefinitionConfig {
@@ -333,6 +369,54 @@ mod multi_user_tests {
         assert!(
             cfg.implies_multi_user(true),
             "any OIDC issuer means many end users"
+        );
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // AuthConfig::Debug must redact the bearer token and never print API keys.
+    #[test]
+    fn auth_config_debug_redacts_bearer_token() {
+        let cfg = AuthConfig {
+            enabled: true,
+            bearer_token: Some(SENTINEL.to_string()),
+            ..AuthConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked bearer_token: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+    }
+
+    // AgentDefinitionConfig::Debug must redact the HS256 secret while keeping
+    // the (non-secret) RSA public key visible.
+    #[test]
+    fn agent_definition_config_debug_redacts_hs256_secret() {
+        let cfg = AgentDefinitionConfig {
+            client_id: "agent-1".to_string(),
+            name: "Agent One".to_string(),
+            hs256_secret: Some(SENTINEL.to_string()),
+            rs256_public_key: Some("-----BEGIN PUBLIC KEY-----".to_string()),
+            scopes: vec!["tools:*".to_string()],
+            issuer: None,
+            audience: None,
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked hs256_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("BEGIN PUBLIC KEY"),
+            "public key is not secret and should stay visible: {dbg}"
         );
     }
 }

--- a/src/config/features/key_server.rs
+++ b/src/config/features/key_server.rs
@@ -38,7 +38,7 @@ const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 60;
 ///         tools: ["*"]
 ///         rate_limit: 100
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct KeyServerConfig {
     /// Enable the key server (default: `false`).
@@ -73,6 +73,26 @@ pub struct KeyServerConfig {
     /// provider and a policy rule, so enabling it does not bypass policy.
     #[serde(default)]
     pub delegated_bearer: bool,
+}
+
+// Manual `Debug` that redacts the admin bearer token (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the revocation-endpoint admin token
+// verbatim into any trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for KeyServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("KeyServerConfig")
+            .field("enabled", &self.enabled)
+            .field("token_ttl_secs", &self.token_ttl_secs)
+            .field("max_tokens_per_identity", &self.max_tokens_per_identity)
+            .field("max_oidc_token_age_secs", &self.max_oidc_token_age_secs)
+            .field("cleanup_interval_secs", &self.cleanup_interval_secs)
+            .field("oidc", &self.oidc)
+            .field("policies", &self.policies)
+            .field("admin_token", &redact_opt(&self.admin_token))
+            .field("delegated_bearer", &self.delegated_bearer)
+            .finish()
+    }
 }
 
 fn default_token_ttl_secs() -> u64 {
@@ -319,5 +339,27 @@ mod tests {
             ..KeyServerConfig::default()
         };
         assert!(cfg.validate().is_ok());
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // KeyServerConfig::Debug must never surface the admin revocation token.
+    #[test]
+    fn key_server_config_debug_redacts_admin_token() {
+        let cfg = KeyServerConfig {
+            admin_token: Some(SENTINEL.to_string()),
+            ..KeyServerConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked admin_token: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
     }
 }

--- a/src/config/features/security.rs
+++ b/src/config/features/security.rs
@@ -24,7 +24,7 @@ pub use crate::security::remote_provenance::RemoteServerSigningConfig;
 ///     shared_secret: "${MCP_GATEWAY_TRANSPARENCY_SECRET}"
 ///     key_id: "v1"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TransparencyLogConfig {
     /// Enable the transparency log. Default: `false` (opt-in).
@@ -38,6 +38,27 @@ pub struct TransparencyLogConfig {
     /// When empty, `sig` / `key_id` are omitted from each entry — the hash
     /// chain alone still provides tamper evidence.
     pub shared_secret: String,
+}
+
+// Manual `Debug` that redacts the HMAC shared secret (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the signing secret verbatim into any
+// trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for TransparencyLogConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransparencyLogConfig")
+            .field("enabled", &self.enabled)
+            .field("path", &self.path)
+            .field("key_id", &self.key_id)
+            .field(
+                "shared_secret",
+                &if self.shared_secret.is_empty() {
+                    "<empty>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .finish()
+    }
 }
 
 impl Default for TransparencyLogConfig {
@@ -70,7 +91,7 @@ impl Default for TransparencyLogConfig {
 ///     replay_window: 300
 ///     key_id: "default"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MessageSigningConfig {
     /// Enable message signing. Default: `false` (opt-in).
@@ -89,6 +110,30 @@ pub struct MessageSigningConfig {
     pub replay_window: u64,
     /// Key identifier included in `_signature.key_id` for rotation tracking.
     pub key_id: String,
+}
+
+// Manual `Debug` that redacts both HMAC signing secrets (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the current and previous signing
+// material verbatim — leaking either lets an attacker forge signed responses.
+// Only secret presence is surfaced.
+impl std::fmt::Debug for MessageSigningConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact = |s: &str| {
+            if s.is_empty() {
+                "<empty>"
+            } else {
+                "<redacted>"
+            }
+        };
+        f.debug_struct("MessageSigningConfig")
+            .field("enabled", &self.enabled)
+            .field("shared_secret", &redact(&self.shared_secret))
+            .field("previous_secret", &redact(&self.previous_secret))
+            .field("require_nonce", &self.require_nonce)
+            .field("replay_window", &self.replay_window)
+            .field("key_id", &self.key_id)
+            .finish()
+    }
 }
 
 impl Default for MessageSigningConfig {
@@ -425,6 +470,45 @@ mod context_integrity_config_tests {
         assert_eq!(
             policy.effective_mode(),
             ContextIntegrityPolicyMode::MonitorOnly
+        );
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // TransparencyLogConfig::Debug must never surface the HMAC shared secret.
+    #[test]
+    fn transparency_log_config_debug_redacts_shared_secret() {
+        let cfg = TransparencyLogConfig {
+            shared_secret: SENTINEL.to_string(),
+            ..TransparencyLogConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked shared_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+    }
+
+    // MessageSigningConfig::Debug must redact both the current and previous
+    // rotation secrets.
+    #[test]
+    fn message_signing_config_debug_redacts_both_secrets() {
+        let cfg = MessageSigningConfig {
+            shared_secret: SENTINEL.to_string(),
+            previous_secret: format!("{SENTINEL}-prev"),
+            ..MessageSigningConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked signing secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -764,8 +764,12 @@ impl std::fmt::Debug for BackendConfig {
             .field("transport", &self.transport)
             .field("idle_timeout", &self.idle_timeout)
             .field("timeout", &self.timeout)
-            .field("env", &self.env)
-            .field("headers", &self.headers)
+            // `env` and `headers` values routinely carry credentials
+            // (Authorization bearers, API keys, env-injected secrets). The
+            // field names are neutral, so the name-based leak lint cannot see
+            // them — redact to counts here, matching `secrets` below.
+            .field("env", &format!("<{} vars>", self.env.len()))
+            .field("headers", &format!("<{} headers>", self.headers.len()))
             .field("oauth", &self.oauth)
             .field("secrets", &format!("<{} rules>", self.secrets.len()))
             .field("passthrough", &self.passthrough)
@@ -1043,10 +1047,13 @@ mod cwe532_debug_redaction {
     const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
 
     // BackendConfig::Debug must never recurse into the credential-injection
-    // rules; only the rule count is surfaced.
+    // rules, nor print `env`/`headers` values (Authorization bearers, API
+    // keys); only counts are surfaced.
     #[test]
     fn backend_config_debug_redacts_secret_rules() {
         let cfg = BackendConfig {
+            env: HashMap::from([("OPENAI_API_KEY".to_string(), SENTINEL.to_string())]),
+            headers: HashMap::from([("Authorization".to_string(), SENTINEL.to_string())]),
             secrets: vec![crate::secret_injection::CredentialRule {
                 name: "openai_api_key".to_string(),
                 credential_type: crate::secret_injection::CredentialType::ApiKey,
@@ -1062,6 +1069,11 @@ mod cwe532_debug_redaction {
         assert!(
             dbg.contains("<1 rules>"),
             "missing rule-count marker: {dbg}"
+        );
+        assert!(dbg.contains("<1 vars>"), "missing env-count marker: {dbg}");
+        assert!(
+            dbg.contains("<1 headers>"),
+            "missing headers-count marker: {dbg}"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -708,7 +708,7 @@ impl Default for MetaMcpConfig {
 // ── Backend ───────────────────────────────────────────────────────────────────
 
 /// Backend configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BackendConfig {
     /// Human-readable description.
@@ -752,6 +752,29 @@ pub struct BackendConfig {
     pub identity_propagation: Option<crate::identity_propagation::IdentityPropagationConfig>,
 }
 
+// Manual `Debug` that redacts the credential-injection rules (CWE-532, mirrors
+// PR #323). A derived `Debug` would recurse into `secrets` and print the
+// injected credential material verbatim into any trace or error context; only
+// the rule count is surfaced.
+impl std::fmt::Debug for BackendConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackendConfig")
+            .field("description", &self.description)
+            .field("enabled", &self.enabled)
+            .field("transport", &self.transport)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("timeout", &self.timeout)
+            .field("env", &self.env)
+            .field("headers", &self.headers)
+            .field("oauth", &self.oauth)
+            .field("secrets", &format!("<{} rules>", self.secrets.len()))
+            .field("passthrough", &self.passthrough)
+            .field("runtime_profile", &self.runtime_profile)
+            .field("identity_propagation", &self.identity_propagation)
+            .finish()
+    }
+}
+
 impl Default for BackendConfig {
     fn default() -> Self {
         Self {
@@ -772,7 +795,7 @@ impl Default for BackendConfig {
 }
 
 /// OAuth configuration for a backend.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OAuthConfig {
     /// Enable OAuth for this backend.
     #[serde(default = "default_true")]
@@ -819,6 +842,26 @@ pub struct OAuthConfig {
     /// ignores this flag — the sole caller always owns the token.
     #[serde(default)]
     pub shared_account: bool,
+}
+
+// Manual `Debug` that redacts the fixed OAuth client secret (CWE-532, mirrors
+// PR #323). A derived `Debug` would print `client_secret` verbatim into any
+// trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for OAuthConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("OAuthConfig")
+            .field("enabled", &self.enabled)
+            .field("scopes", &self.scopes)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &redact_opt(&self.client_secret))
+            .field("callback_host", &self.callback_host)
+            .field("callback_port", &self.callback_port)
+            .field("callback_path", &self.callback_path)
+            .field("token_refresh_buffer_secs", &self.token_refresh_buffer_secs)
+            .field("shared_account", &self.shared_account)
+            .finish()
+    }
 }
 
 fn default_token_refresh_buffer() -> u64 {
@@ -992,3 +1035,59 @@ pub mod humantime_serde {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // BackendConfig::Debug must never recurse into the credential-injection
+    // rules; only the rule count is surfaced.
+    #[test]
+    fn backend_config_debug_redacts_secret_rules() {
+        let cfg = BackendConfig {
+            secrets: vec![crate::secret_injection::CredentialRule {
+                name: "openai_api_key".to_string(),
+                credential_type: crate::secret_injection::CredentialType::ApiKey,
+                value: SENTINEL.to_string(),
+                inject_as: crate::secret_injection::InjectTarget::Header,
+                inject_key: "Authorization".to_string(),
+                tools: vec!["*".to_string()],
+            }],
+            ..Default::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked credential value: {dbg}");
+        assert!(
+            dbg.contains("<1 rules>"),
+            "missing rule-count marker: {dbg}"
+        );
+    }
+
+    // OAuthConfig::Debug must never surface the fixed client secret.
+    #[test]
+    fn oauth_config_debug_redacts_client_secret() {
+        let cfg = OAuthConfig {
+            enabled: true,
+            scopes: vec!["read".to_string()],
+            client_id: Some("client-123".to_string()),
+            client_secret: Some(SENTINEL.to_string()),
+            callback_host: None,
+            callback_port: None,
+            callback_path: None,
+            token_refresh_buffer_secs: 300,
+            shared_account: false,
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked client_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("client-123"),
+            "client_id should stay visible: {dbg}"
+        );
+    }
+}

--- a/src/gateway/oauth/agents.rs
+++ b/src/gateway/oauth/agents.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use super::scopes::Scope;
 
 /// A registered agent definition.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AgentDefinition {
     /// Unique client identifier (issued at registration).
     pub client_id: String,
@@ -43,6 +43,24 @@ pub struct AgentDefinition {
     /// Optional expected audience (`aud` claim).
     #[serde(default)]
     pub audience: Option<String>,
+}
+
+// Manual `Debug` that redacts the HS256 shared secret (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the token-signing secret verbatim; the
+// RSA *public* key is not secret and stays visible.
+impl std::fmt::Debug for AgentDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("AgentDefinition")
+            .field("client_id", &self.client_id)
+            .field("name", &self.name)
+            .field("hs256_secret", &redact_opt(&self.hs256_secret))
+            .field("rs256_public_key", &self.rs256_public_key)
+            .field("scopes", &self.scopes)
+            .field("issuer", &self.issuer)
+            .field("audience", &self.audience)
+            .finish()
+    }
 }
 
 impl AgentDefinition {
@@ -195,5 +213,37 @@ mod tests {
 
         // Both should see the same underlying store
         assert_eq!(reg2.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // AgentDefinition::Debug must redact the HS256 secret while keeping the
+    // (non-secret) RSA public key visible.
+    #[test]
+    fn agent_definition_debug_redacts_hs256_secret() {
+        let agent = AgentDefinition {
+            client_id: "agent-1".to_string(),
+            name: "Agent One".to_string(),
+            hs256_secret: Some(SENTINEL.to_string()),
+            rs256_public_key: Some("-----BEGIN PUBLIC KEY-----".to_string()),
+            scopes: vec!["tools:*".to_string()],
+            issuer: None,
+            audience: None,
+        };
+        let dbg = format!("{agent:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked hs256_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("BEGIN PUBLIC KEY"),
+            "public key is not secret and should stay visible: {dbg}"
+        );
     }
 }

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -97,7 +97,7 @@ pub struct OAuthClient {
 }
 
 /// OAuth token response
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct TokenResponse {
     access_token: String,
     token_type: Option<String>,
@@ -106,19 +106,48 @@ struct TokenResponse {
     scope: Option<String>,
 }
 
+// Manual `Debug` that redacts the OAuth tokens (CWE-532, mirrors PR #323). A
+// derived `Debug` would print `access_token` / `refresh_token` verbatim into
+// any trace or error context.
+impl std::fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("TokenResponse")
+            .field("access_token", &"<redacted>")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field("refresh_token", &redact_opt(&self.refresh_token))
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
 /// Client registration response
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct ClientRegistrationResponse {
     client_id: String,
     #[allow(dead_code)]
     client_secret: Option<String>,
 }
 
+// Manual `Debug` that redacts the issued client secret (CWE-532, mirrors PR
+// #323). A derived `Debug` would print `client_secret` verbatim into any trace
+// or error context; only its presence is surfaced.
+impl std::fmt::Debug for ClientRegistrationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("ClientRegistrationResponse")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &redact_opt(&self.client_secret))
+            .finish()
+    }
+}
+
 /// Configuration for constructing an [`OAuthClient`].
 ///
 /// Bundles the optional per-provider settings so that [`OAuthClient::new`]
 /// stays within Clippy's argument-count limit.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct OAuthClientConfig {
     /// Pre-configured client ID.
     pub client_id: Option<String>,
@@ -132,6 +161,23 @@ pub struct OAuthClientConfig {
     pub callback_path: Option<String>,
     /// Seconds before expiry to proactively refresh (default: 300).
     pub token_refresh_buffer_secs: u64,
+}
+
+// Manual `Debug` that redacts the fixed OAuth client secret (CWE-532, mirrors
+// PR #323). A derived `Debug` would print `client_secret` verbatim into any
+// trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for OAuthClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let redact_opt = |v: &Option<String>| if v.is_some() { "<redacted>" } else { "None" };
+        f.debug_struct("OAuthClientConfig")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &redact_opt(&self.client_secret))
+            .field("callback_host", &self.callback_host)
+            .field("callback_port", &self.callback_port)
+            .field("callback_path", &self.callback_path)
+            .field("token_refresh_buffer_secs", &self.token_refresh_buffer_secs)
+            .finish()
+    }
 }
 
 impl OAuthClient {
@@ -893,3 +939,71 @@ fn open_browser(url: &str) -> bool {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // TokenResponse::Debug must never surface the access/refresh tokens.
+    #[test]
+    fn token_response_debug_redacts_tokens() {
+        let r = TokenResponse {
+            access_token: SENTINEL.to_string(),
+            token_type: Some("Bearer".to_string()),
+            expires_in: Some(3600),
+            refresh_token: Some(format!("{SENTINEL}-refresh")),
+            scope: Some("read".to_string()),
+        };
+        let dbg = format!("{r:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked token: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("Bearer"),
+            "token_type should stay visible: {dbg}"
+        );
+    }
+
+    // ClientRegistrationResponse::Debug must never surface the issued secret.
+    #[test]
+    fn client_registration_response_debug_redacts_secret() {
+        let r = ClientRegistrationResponse {
+            client_id: "client-123".to_string(),
+            client_secret: Some(SENTINEL.to_string()),
+        };
+        let dbg = format!("{r:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked client_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("client-123"),
+            "client_id should stay visible: {dbg}"
+        );
+    }
+
+    // OAuthClientConfig::Debug must never surface the fixed client secret.
+    #[test]
+    fn oauth_client_config_debug_redacts_client_secret() {
+        let cfg = OAuthClientConfig {
+            client_secret: Some(SENTINEL.to_string()),
+            client_id: Some("client-123".to_string()),
+            ..Default::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked client_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
+        assert!(
+            dbg.contains("client-123"),
+            "client_id should stay visible: {dbg}"
+        );
+    }
+}

--- a/src/security/transparency_log.rs
+++ b/src/security/transparency_log.rs
@@ -79,7 +79,7 @@ const MAX_TAIL_SCAN_BYTES: u64 = 4 * 1024 * 1024;
 ///
 /// Serialisation lives in `src/config/features/security.rs` alongside the
 /// other security configs; this struct is the "resolved" in-memory copy.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TransparencyLogConfig {
     /// Enable the transparency log.  Default: `false` (opt-in).
     pub enabled: bool,
@@ -90,6 +90,27 @@ pub struct TransparencyLogConfig {
     /// HMAC shared secret.  When empty, the `sig` / `key_id` fields are
     /// omitted from each entry (hash chain still provides tamper evidence).
     pub shared_secret: String,
+}
+
+// Manual `Debug` that redacts the HMAC shared secret (CWE-532, mirrors PR
+// #323). A derived `Debug` would print the resolved signing secret verbatim
+// into any trace or error context; only its presence is surfaced.
+impl std::fmt::Debug for TransparencyLogConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransparencyLogConfig")
+            .field("enabled", &self.enabled)
+            .field("path", &self.path)
+            .field("key_id", &self.key_id)
+            .field(
+                "shared_secret",
+                &if self.shared_secret.is_empty() {
+                    "<empty>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .finish()
+    }
 }
 
 impl Default for TransparencyLogConfig {
@@ -1293,5 +1314,28 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         let ok = bounded_read_to_string(tmp.path(), 200).unwrap();
         assert_eq!(ok.len(), 100);
+    }
+}
+
+#[cfg(test)]
+mod cwe532_debug_redaction {
+    use super::*;
+
+    const SENTINEL: &str = "SENTINEL_SECRET_a1b2c3";
+
+    // The resolved in-memory TransparencyLogConfig::Debug must never surface
+    // the HMAC shared secret.
+    #[test]
+    fn transparency_log_config_debug_redacts_shared_secret() {
+        let cfg = TransparencyLogConfig {
+            shared_secret: SENTINEL.to_string(),
+            ..TransparencyLogConfig::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains(SENTINEL), "leaked shared_secret: {dbg}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "missing redaction marker: {dbg}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a CWE-532 secret-leak lint (`scripts/dev/cwe532-leak-lint.py`) and wires it into the CI and release gates. It flags `#[derive(Debug)]` structs and log macros (`info!` / `error!` / `println!`) that interpolate secret-named fields, which is the leak-into-logs class fixed in #323.

## Relation to the existing secrets-scan

The current `secrets-scan` job (trufflehog) scans git history for committed secret values. This lint targets a different class: secrets reaching logs at runtime through `Debug` or format strings. Complementary, not a duplicate.

## Design notes

- Baseline keyed by a stable `(path, kind, field)` identity rather than line number, so it survives unrelated edits.
- `// ci-allow-secret-*` escape markers for reviewed exceptions.
