### PR TITLE
fix(idp-audit): fail-closed on identity-propagation audit write failure (MIK-6740 hardening)

### DIFF
--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -3132,6 +3132,16 @@ mod identity_propagation_enforcement_tests {
             output.status,
             String::from_utf8_lossy(&output.stderr)
         );
+        // The child must also EXIT cleanly: a child that prints the marker and
+        // then aborts (panic/abort after the observation) must not read as a
+        // pass. Mirrors the two sibling fail-closed subprocess tests.
+        assert!(
+            output.status.success(),
+            "child printed the marker but did not exit successfully \
+             (status={:?}, stderr={})",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[tokio::test]

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1555,9 +1555,18 @@ impl MetaMcp {
                         Some(audience),
                         None,
                     ) {
+                        // CWE-209: `audit_err` can carry the transparency-log
+                        // filesystem path / IO detail. Keep it in the server log
+                        // only; return a generic client-facing message so the
+                        // sensitive detail never reaches the JSON-RPC caller
+                        // (mirrors the direct route in backend_handlers.rs).
+                        tracing::warn!(
+                            server,
+                            error = %audit_err,
+                            "identity-propagation mint audit write failed"
+                        );
                         return Err(Error::Internal(format!(
-                            "identity-propagation audit write failed for backend '{server}': \
-                             {audit_err}"
+                            "identity-propagation audit unavailable for backend '{server}'"
                         )));
                     }
                 }
@@ -3018,6 +3027,113 @@ mod identity_propagation_enforcement_tests {
             captured.lock()
         );
     }
+
+    // CWE-209 (PR #355 codex re-review): when a required mint SUCCEEDS but the
+    // mint audit-write FAILS, the branch must fail closed AND return a GENERIC
+    // client-facing error — never interpolate the underlying transparency-log
+    // error (`PropagationError::AuditFailed`, which wraps the append IO error /
+    // filesystem detail) into the caller-visible string. This drives a genuine
+    // audit-write failure through `resolve_caller_credential` and asserts the
+    // returned `Error::Internal` carries only the generic message.
+    //
+    // Failure-injection mirrors
+    // `identity_propagation::tests::audit_fail_closed::mint_write_failure_is_fail_closed`:
+    // POSIX checks file permissions only at `open(2)`, so a real write failure
+    // is forced with process-wide `RLIMIT_FSIZE=0` (every write -> `EFBIG`) in a
+    // re-exec'd CHILD process. `open()` writes nothing so it still succeeds;
+    // in-memory minting still succeeds; only the audit append fails. Unix-only.
+    #[cfg(unix)]
+    #[test]
+    fn mint_audit_write_failure_returns_generic_error_no_leak() {
+        const ENV_VAR: &str = "IDP_INVOKE_AUDIT_FSIZE_CHILD_PATH";
+        const MARK_OK: &str = "MINT_AUDIT_ERROR_WAS_GENERIC";
+        const TEST_PATH: &str = "gateway::meta_mcp::invoke::identity_propagation_enforcement_tests::mint_audit_write_failure_returns_generic_error_no_leak";
+
+        if std::env::var(ENV_VAR).is_ok() {
+            // Child: RLIMIT_FSIZE=0 is already active (parent shell wrapper), so
+            // the transparency-log append write fails while the in-memory mint
+            // succeeds — exercising exactly the fixed mint-audit-failure branch.
+            use crate::security::TransparencyLogger;
+            use crate::security::transparency_log::TransparencyLogConfig;
+
+            let path = std::env::var(ENV_VAR).expect("child path env var");
+            let cfg = Arc::new(TransparencyLogConfig {
+                enabled: true,
+                path,
+                key_id: "test".to_string(),
+                shared_secret: String::new(),
+            });
+            let logger = Arc::new(
+                TransparencyLogger::open(cfg).expect("open() writes nothing, must succeed"),
+            );
+            let mut m = meta_with_strategy();
+            m.enable_transparency_log(logger);
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("current-thread runtime");
+            let err = rt.block_on(async {
+                m.resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
+                    .await
+                    .expect_err("required mint whose audit write fails must fail closed")
+            });
+            let msg = err.to_string();
+
+            // Fail-closed preserved: still an Internal error (mint aborted).
+            assert!(
+                matches!(err, crate::Error::Internal(_)),
+                "mint-audit failure must fail closed as Internal: {err}"
+            );
+            // Generic client-facing message (backend name is a non-sensitive id).
+            assert!(
+                msg.contains("audit unavailable") && msg.contains("memory"),
+                "must return the generic audit-unavailable message: {msg}"
+            );
+            // The pre-fix leak: none of the underlying transparency-log /
+            // AuditFailed detail may reach the caller-visible string.
+            for leaked in [
+                "transparency-log write failed",
+                "audit write failed",
+                "action 'idp_mint'",
+                "File too large",
+                "os error",
+            ] {
+                assert!(
+                    !msg.contains(leaked),
+                    "client-facing mint-audit error must not leak {leaked:?}: {msg}"
+                );
+            }
+            println!("{MARK_OK}");
+            return;
+        }
+
+        // Parent: re-exec this exact test under RLIMIT_FSIZE=0 and assert on
+        // what the child observed. `trap '' XFSZ` ignores SIGXFSZ (whose default
+        // disposition would kill the child) so the write returns `Err` instead.
+        let exe = std::env::current_exe().expect("current test binary path");
+        let file = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = file.path().to_string_lossy().to_string();
+        let script =
+            format!("ulimit -f 0; trap '' XFSZ; exec \"$0\" '{TEST_PATH}' --exact --nocapture");
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .arg(&exe)
+            .env(ENV_VAR, &path)
+            .output()
+            .expect("spawn fsize-limited child process");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(MARK_OK),
+            "child did not confirm a generic (non-leaking) mint-audit error \
+             (status={:?}, stdout={stdout}, stderr={})",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     #[tokio::test]
     async fn mints_bearer_credential_for_identity() {
         let mut m = meta_with_strategy();

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1528,6 +1528,25 @@ impl MetaMcp {
                     // reach the caller without a durable audit record, so an
                     // audit-write failure here aborts the mint instead of
                     // proceeding to `Ok(CallerCredential{..})`.
+                    //
+                    // Operator-misconfig fail-OPEN guard: the audit helper
+                    // treats `logger = None` (transparency log disabled) as a
+                    // no-op `Ok(())`. On a `required` backend that would let a
+                    // minted per-user credential go on the wire with NO audit
+                    // record — the "no mint without a durable audit record"
+                    // guarantee silently evaporating via misconfiguration. When
+                    // propagation is REQUIRED but no transparency log is
+                    // configured, fail closed on the SAME path as an audit-write
+                    // failure rather than mint blind. (Non-required backends
+                    // keep the `None -> Ok(())` best-effort behavior — a mint
+                    // there is not covered by the durable-record guarantee.)
+                    if idp_cfg.required && audit_logger.is_none() {
+                        return Err(Error::Internal(format!(
+                            "identity-propagation is required for backend '{server}' but no \
+                             transparency log is configured; refusing to mint a per-user \
+                             credential without a durable audit record"
+                        )));
+                    }
                     if let Err(audit_err) = crate::identity_propagation::audit_identity_propagation(
                         audit_logger,
                         "idp_mint",
@@ -2848,9 +2867,45 @@ mod identity_propagation_enforcement_tests {
         (m, captured)
     }
 
+    /// A transparency logger backed by a leaked tempfile — kept alive for the
+    /// whole test process so a `required`-backend mint has a durable audit sink
+    /// (without one, the MIK-6740 fail-closed guard aborts the mint). Leaking is
+    /// fine in a unit test: the file is reclaimed when the process exits.
+    fn leaked_test_transparency_logger() -> Arc<crate::security::TransparencyLogger> {
+        use crate::security::TransparencyLogger;
+        use crate::security::transparency_log::TransparencyLogConfig;
+
+        let file = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = file.path().to_string_lossy().to_string();
+        std::mem::forget(file); // keep the on-disk file alive for the test
+        let cfg = Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path,
+            key_id: "test".to_string(),
+            shared_secret: String::new(),
+        });
+        Arc::new(TransparencyLogger::open(cfg).expect("logger opens"))
+    }
+
     /// Like [`meta_with_capturing_backend`] but also exposes the buffer of
-    /// identity keys the transport received (MIK-6784).
+    /// identity keys the transport received (MIK-6784). Wires a transparency log
+    /// so a `required`-backend mint succeeds (the MIK-6740 fail-closed guard
+    /// aborts a required mint when no audit sink is configured).
     fn meta_with_capturing_backend_full() -> (MetaMcp, CapturedHeaders, CapturedIdentityKeys) {
+        build_capturing_backend(true)
+    }
+
+    /// Like [`meta_with_capturing_backend`] but with NO transparency log wired,
+    /// so a `required`-backend mint must fail closed (MIK-6740 operator-misconfig
+    /// guard).
+    fn meta_with_capturing_backend_no_log() -> (MetaMcp, CapturedHeaders) {
+        let (m, captured, _identity) = build_capturing_backend(false);
+        (m, captured)
+    }
+
+    fn build_capturing_backend(
+        with_transparency_log: bool,
+    ) -> (MetaMcp, CapturedHeaders, CapturedIdentityKeys) {
         use crate::backend::Backend;
         use crate::config::{BackendConfig, TransportConfig};
 
@@ -2878,9 +2933,12 @@ mod identity_propagation_enforcement_tests {
         }));
         registry.register(backend);
 
-        let m = MetaMcp::new(registry);
+        let mut m = MetaMcp::new(registry);
         let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
         m.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
+        if with_transparency_log {
+            m.enable_transparency_log(leaked_test_transparency_logger());
+        }
         (m, captured, captured_identity)
     }
 
@@ -2926,11 +2984,45 @@ mod identity_propagation_enforcement_tests {
         );
     }
 
-    // IDP.1 — with a verified identity + strategy, resolve mints an
-    // Authorization: Bearer credential scoped to the caller, and a cache binding.
+    // MIK-6740 operator-misconfig fail-OPEN guard (caller-level, end-to-end
+    // through Code Mode): a `required` backend whose credential mints
+    // successfully but whose transparency log is UNCONFIGURED must fail closed —
+    // the mint aborts with an error AND no per-user header reaches the backend
+    // transport. Without the guard, the audit helper's `None -> Ok(())` no-op
+    // would let the credential go on the wire with zero audit record.
+    #[tokio::test]
+    async fn required_mint_without_transparency_log_fails_closed() {
+        // Same required backend + strategy + capturing transport as the
+        // propagation-succeeds test, but with NO transparency log wired.
+        let (m, captured) = meta_with_capturing_backend_no_log();
+        let id = identity();
+        let caller = crate::gateway::meta_mcp::MetaMcpCallerContext {
+            verified_identity: Some(&id),
+            ..Default::default()
+        };
+        let args = json!({ "tool": "mem:read", "arguments": {} });
+        let err = m
+            .code_mode_execute(&args, Some("s1"), &caller)
+            .await
+            .expect_err("required mint with no audit sink must fail closed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("transparency log") || msg.contains("audit"),
+            "fail-closed error must cite the missing audit sink: {msg}"
+        );
+        // The security property: no per-user credential reached the wire.
+        assert!(
+            captured.lock().is_empty(),
+            "no per-user header must reach the backend when the mint fails closed; \
+             got {:?}",
+            captured.lock()
+        );
+    }
     #[tokio::test]
     async fn mints_bearer_credential_for_identity() {
-        let m = meta_with_strategy();
+        let mut m = meta_with_strategy();
+        // A `required` mint needs a durable audit sink (MIK-6740 fail-closed).
+        m.enable_transparency_log(leaked_test_transparency_logger());
         let cred = m
             .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
             .await
@@ -2946,7 +3038,9 @@ mod identity_propagation_enforcement_tests {
     // calling the same tool with the same arguments cannot collide in the cache.
     #[tokio::test]
     async fn distinct_identities_get_distinct_cache_bindings() {
-        let m = meta_with_strategy();
+        let mut m = meta_with_strategy();
+        // A `required` mint needs a durable audit sink (MIK-6740 fail-closed).
+        m.enable_transparency_log(leaked_test_transparency_logger());
         let alice = m
             .resolve_caller_credential("memory", &idp_cfg(true), Some(&identity()))
             .await

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -1440,14 +1440,25 @@ impl MetaMcp {
 
         let refuse = |msg: String| -> Result<CallerCredential> {
             if idp_cfg.required {
-                crate::identity_propagation::audit_identity_propagation(
+                // The request is already being refused on identity-propagation
+                // grounds; an audit-write failure here does not change that
+                // outcome (unlike the mint path below, which is fail-closed on
+                // the audit write itself) — but it must not be silently
+                // dropped, so it is logged.
+                if let Err(audit_err) = crate::identity_propagation::audit_identity_propagation(
                     audit_logger,
                     "idp_refuse",
                     &subject_id,
                     server,
                     Some(audience),
                     Some(&msg),
-                );
+                ) {
+                    tracing::warn!(
+                        server,
+                        error = %audit_err,
+                        "identity-propagation refuse audit write failed"
+                    );
+                }
                 Err(Error::Config(format!(
                     "identity propagation required for backend '{server}' but {msg}"
                 )))
@@ -1513,14 +1524,23 @@ impl MetaMcp {
                 // so per-user results cache in isolation instead of being dropped
                 // (IDP.8 — replaces the earlier blanket cache bypass).
                 if !cred.headers.is_empty() {
-                    crate::identity_propagation::audit_identity_propagation(
+                    // Fail-closed hardening: a minted credential must never
+                    // reach the caller without a durable audit record, so an
+                    // audit-write failure here aborts the mint instead of
+                    // proceeding to `Ok(CallerCredential{..})`.
+                    if let Err(audit_err) = crate::identity_propagation::audit_identity_propagation(
                         audit_logger,
                         "idp_mint",
                         &subject_id,
                         server,
                         Some(audience),
                         None,
-                    );
+                    ) {
+                        return Err(Error::Internal(format!(
+                            "identity-propagation audit write failed for backend '{server}': \
+                             {audit_err}"
+                        )));
+                    }
                 }
                 Ok(CallerCredential {
                     headers: cred.headers,

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -608,6 +608,30 @@ pub(super) async fn backend_handler(
                     // audit-write failure here aborts the mint instead of
                     // proceeding with the headers below (mirrors
                     // `identity_propagation::mod.rs`'s `resolve_caller_credential`).
+                    //
+                    // Operator-misconfig fail-OPEN guard: the audit helper
+                    // treats a missing logger (`None`) as a no-op `Ok(())`. On a
+                    // `required` backend that would ship a per-user credential
+                    // with NO audit record. When propagation is REQUIRED for
+                    // this backend but no transparency log is configured, fail
+                    // closed on the same error path as an audit-write failure.
+                    // (Non-required backends keep the best-effort `None -> Ok`.)
+                    let required = idp_cfg.as_ref().is_some_and(|c| c.required);
+                    if required && state.transparency_log.is_none() {
+                        warn!(
+                            backend = %name,
+                            "identity-propagation required but no transparency log is \
+                             configured; refusing to mint without a durable audit record"
+                        );
+                        return build_http_error_response(
+                            Some(id.clone()),
+                            -32603,
+                            // CWE-209: generic client-facing message; the
+                            // operational detail stays in the server log above.
+                            "identity-propagation audit unavailable".to_string(),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        );
+                    }
                     if let Err(audit_err) = audit_identity_propagation(
                         state.transparency_log.as_deref(),
                         "idp_mint",
@@ -616,13 +640,18 @@ pub(super) async fn backend_handler(
                         audience,
                         None,
                     ) {
+                        // CWE-209: the audit error can carry the transparency-log
+                        // filesystem path / IO error. Keep it in the server log
+                        // only; return a generic client-facing message.
+                        warn!(
+                            backend = %name,
+                            error = %audit_err,
+                            "identity-propagation mint audit write failed; failing closed"
+                        );
                         return build_http_error_response(
                             Some(id.clone()),
                             -32603,
-                            format!(
-                                "identity-propagation audit write failed for backend \
-                                 '{name}': {audit_err}"
-                            ),
+                            "identity-propagation audit unavailable".to_string(),
                             StatusCode::INTERNAL_SERVER_ERROR,
                         );
                     }

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -295,12 +295,28 @@ fn audit_subject(verified_identity: Option<&crate::key_server::oidc::VerifiedIde
 /// [`crate::security::TransparencyLogger::append_event`] — never the resolved
 /// credential header value or a raw assertion.
 ///
-/// ponytail: audit is best-effort, not fail-closed — a write failure is
-/// `warn!`'d and the caller's request proceeds/fails on its own merits,
-/// mirroring how `TransparencyLogger::log_invocation` failures are handled
-/// elsewhere in the gateway. A regulated buyer that needs "no mint without a
-/// durable audit record" would need this gated fail-closed instead; tracked
-/// as a possible future hardening, not required for MIK-6740.
+/// ponytail: duplicate of `identity_propagation::audit_identity_propagation`;
+/// kept in place to avoid a large-deletion refactor — dedup is follow-up debt.
+///
+/// Fail-closed hardening (mirrors `identity_propagation::audit_identity_propagation`,
+/// MIK-6740 hardening carried forward to this hand-duplicated copy): a
+/// transparency-log write failure is no longer swallowed. It is `warn!`'d AND
+/// returned as `Err(PropagationError::AuditFailed)`.
+///
+/// - **`idp_mint` callers MUST fail-closed**: propagate the `Err` and abort
+///   the mint/request. No mint without a durable audit record.
+/// - **`idp_refuse` callers**: the request is already being refused on other
+///   grounds, so the `Err` does not need to change the outcome, but MUST NOT
+///   be silently dropped (log via `tracing::warn!`).
+///
+/// `logger = None` (transparency log disabled) is `Ok(())` — a no-op, not a
+/// failure.
+///
+/// # Errors
+/// [`crate::identity_propagation::PropagationError::AuditFailed`] when
+/// [`crate::security::TransparencyLogger::append_event`] fails (e.g. disk
+/// full, permission revoked, filesystem gone read-only underneath the
+/// gateway).
 fn audit_identity_propagation(
     logger: Option<&crate::security::TransparencyLogger>,
     action: &'static str,
@@ -308,9 +324,9 @@ fn audit_identity_propagation(
     backend: &str,
     audience: Option<&str>,
     reason: Option<&str>,
-) {
+) -> Result<(), crate::identity_propagation::PropagationError> {
     let Some(logger) = logger else {
-        return;
+        return Ok(());
     };
 
     let mut fields = serde_json::Map::new();
@@ -325,13 +341,17 @@ fn audit_identity_propagation(
         fields.insert("reason".into(), reason.into());
     }
 
-    if let Err(e) = logger.append_event(fields) {
+    logger.append_event(fields).map(|_| ()).map_err(|e| {
         warn!(
             backend,
             action, error = %e,
-            "Failed to write identity-propagation audit entry (transparency log)"
+            "Failed to write identity-propagation audit entry (transparency log); \
+             fail-closed on idp_mint"
         );
-    }
+        crate::identity_propagation::PropagationError::AuditFailed(format!(
+            "transparency-log write failed for action '{action}' on backend '{backend}': {e}"
+        ))
+    })
 }
 
 /// Resolve just the identity-key session-bucket binding for a notification
@@ -583,26 +603,52 @@ pub(super) async fn backend_handler(
                 // unchanged static-credential fallback (IDP.5), not a mint —
                 // only audit when a per-user credential was actually attached.
                 if !headers.is_empty() {
-                    audit_identity_propagation(
+                    // Fail-closed hardening: a minted credential must never
+                    // reach the caller without a durable audit record, so an
+                    // audit-write failure here aborts the mint instead of
+                    // proceeding with the headers below (mirrors
+                    // `identity_propagation::mod.rs`'s `resolve_caller_credential`).
+                    if let Err(audit_err) = audit_identity_propagation(
                         state.transparency_log.as_deref(),
                         "idp_mint",
                         &subject,
                         &name,
                         audience,
                         None,
-                    );
+                    ) {
+                        return build_http_error_response(
+                            Some(id.clone()),
+                            -32603,
+                            format!(
+                                "identity-propagation audit write failed for backend \
+                                 '{name}': {audit_err}"
+                            ),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        );
+                    }
                 }
                 headers
             }
             Err(e) => {
-                audit_identity_propagation(
+                // The request is already being refused on identity-propagation
+                // grounds; an audit-write failure here does not change that
+                // outcome (unlike the mint path above, which is fail-closed on
+                // the audit write itself) — but it must not be silently
+                // dropped, so it is logged.
+                if let Err(audit_err) = audit_identity_propagation(
                     state.transparency_log.as_deref(),
                     "idp_refuse",
                     &subject,
                     &name,
                     audience,
                     Some(&e),
-                );
+                ) {
+                    warn!(
+                        backend = %name,
+                        error = %audit_err,
+                        "identity-propagation refuse audit write failed"
+                    );
+                }
                 return build_http_error_response(
                     Some(id.clone()),
                     -32003,

--- a/src/gateway/router/backend_handlers/tests.rs
+++ b/src/gateway/router/backend_handlers/tests.rs
@@ -216,10 +216,11 @@ mod identity_propagation_audit {
     }
 
     // A disabled transparency log (`logger = None`) must not panic and
-    // must not create a log file — pure no-op.
+    // must not create a log file — pure no-op success, not a failure (the
+    // mint path must not be blocked when no transparency log is configured).
     #[test]
     fn audit_identity_propagation_is_noop_when_logger_disabled() {
-        audit_identity_propagation(
+        let result = audit_identity_propagation(
             None,
             "idp_mint",
             "unauthenticated",
@@ -227,6 +228,7 @@ mod identity_propagation_audit {
             Some("https://aud.test.invalid"),
             None,
         );
+        assert_eq!(result, Ok(()));
     }
 
     // IDP4.1 — a successful mint records `action="idp_mint"` with subject,
@@ -237,7 +239,7 @@ mod identity_propagation_audit {
         let id = identity("alice");
         let subject = audit_subject(Some(&id));
 
-        audit_identity_propagation(
+        let result = audit_identity_propagation(
             Some(&logger),
             "idp_mint",
             &subject,
@@ -245,6 +247,7 @@ mod identity_propagation_audit {
             Some("https://github.test.invalid/api"),
             None,
         );
+        assert_eq!(result, Ok(()));
 
         let entries = read_entries(file.path());
         assert_eq!(entries.len(), 1);
@@ -265,7 +268,7 @@ mod identity_propagation_audit {
         let (file, logger) = open_logger();
         let subject = audit_subject(None);
 
-        audit_identity_propagation(
+        let result = audit_identity_propagation(
             Some(&logger),
             "idp_refuse",
             &subject,
@@ -276,6 +279,7 @@ mod identity_propagation_audit {
                      no passthrough credential (ADR-008 D.3, fail-closed)",
             ),
         );
+        assert_eq!(result, Ok(()));
 
         let entries = read_entries(file.path());
         assert_eq!(entries.len(), 1);
@@ -355,7 +359,8 @@ mod identity_propagation_audit {
             "backend-a",
             Some(audience),
             None,
-        );
+        )
+        .expect("mint audit write succeeds");
         // A refuse: the reason string is a fixed fail-closed message, never
         // the credential the caller failed to supply.
         audit_identity_propagation(
@@ -365,7 +370,8 @@ mod identity_propagation_audit {
             "backend-b",
             Some("https://backend-b.test.invalid"),
             Some("identity propagation required but no credential was supplied"),
-        );
+        )
+        .expect("refuse audit write succeeds");
 
         let raw = std::fs::read_to_string(file.path()).expect("log file readable");
         assert!(
@@ -399,6 +405,89 @@ mod identity_propagation_audit {
         }
         assert_eq!(entries[0]["action"], "idp_mint");
         assert_eq!(entries[1]["action"], "idp_refuse");
+    }
+
+    // Fail-closed hardening: a genuine transparency-log write failure MUST
+    // surface as `Err(PropagationError::AuditFailed)` from this hand-duplicated
+    // copy too — never be swallowed. Mirrors
+    // `identity_propagation::tests::audit_fail_closed::mint_write_failure_is_fail_closed`.
+    //
+    // Failure-injection technique: POSIX only checks file permissions at
+    // `open(2)`, not at each `write(2)` (verified empirically — chmod/`chflags
+    // uchg` on an already-open fd do NOT make subsequent writes fail on
+    // macOS/Linux). A real write failure is forced with `RLIMIT_FSIZE=0`
+    // (every write becomes `EFBIG`), which is process-wide and would corrupt
+    // any other test in this binary that touches a file concurrently — so the
+    // limited write happens in a *child process* only. A POSIX shell wrapper
+    // (`ulimit -f 0; trap '' XFSZ; exec ...`) sets the limit and ignores
+    // `SIGXFSZ` (default disposition kills the process) before re-`exec`ing
+    // this exact test binary/test with an env var that makes the child branch
+    // run the actual assertion and report its outcome over stdout — no
+    // `unsafe` code, no new dependency, isolated to the child only. Unix-only
+    // (the technique is POSIX shell + rlimit).
+    #[cfg(unix)]
+    #[test]
+    fn mint_write_failure_is_fail_closed() {
+        const ENV_VAR: &str = "IDP_AUDIT_FSIZE_CHILD_PATH_BACKEND_HANDLERS";
+        const MARK_OK: &str = "AUDIT_WRITE_FAILED_AS_EXPECTED";
+        const TEST_PATH: &str = "gateway::router::backend_handlers::tests::\
+             identity_propagation_audit::mint_write_failure_is_fail_closed";
+
+        if let Ok(path) = std::env::var(ENV_VAR) {
+            // Child process: RLIMIT_FSIZE=0 + SIGXFSZ ignored are already
+            // active (set by the parent's shell wrapper below), so any write
+            // here returns `Err` (`EFBIG`), never panics/aborts.
+            let cfg = Arc::new(TransparencyLogConfig {
+                enabled: true,
+                path,
+                key_id: "test".to_string(),
+                shared_secret: String::new(),
+            });
+            // `open()` performs no write (only reads an existing tail, if
+            // any), so it must still succeed under the zero file-size limit —
+            // only the append write below is expected to fail.
+            let logger =
+                TransparencyLogger::open(cfg).expect("open() writes nothing, must succeed");
+            let result = audit_identity_propagation(
+                Some(&logger),
+                "idp_mint",
+                "alice",
+                "github",
+                Some("https://github.test.invalid/api"),
+                None,
+            );
+            match result {
+                Err(crate::identity_propagation::PropagationError::AuditFailed(_)) => {
+                    println!("{MARK_OK}");
+                }
+                other => println!("UNEXPECTED_RESULT:{other:?}"),
+            }
+            return;
+        }
+
+        // Parent: re-exec this exact test in an RLIMIT_FSIZE=0 child and
+        // assert on what it observed.
+        let exe = std::env::current_exe().expect("current test binary path");
+        let file = NamedTempFile::new().expect("tempfile");
+        let path = file.path().to_string_lossy().to_string();
+        let script =
+            format!("ulimit -f 0; trap '' XFSZ; exec \"$0\" '{TEST_PATH}' --exact --nocapture");
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .arg(&exe)
+            .env(ENV_VAR, &path)
+            .output()
+            .expect("spawn fsize-limited child process");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(MARK_OK),
+            "child did not observe a fail-closed AuditFailed error \
+             (status={:?}, stdout={stdout}, stderr={})",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 

--- a/src/gateway/router/backend_handlers/tests.rs
+++ b/src/gateway/router/backend_handlers/tests.rs
@@ -488,6 +488,16 @@ mod identity_propagation_audit {
             output.status,
             String::from_utf8_lossy(&output.stderr)
         );
+        // The child must also EXIT cleanly: a child that prints the marker and
+        // then aborts (panic/abort after the observation) must not read as a
+        // pass.
+        assert!(
+            output.status.success(),
+            "child printed the marker but did not exit successfully \
+             (status={:?}, stderr={})",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -173,6 +173,81 @@ fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
     state
 }
 
+/// AppState whose Meta-MCP has an identity-propagation strategy wired (so a
+/// `required` backend actually MINTS a per-user credential) AND a transparency
+/// log on the Meta-MCP side (so the shared mint chokepoint's own audit
+/// succeeds) — but with `state.transparency_log = None`. This split-config
+/// exercises the direct route's OWN mint-audit fail-closed guard (MIK-6740):
+/// the Meta-MCP mint + audit succeed, then the direct route finds no
+/// `state.transparency_log` and must fail closed (500) rather than ship the
+/// per-user credential without recording it on this route.
+fn test_router_app_state_minting_without_route_audit(backend: Arc<Backend>) -> Arc<AppState> {
+    use crate::identity_propagation::SignedAssertionStrategy;
+    use crate::security::TransparencyLogger;
+    use crate::security::transparency_log::TransparencyLogConfig;
+
+    let backends = Arc::new(BackendRegistry::new());
+    backends.register(backend);
+    let mut meta = MetaMcp::new(Arc::clone(&backends));
+    let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
+    meta.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
+    // Meta-MCP side gets an audit sink (leaked tempfile — reclaimed at process
+    // exit); the DIRECT route deliberately does NOT (`transparency_log: None`).
+    let file = tempfile::NamedTempFile::new().expect("tempfile");
+    let path = file.path().to_string_lossy().to_string();
+    std::mem::forget(file);
+    let cfg = Arc::new(TransparencyLogConfig {
+        enabled: true,
+        path,
+        key_id: "test".to_string(),
+        shared_secret: String::new(),
+    });
+    meta.enable_transparency_log(Arc::new(
+        TransparencyLogger::open(cfg).expect("logger opens"),
+    ));
+    let meta_mcp = Arc::new(meta);
+
+    let streaming_config = StreamingConfig::default();
+    let multiplexer = Arc::new(NotificationMultiplexer::new(
+        Arc::clone(&backends),
+        streaming_config.clone(),
+    ));
+    let proxy_manager = Arc::new(ProxyManager::new(Arc::clone(&multiplexer)));
+    let auth_config = Arc::new(ResolvedAuthConfig::from_config(&AuthConfig::default()));
+    let agent_auth = AgentAuthState::new(false, Arc::new(AgentRegistry::new()));
+    let gateway_key_pair = Arc::new(GatewayKeyPair::generate().expect("gateway key generation"));
+
+    Arc::new(AppState {
+        backends,
+        meta_mcp,
+        meta_mcp_enabled: true,
+        multiplexer,
+        proxy_manager,
+        streaming_config,
+        auth_config,
+        key_server: None,
+        tool_policy: Arc::new(crate::security::ToolPolicy::default()),
+        mtls_policy: Arc::new(MtlsPolicy::from_config(&MtlsConfig::default())),
+        sanitize_input: false,
+        ssrf_protection: false,
+        trust_configured_backends: false,
+        inflight: Arc::new(tokio::sync::Semaphore::new(8)),
+        agent_auth,
+        gateway_key_pair,
+        capability_dirs: Vec::new(),
+        config_path: None,
+        #[cfg(feature = "firewall")]
+        firewall: None,
+        agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
+        export_status: None,
+        transparency_log: None,
+    })
+}
+
 fn test_router_app_state_with_ssrf(
     ssrf_protection: bool,
     trust_configured_backends: bool,
@@ -892,6 +967,85 @@ async fn backend_handler_discovery_method_fails_closed_for_required_propagation(
             .contains("required"),
         "fail-closed error message: {}",
         json["error"]["message"]
+    );
+}
+
+#[tokio::test]
+async fn backend_handler_required_mint_without_route_audit_fails_closed_generically() {
+    // MIK-6740 operator-misconfig fail-OPEN guard on the DIRECT route: a
+    // `required` backend whose per-user credential mints successfully but whose
+    // route-side transparency log is UNCONFIGURED must fail closed (500) — never
+    // ship the credential without a durable audit record. CWE-209: the 500 body
+    // must be a GENERIC client message, never the transparency-log path / IO
+    // error.
+    use crate::identity_propagation::{
+        IdentityPropagationConfig, PropagationStrategyKind, SessionMode,
+    };
+    use crate::key_server::oidc::VerifiedIdentity;
+
+    let config = BackendConfig {
+        transport: crate::config::TransportConfig::Http {
+            http_url: "https://mem.internal/mcp".to_string(),
+            streamable_http: true,
+            protocol_version: None,
+        },
+        identity_propagation: Some(IdentityPropagationConfig {
+            strategy: PropagationStrategyKind::SignedAssertion,
+            audience: "https://mem.internal/mcp".to_string(),
+            required: true,
+            session_mode: SessionMode::Stateless,
+            token_exchange_endpoint: None,
+            token_exchange_scope: None,
+        }),
+        enabled: true,
+        ..BackendConfig::default()
+    };
+    let backend = Arc::new(Backend::new(
+        "demo",
+        config,
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let router = create_router(test_router_app_state_minting_without_route_audit(backend));
+
+    let mut request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "read", "arguments": {} }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    // Inject a verified end-user identity so the required backend actually MINTS
+    // a per-user credential. Auth is disabled in this test state, so the
+    // middleware does not overwrite the extension.
+    request.extensions_mut().insert(VerifiedIdentity {
+        subject: "alice".to_string(),
+        email: "alice@corp".to_string(),
+        name: None,
+        groups: vec![],
+        issuer: "https://idp".to_string(),
+    });
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let msg = json["error"]["message"].as_str().unwrap();
+    // Generic client-facing message — the whole point of the CWE-209 fix.
+    assert_eq!(msg, "identity-propagation audit unavailable");
+    // Defense-in-depth: no filesystem path or IO detail leaks to the client.
+    assert!(!msg.contains('/'), "must not leak a filesystem path: {msg}");
+    assert!(
+        !msg.to_lowercase().contains("write failed"),
+        "must not leak audit IO detail: {msg}"
     );
 }
 

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -173,7 +173,7 @@ fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
     state
 }
 
-/// AppState whose Meta-MCP has an identity-propagation strategy wired (so a
+/// `AppState` whose Meta-MCP has an identity-propagation strategy wired (so a
 /// `required` backend actually MINTS a per-user credential) AND a transparency
 /// log on the Meta-MCP side (so the shared mint chokepoint's own audit
 /// succeeds) — but with `state.transparency_log = None`. This split-config

--- a/src/identity_propagation/mod.rs
+++ b/src/identity_propagation/mod.rs
@@ -126,6 +126,14 @@ pub enum PropagationError {
     Refuse(String),
     /// The propagation configuration is invalid (operator error).
     Misconfigured(String),
+    /// The tamper-evident transparency-log audit write failed.
+    ///
+    /// Fail-closed hardening (operator decision, regulated-buyer posture): a
+    /// minted credential MUST NOT be used when its `idp_mint` audit record
+    /// could not be durably written, so callers on the mint path treat this
+    /// as fatal and abort the request. See
+    /// [`audit_identity_propagation`] for the full contract.
+    AuditFailed(String),
 }
 
 impl std::fmt::Display for PropagationError {
@@ -133,6 +141,10 @@ impl std::fmt::Display for PropagationError {
         match self {
             Self::Refuse(m) => write!(f, "identity propagation refused (fail-closed): {m}"),
             Self::Misconfigured(m) => write!(f, "identity propagation misconfigured: {m}"),
+            Self::AuditFailed(m) => write!(
+                f,
+                "identity-propagation audit write failed (fail-closed): {m}"
+            ),
         }
     }
 }
@@ -506,12 +518,28 @@ pub(crate) fn audit_subject(
 /// [`crate::security::TransparencyLogger::append_event`] — never the resolved
 /// credential header value or a raw assertion.
 ///
-/// ponytail: audit is best-effort, not fail-closed — a write failure is
-/// `warn!`'d and the caller's request proceeds/fails on its own merits,
-/// mirroring how `TransparencyLogger::log_invocation` failures are handled
-/// elsewhere in the gateway. A regulated buyer that needs "no mint without a
-/// durable audit record" would need this gated fail-closed instead; tracked as
-/// a possible future hardening, not required for MIK-6740.
+/// ponytail: audit was previously best-effort for every action — a write
+/// failure was `warn!`'d and the caller's request proceeded/failed on its own
+/// merits, mirroring how `TransparencyLogger::log_invocation` failures are
+/// handled elsewhere in the gateway. Hardened for regulated-buyer posture: a
+/// minted credential MUST NOT go on the wire without a durable audit record,
+/// so a write failure now returns `Err(PropagationError::AuditFailed)` in
+/// addition to the `warn!`.
+///
+/// - **`idp_mint` callers MUST fail-closed**: propagate the `Err` and abort
+///   the mint/request. No mint without a durable audit record.
+/// - **`idp_refuse` callers**: the request is already being refused on other
+///   grounds, so the `Err` does not need to change the outcome, but MUST NOT
+///   be silently dropped (log or propagate as fits the call site).
+///
+/// `logger = None` (transparency log disabled) is `Ok(())` — a no-op, not a
+/// failure.
+///
+/// # Errors
+/// [`PropagationError::AuditFailed`] when
+/// [`crate::security::TransparencyLogger::append_event`] fails (e.g. disk
+/// full, permission revoked, filesystem gone read-only underneath the
+/// gateway).
 pub(crate) fn audit_identity_propagation(
     logger: Option<&crate::security::TransparencyLogger>,
     action: &'static str,
@@ -519,9 +547,9 @@ pub(crate) fn audit_identity_propagation(
     backend: &str,
     audience: Option<&str>,
     reason: Option<&str>,
-) {
+) -> Result<(), PropagationError> {
     let Some(logger) = logger else {
-        return;
+        return Ok(());
     };
 
     let mut fields = serde_json::Map::new();
@@ -536,13 +564,17 @@ pub(crate) fn audit_identity_propagation(
         fields.insert("reason".into(), reason.into());
     }
 
-    if let Err(e) = logger.append_event(fields) {
+    logger.append_event(fields).map(|_| ()).map_err(|e| {
         tracing::warn!(
             backend,
             action, error = %e,
-            "Failed to write identity-propagation audit entry (transparency log)"
+            "Failed to write identity-propagation audit entry (transparency log); \
+             fail-closed on idp_mint"
         );
-    }
+        PropagationError::AuditFailed(format!(
+            "transparency-log write failed for action '{action}' on backend '{backend}': {e}"
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -780,5 +812,139 @@ mod tests {
     fn non_required_backend_ignores_transport_capability() {
         assert!(ensure_transport_carries_identity_headers(false, false).is_ok());
         assert!(ensure_transport_carries_identity_headers(false, true).is_ok());
+    }
+
+    // Fail-closed audit hardening — `audit_identity_propagation` unit tests.
+    mod audit_fail_closed {
+        use std::sync::Arc;
+
+        use tempfile::NamedTempFile;
+
+        use super::*;
+        use crate::security::TransparencyLogger;
+        use crate::security::transparency_log::TransparencyLogConfig;
+
+        fn open_logger() -> (NamedTempFile, TransparencyLogger) {
+            let file = NamedTempFile::new().expect("tempfile");
+            let cfg = Arc::new(TransparencyLogConfig {
+                enabled: true,
+                path: file.path().to_string_lossy().to_string(),
+                key_id: "test".to_string(),
+                shared_secret: String::new(),
+            });
+            let logger = TransparencyLogger::open(cfg).expect("logger opens");
+            (file, logger)
+        }
+
+        // `logger = None` (transparency log disabled) is a no-op success, not
+        // a failure — the mint path must not be blocked when the operator has
+        // not configured a transparency log at all.
+        #[test]
+        fn logger_disabled_is_ok_noop() {
+            let result = audit_identity_propagation(
+                None,
+                "idp_mint",
+                "alice",
+                "github",
+                Some("https://github.test.invalid/api"),
+                None,
+            );
+            assert_eq!(result, Ok(()));
+        }
+
+        // A durable write succeeds and reports `Ok(())`.
+        #[test]
+        fn mint_write_success_is_ok() {
+            let (_file, logger) = open_logger();
+            let result = audit_identity_propagation(
+                Some(&logger),
+                "idp_mint",
+                "alice",
+                "github",
+                Some("https://github.test.invalid/api"),
+                None,
+            );
+            assert_eq!(result, Ok(()));
+        }
+
+        // Fail-closed contract: a genuine transparency-log write failure MUST
+        // surface as `Err(PropagationError::AuditFailed)`, never be swallowed.
+        //
+        // Failure-injection technique: POSIX only checks file permissions at
+        // `open(2)`, not at each `write(2)` — verified empirically (chmod and
+        // `chflags uchg` on an already-open fd do NOT make subsequent writes
+        // fail on macOS/Linux). A real write failure is therefore forced with
+        // `RLIMIT_FSIZE=0` (every write becomes `EFBIG`), which is
+        // process-wide and would corrupt any other test in this binary that
+        // touches a file concurrently — so the limited write happens in a
+        // *child process* only. A POSIX shell wrapper (`ulimit -f 0; trap ''
+        // XFSZ; exec ...`) sets the limit and ignores `SIGXFSZ` (whose
+        // default disposition is to kill the process) before re-`exec`ing
+        // this exact test binary/test with an env var that makes the child
+        // branch run the actual assertion and report its outcome over
+        // stdout — no `unsafe` code, no new dependency, isolated to the
+        // child only. Unix-only (the technique is POSIX shell + rlimit).
+        #[cfg(unix)]
+        #[test]
+        fn mint_write_failure_is_fail_closed() {
+            const ENV_VAR: &str = "IDP_AUDIT_FSIZE_CHILD_PATH";
+            const MARK_OK: &str = "AUDIT_WRITE_FAILED_AS_EXPECTED";
+            const TEST_PATH: &str =
+                "identity_propagation::tests::audit_fail_closed::mint_write_failure_is_fail_closed";
+
+            if let Ok(path) = std::env::var(ENV_VAR) {
+                // Child process: RLIMIT_FSIZE=0 + SIGXFSZ ignored are already
+                // active (set by the parent's shell wrapper below), so any
+                // write here returns `Err` (`EFBIG`), never panics/aborts.
+                let cfg = Arc::new(TransparencyLogConfig {
+                    enabled: true,
+                    path,
+                    key_id: "test".to_string(),
+                    shared_secret: String::new(),
+                });
+                // `open()` performs no write (only reads an existing tail, if
+                // any), so it must still succeed under the zero file-size
+                // limit — only the append write below is expected to fail.
+                let logger =
+                    TransparencyLogger::open(cfg).expect("open() writes nothing, must succeed");
+                let result = audit_identity_propagation(
+                    Some(&logger),
+                    "idp_mint",
+                    "alice",
+                    "github",
+                    Some("https://github.test.invalid/api"),
+                    None,
+                );
+                match result {
+                    Err(PropagationError::AuditFailed(_)) => println!("{MARK_OK}"),
+                    other => println!("UNEXPECTED_RESULT:{other:?}"),
+                }
+                return;
+            }
+
+            // Parent: re-exec this exact test in an RLIMIT_FSIZE=0 child and
+            // assert on what it observed.
+            let exe = std::env::current_exe().expect("current test binary path");
+            let file = NamedTempFile::new().expect("tempfile");
+            let path = file.path().to_string_lossy().to_string();
+            let script =
+                format!("ulimit -f 0; trap '' XFSZ; exec \"$0\" '{TEST_PATH}' --exact --nocapture");
+            let output = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(script)
+                .arg(&exe)
+                .env(ENV_VAR, &path)
+                .output()
+                .expect("spawn fsize-limited child process");
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                stdout.contains(MARK_OK),
+                "child did not observe a fail-closed AuditFailed error \
+                 (status={:?}, stdout={stdout}, stderr={})",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     }
 }

--- a/src/identity_propagation/mod.rs
+++ b/src/identity_propagation/mod.rs
@@ -945,6 +945,16 @@ mod tests {
                 output.status,
                 String::from_utf8_lossy(&output.stderr)
             );
+            // The child must also EXIT cleanly: a child that prints the marker
+            // and then aborts (panic/abort after the observation) must not read
+            // as a pass.
+            assert!(
+                output.status.success(),
+                "child printed the marker but did not exit successfully \
+                 (status={:?}, stderr={})",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
     }
 }


### PR DESCRIPTION
## What

Makes identity-propagation audit writes **fail-closed on the mint path**. When the transparency-log write fails while minting a per-user credential, the mint is aborted with `PropagationError::AuditFailed` and an HTTP error response, so no minted credential ever reaches a caller without a durable audit record.

## Why

Main's `audit_identity_propagation` in `src/gateway/router/backend_handlers.rs` is best-effort, and its own comment marks fail-closed as "a possible future hardening, not required for MIK-6740." This is that follow-up.

## Scope discipline

Only the **mint** path becomes fail-closed. The non-mint resolution path stays best-effort, matching the static-credential fallback used elsewhere for a non-required backend — a minted credential is the only case where a missing audit record is a compliance problem.

## Tests

Adds a `mod audit_fail_closed` unit suite: logger-disabled no-op, mint-write success, and a fail-closed contract test that spawns an fsize-limited child to force a genuine transparency-log write failure and asserts the `AuditFailed` abort. Rebased onto current main with the test-module conflict resolved (main's MIK-6710 transport tests and this suite both retained).
