### PR TITLE
fix(security): salvage SSE SSRF + transport hardening onto current main

### DIFF
--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -33,6 +33,15 @@ use crate::protocol::{
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
+/// Origin equality per WHATWG (scheme + host + effective port). Used to enforce
+/// that an SSE-advertised message endpoint is same-origin as the SSE stream
+/// before any per-user credential is sent to it (SSRF + credential-exfil guard).
+fn same_origin(a: &Url, b: &Url) -> bool {
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
+}
+
 /// Detect the session-expiry signature in a transport error (MIK-5982).
 ///
 /// Matches three observed shapes:

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -611,21 +611,47 @@ impl HttpTransport {
         ))
     }
 
-    /// Resolve a potentially relative message URL against the SSE URL
+    /// Resolve a potentially relative message URL against the SSE URL.
+    ///
+    /// The `endpoint` value is backend-controlled (it arrives on the SSE
+    /// stream). Per the MCP SSE spec the message endpoint MUST be same-origin
+    /// as the SSE stream. Every endpoint — absolute, relative, network-path
+    /// (`//host/x`), backslash (`\\host`, `/\host`), or scheme-relative
+    /// (`https:/\/\host`) — is **resolved against the base URL first**, then the
+    /// *resolved* origin is checked. Classifying by string prefix instead
+    /// (`starts_with("http://")`) is unsafe: WHATWG URL resolution normalizes
+    /// backslashes to slashes and treats `//host` as an authority-relative
+    /// reference, so `base.join("//169.254.169.254/x")` REPLACES the authority
+    /// and yields a cross-origin URL despite not starting with a scheme. Without
+    /// checking the resolved origin, a malicious backend could return
+    /// `data: //169.254.169.254/latest/meta-data/...` and the gateway would POST
+    /// the JSON-RPC request together with the per-user identity credential
+    /// headers (`Authorization: Bearer <assertion>`, MIK-6704) to an
+    /// attacker-chosen internal / metadata host — an SSRF + credential-exfil
+    /// vector. Same-origin equality (rather than the outbound SSRF guard) is
+    /// used deliberately: legitimate MCP backends commonly bind to loopback,
+    /// which a private/loopback SSRF reject would break — the real defect is a
+    /// *cross-origin* redirect of credentials, which same-origin equality stops.
     fn resolve_message_url(&self, endpoint: &str) -> Result<String> {
-        // If endpoint is already absolute, use it directly
-        if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
-            return Ok(endpoint.to_string());
-        }
-
-        // Parse the base SSE URL
         let base_url = Url::parse(&self.base_url)
             .map_err(|e| Error::Transport(format!("Invalid SSE URL: {e}")))?;
 
-        // Resolve relative URL
+        // Resolve every endpoint shape against the base, then validate the
+        // *resolved* origin. `Url::join` handles absolute and relative inputs
+        // alike, so absolute and relative branches collapse into one path — and
+        // authority-replacing shapes (`//host`, `\\host`, `https:/\/\host`) can
+        // no longer slip past a prefix-based classifier.
         let resolved = base_url
             .join(endpoint)
             .map_err(|e| Error::Transport(format!("Failed to resolve endpoint URL: {e}")))?;
+
+        if !same_origin(&base_url, &resolved) {
+            return Err(Error::Transport(
+                "SSE message endpoint is cross-origin to the SSE stream; \
+                 refusing to send credentials to a different host"
+                    .to_string(),
+            ));
+        }
 
         Ok(resolved.to_string())
     }

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -558,11 +558,24 @@ impl HttpTransport {
         let mut buffer = String::new();
         let mut event_type: Option<String> = None;
 
+        // Bound the unparsed handshake buffer at 64 KiB. The endpoint event is
+        // a single short SSE line; complete lines are drained below, so a
+        // well-behaved backend never approaches this. A compromised/misbehaving
+        // backend streaming bytes without a newline is capped here rather than
+        // growing `buffer` without limit (trusted-backend DoS defence in depth).
+        let max_sse_handshake_buffer: usize = 64 * 1024;
+
         while let Some(chunk_result) = stream.next().await {
             let chunk = chunk_result
                 .map_err(|e| Error::Transport(format!("Failed to read SSE chunk: {e}")))?;
 
             buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            if buffer.len() > max_sse_handshake_buffer {
+                return Err(Error::Transport(format!(
+                    "SSE handshake exceeded {max_sse_handshake_buffer}-byte buffer without an endpoint event"
+                )));
+            }
 
             // Process complete lines in the buffer
             while let Some(newline_pos) = buffer.find('\n') {

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -42,6 +42,52 @@ fn same_origin(a: &Url, b: &Url) -> bool {
         && a.port_or_known_default() == b.port_or_known_default()
 }
 
+/// Outcome of evaluating one redirect hop for the transport's HTTP client.
+///
+/// Extracted from the [`reqwest::redirect::Policy::custom`] closure so the
+/// policy is unit-testable: reqwest's `Attempt` cannot be constructed in a
+/// test, but this pure decision can. See [`evaluate_redirect`].
+#[derive(Debug, PartialEq, Eq)]
+enum RedirectDecision {
+    /// Hop budget exhausted — stop and surface the last response as-is.
+    Stop,
+    /// Refuse the redirect; the payload is the operator-facing reason.
+    Reject(String),
+    /// Safe to follow.
+    Follow,
+}
+
+/// Decide whether to follow a single redirect on the SSE/message client.
+///
+/// Three guards, each of which a hop must clear:
+/// 1. **Hop cap** — at most five redirects, matching the prior policy.
+/// 2. **SSRF** — the target must not resolve to an internal/metadata range
+///    ([`validate_url_not_ssrf`]).
+/// 3. **Same-origin** — the target must share the base URL's origin. The SSE
+///    message POST carries the per-user `Authorization: Bearer <assertion>`
+///    (MIK-6704); without this guard a legitimate same-origin backend could
+///    answer with `30x Location: https://evil.example/…` — a *public* host
+///    that clears the SSRF check — and reqwest would replay the bearer
+///    cross-origin, defeating the same-origin guard `resolve_message_url`
+///    added. MCP message endpoints are same-origin by spec, so this rejects
+///    nothing legitimate.
+fn evaluate_redirect(base: &Url, target: &Url, previous_hops: usize) -> RedirectDecision {
+    if previous_hops >= 5 {
+        return RedirectDecision::Stop;
+    }
+    if let Err(e) = validate_url_not_ssrf(target.as_str()) {
+        return RedirectDecision::Reject(e.to_string());
+    }
+    if !same_origin(base, target) {
+        return RedirectDecision::Reject(format!(
+            "redirect target is cross-origin to the transport base URL; \
+             refusing to replay per-user credentials to a different origin \
+             (base={base}, target={target})"
+        ));
+    }
+    RedirectDecision::Follow
+}
+
 /// Detect the session-expiry signature in a transport error (MIK-5982).
 ///
 /// Matches three observed shapes:
@@ -178,21 +224,29 @@ impl HttpTransport {
         oauth_client: Option<OAuthClient>,
         protocol_version: Option<String>,
     ) -> Result<Arc<Self>> {
+        // Parse the base URL once so the redirect policy can enforce
+        // same-origin on every hop (credential-exfil guard, see
+        // `evaluate_redirect`). An unparseable base cannot function as a
+        // transport at all, so failing construction here is correct.
+        let base_origin = Url::parse(url)
+            .map_err(|e| Error::Transport(format!("Invalid transport base URL {url:?}: {e}")))?;
         let client = Client::builder()
             .timeout(timeout)
             .pool_max_idle_per_host(10)
             .pool_idle_timeout(Duration::from_secs(90))
             .tcp_keepalive(Duration::from_secs(30))
             .tcp_nodelay(true)
-            .redirect(reqwest::redirect::Policy::custom(|attempt| {
-                if attempt.previous().len() >= 5 {
-                    return attempt.stop();
-                }
-                if let Err(e) = validate_url_not_ssrf(attempt.url().as_str()) {
-                    return attempt.error(e.to_string());
-                }
-                attempt.follow()
-            }))
+            .redirect(reqwest::redirect::Policy::custom(
+                move |attempt| match evaluate_redirect(
+                    &base_origin,
+                    attempt.url(),
+                    attempt.previous().len(),
+                ) {
+                    RedirectDecision::Stop => attempt.stop(),
+                    RedirectDecision::Reject(msg) => attempt.error(msg),
+                    RedirectDecision::Follow => attempt.follow(),
+                },
+            ))
             .build()
             .map_err(|e| Error::Transport(e.to_string()))?;
 

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -286,6 +286,29 @@ fn evaluate_redirect_hop_cap_stops() {
     assert_eq!(decision, RedirectDecision::Stop);
 }
 
+#[test]
+fn evaluate_redirect_cross_origin_rejected_mid_chain() {
+    // A same-origin first hop must not become a springboard for a later
+    // cross-origin pivot: every target is compared against the ORIGINAL base
+    // origin, not the immediately-preceding hop. Here the chain has already
+    // followed same-origin hops (previous_hops in 1..5) and now pivots to a
+    // public but foreign origin — it must still Reject, not Follow.
+    for previous_hops in [2, 4] {
+        let decision = evaluate_redirect(
+            &url("https://api.example.com/sse"),
+            &url("https://evil.example.com/steal"),
+            previous_hops,
+        );
+        match decision {
+            RedirectDecision::Reject(msg) => assert!(
+                msg.contains("cross-origin"),
+                "expected cross-origin rejection at hop {previous_hops}, got: {msg}"
+            ),
+            other => panic!("expected Reject at hop {previous_hops}, got {other:?}"),
+        }
+    }
+}
+
 // =========================================================================
 // get_message_url
 // =========================================================================

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -123,10 +123,18 @@ fn parse_supported_versions_empty_after_colon() {
 // =========================================================================
 
 #[test]
-fn resolve_message_url_absolute_http() {
+fn resolve_message_url_absolute_cross_origin_rejected() {
+    // A backend-advertised absolute endpoint on a different origin than the SSE
+    // stream must be rejected: sending per-user credentials there is the SSRF +
+    // credential-exfil vector this guard closes.
     let t = make_transport("http://localhost:8080/sse");
-    let result = t.resolve_message_url("http://other:9090/messages").unwrap();
-    assert_eq!(result, "http://other:9090/messages");
+    let err = t
+        .resolve_message_url("http://other:9090/messages")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("cross-origin"),
+        "expected cross-origin rejection, got: {err}"
+    );
 }
 
 #[test]

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -152,6 +152,42 @@ fn resolve_message_url_relative_sibling() {
     assert_eq!(result, "http://localhost:8080/api/messages");
 }
 
+// Authority-replacing endpoints that do NOT start with `http://`/`https://`
+// but resolve cross-origin via WHATWG URL rules (network-path, backslash,
+// scheme-relative). A prefix classifier routes these to the relative branch and
+// misses them; resolve-then-check catches them. All four MUST be rejected.
+fn assert_cross_origin_rejected(base: &str, endpoint: &str) {
+    let t = make_transport(base);
+    let err = t.resolve_message_url(endpoint).unwrap_err();
+    assert!(
+        matches!(&err, crate::Error::Transport(m) if m.contains("cross-origin")),
+        "expected cross-origin rejection for endpoint {endpoint:?}, got: {err:?}"
+    );
+}
+
+#[test]
+fn resolve_message_url_network_path_metadata_host_rejected() {
+    assert_cross_origin_rejected(
+        "http://localhost:8080/sse",
+        "//169.254.169.254/latest/meta-data/",
+    );
+}
+
+#[test]
+fn resolve_message_url_backslash_authority_rejected() {
+    assert_cross_origin_rejected("http://localhost:8080/sse", "\\\\169.254.169.254/x");
+}
+
+#[test]
+fn resolve_message_url_slash_backslash_authority_rejected() {
+    assert_cross_origin_rejected("http://localhost:8080/sse", "/\\attacker-host/x");
+}
+
+#[test]
+fn resolve_message_url_scheme_relative_authority_rejected() {
+    assert_cross_origin_rejected("http://localhost:8080/sse", "https:/\\/\\attacker-host/x");
+}
+
 // =========================================================================
 // get_message_url
 // =========================================================================

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -197,6 +197,96 @@ fn resolve_message_url_scheme_relative_authority_rejected() {
 }
 
 // =========================================================================
+// evaluate_redirect (redirect-policy same-origin credential-exfil guard)
+// =========================================================================
+
+fn url(s: &str) -> url::Url {
+    url::Url::parse(s).unwrap()
+}
+
+#[test]
+fn evaluate_redirect_cross_origin_public_host_rejected() {
+    // A same-origin backend answering with `30x Location: https://evil…` points
+    // at a PUBLIC host that clears the SSRF check but is a different origin.
+    // Following it would replay the per-user bearer cross-origin: must reject.
+    let decision = evaluate_redirect(
+        &url("https://api.example.com/sse"),
+        &url("https://evil.example.com/steal"),
+        0,
+    );
+    match decision {
+        RedirectDecision::Reject(msg) => assert!(
+            msg.contains("cross-origin"),
+            "expected cross-origin rejection, got: {msg}"
+        ),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn evaluate_redirect_same_origin_allowed() {
+    // A redirect that stays on the base origin (different path) is legitimate
+    // per the MCP spec and must be followed.
+    let decision = evaluate_redirect(
+        &url("https://api.example.com/sse"),
+        &url("https://api.example.com/messages?session_id=abc"),
+        0,
+    );
+    assert_eq!(decision, RedirectDecision::Follow);
+}
+
+#[test]
+fn evaluate_redirect_same_origin_different_port_rejected() {
+    // Same host+scheme but a different port is a distinct origin (WHATWG) —
+    // still a credential-exfil target, so reject.
+    let decision = evaluate_redirect(
+        &url("https://api.example.com/sse"),
+        &url("https://api.example.com:8443/messages"),
+        0,
+    );
+    assert!(
+        matches!(&decision, RedirectDecision::Reject(m) if m.contains("cross-origin")),
+        "expected cross-origin rejection, got: {decision:?}"
+    );
+}
+
+#[test]
+fn evaluate_redirect_internal_range_still_ssrf_rejected() {
+    // An internal/metadata target is rejected by the SSRF guard, which runs
+    // before the same-origin check, so the reason names SSRF (not cross-origin).
+    let decision = evaluate_redirect(
+        &url("https://api.example.com/sse"),
+        &url("http://169.254.169.254/latest/meta-data/"),
+        0,
+    );
+    match decision {
+        RedirectDecision::Reject(msg) => {
+            assert!(
+                msg.contains("SSRF"),
+                "expected SSRF rejection reason, got: {msg}"
+            );
+            assert!(
+                !msg.contains("cross-origin"),
+                "SSRF guard must fire before same-origin, got: {msg}"
+            );
+        }
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn evaluate_redirect_hop_cap_stops() {
+    // At the fifth prior hop the policy stops following, matching the prior cap,
+    // regardless of whether the target would otherwise be allowed.
+    let decision = evaluate_redirect(
+        &url("https://api.example.com/sse"),
+        &url("https://api.example.com/again"),
+        5,
+    );
+    assert_eq!(decision, RedirectDecision::Stop);
+}
+
+// =========================================================================
 // get_message_url
 // =========================================================================
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -31,10 +31,8 @@
 //! ```text
 //! TunnelManager::setup_tailscale  →  tailscale CLI  →  TunnelInfo { public_url }
 //! TunnelManager::setup_pipenet    →  HTTP POST /register  →  TunnelInfo { public_url }
-//! TailscaleIdentity::from_headers →  identity extracted from request headers
 //! ```
 
-use std::collections::HashMap;
 use std::process::Command;
 
 use serde::{Deserialize, Serialize};
@@ -154,82 +152,6 @@ pub struct TunnelInfo {
     pub status: TunnelStatus,
     /// Human-readable description of the tunnel type.
     pub tunnel_type: String,
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// TailscaleIdentity — header extraction
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Identity injected by `tailscale serve` into proxied HTTP requests.
-///
-/// When the gateway is behind `tailscale serve`, Tailscale unconditionally
-/// adds these headers and prevents external clients from spoofing them.
-/// Enable `auth_via_identity: true` to trust them.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct TailscaleIdentity {
-    /// Tailscale login e-mail address (`Tailscale-User-Login`).
-    pub login: Option<String>,
-    /// Display name of the Tailscale user (`Tailscale-User-Name`).
-    pub name: Option<String>,
-    /// Tailscale profile picture URL (`Tailscale-User-Profile-Pic`).
-    pub profile_pic: Option<String>,
-}
-
-/// Header name for the Tailscale user login.
-const HEADER_USER_LOGIN: &str = "Tailscale-User-Login";
-/// Header name for the Tailscale user display name.
-const HEADER_USER_NAME: &str = "Tailscale-User-Name";
-/// Header name for the Tailscale user profile picture.
-const HEADER_USER_PROFILE_PIC: &str = "Tailscale-User-Profile-Pic";
-
-impl TailscaleIdentity {
-    /// Extract Tailscale identity from a `HashMap<String, String>` of HTTP headers.
-    ///
-    /// Header lookup is **case-insensitive** to comply with HTTP/1.1 and HTTP/2
-    /// specifications.
-    ///
-    /// Returns `None` when neither `Tailscale-User-Login` nor `Tailscale-User-Name`
-    /// are present (i.e. the request did not arrive via `tailscale serve`).
-    #[must_use]
-    pub fn from_headers(headers: &HashMap<String, String>) -> Option<Self> {
-        let login = find_header(headers, HEADER_USER_LOGIN);
-        let name = find_header(headers, HEADER_USER_NAME);
-        let profile_pic = find_header(headers, HEADER_USER_PROFILE_PIC);
-
-        if login.is_none() && name.is_none() {
-            return None;
-        }
-
-        Some(Self {
-            login,
-            name,
-            profile_pic,
-        })
-    }
-
-    /// Returns `true` when at least a login or display name was found.
-    #[must_use]
-    pub fn is_authenticated(&self) -> bool {
-        self.login.is_some() || self.name.is_some()
-    }
-
-    /// Best-effort display label for audit logs: login > name > `"<unknown>"`.
-    #[must_use]
-    pub fn display_name(&self) -> &str {
-        self.login
-            .as_deref()
-            .or(self.name.as_deref())
-            .unwrap_or("<unknown>")
-    }
-}
-
-/// Case-insensitive header lookup.
-fn find_header(headers: &HashMap<String, String>, name: &str) -> Option<String> {
-    let lower = name.to_ascii_lowercase();
-    headers
-        .iter()
-        .find(|(k, _)| k.to_ascii_lowercase() == lower)
-        .map(|(_, v)| v.clone())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -574,118 +496,6 @@ pipenet:
         assert!(cfg.pipenet.is_some());
     }
 
-    // ── TailscaleIdentity header extraction ───────────────────────────────────
-
-    fn make_headers(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        pairs
-            .iter()
-            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-            .collect()
-    }
-
-    #[test]
-    fn tailscale_identity_extracts_login_and_name() {
-        let headers = make_headers(&[
-            ("Tailscale-User-Login", "alice@example.com"),
-            ("Tailscale-User-Name", "Alice Smith"),
-        ]);
-        let id = TailscaleIdentity::from_headers(&headers).unwrap();
-        assert_eq!(id.login.as_deref(), Some("alice@example.com"));
-        assert_eq!(id.name.as_deref(), Some("Alice Smith"));
-    }
-
-    #[test]
-    fn tailscale_identity_returns_none_when_no_headers() {
-        let headers = make_headers(&[("Authorization", "Bearer token123")]);
-        assert!(TailscaleIdentity::from_headers(&headers).is_none());
-    }
-
-    #[test]
-    fn tailscale_identity_present_with_login_only() {
-        let headers = make_headers(&[("Tailscale-User-Login", "bob@corp.com")]);
-        let id = TailscaleIdentity::from_headers(&headers).unwrap();
-        assert_eq!(id.login.as_deref(), Some("bob@corp.com"));
-        assert!(id.name.is_none());
-    }
-
-    #[test]
-    fn tailscale_identity_present_with_name_only() {
-        let headers = make_headers(&[("Tailscale-User-Name", "Bob Jones")]);
-        let id = TailscaleIdentity::from_headers(&headers).unwrap();
-        assert!(id.login.is_none());
-        assert_eq!(id.name.as_deref(), Some("Bob Jones"));
-    }
-
-    #[test]
-    fn tailscale_identity_case_insensitive_lookup() {
-        // HTTP headers are case-insensitive per spec
-        let headers = make_headers(&[
-            ("tailscale-user-login", "carol@example.com"),
-            ("TAILSCALE-USER-NAME", "Carol White"),
-        ]);
-        let id = TailscaleIdentity::from_headers(&headers).unwrap();
-        assert_eq!(id.login.as_deref(), Some("carol@example.com"));
-        assert_eq!(id.name.as_deref(), Some("Carol White"));
-    }
-
-    #[test]
-    fn tailscale_identity_extracts_profile_pic() {
-        let headers = make_headers(&[
-            ("Tailscale-User-Login", "dave@example.com"),
-            (
-                "Tailscale-User-Profile-Pic",
-                "https://cdn.example.com/dave.jpg",
-            ),
-        ]);
-        let id = TailscaleIdentity::from_headers(&headers).unwrap();
-        assert_eq!(
-            id.profile_pic.as_deref(),
-            Some("https://cdn.example.com/dave.jpg")
-        );
-    }
-
-    #[test]
-    fn tailscale_identity_is_authenticated_with_login() {
-        let id = TailscaleIdentity {
-            login: Some("user@example.com".to_owned()),
-            name: None,
-            profile_pic: None,
-        };
-        assert!(id.is_authenticated());
-    }
-
-    #[test]
-    fn tailscale_identity_is_not_authenticated_when_empty() {
-        let id = TailscaleIdentity::default();
-        assert!(!id.is_authenticated());
-    }
-
-    #[test]
-    fn tailscale_identity_display_name_prefers_login() {
-        let id = TailscaleIdentity {
-            login: Some("user@example.com".to_owned()),
-            name: Some("Full Name".to_owned()),
-            profile_pic: None,
-        };
-        assert_eq!(id.display_name(), "user@example.com");
-    }
-
-    #[test]
-    fn tailscale_identity_display_name_falls_back_to_name() {
-        let id = TailscaleIdentity {
-            login: None,
-            name: Some("Full Name".to_owned()),
-            profile_pic: None,
-        };
-        assert_eq!(id.display_name(), "Full Name");
-    }
-
-    #[test]
-    fn tailscale_identity_display_name_is_unknown_when_empty() {
-        let id = TailscaleIdentity::default();
-        assert_eq!(id.display_name(), "<unknown>");
-    }
-
     // ── AuthMethod and TunnelStatus serde ─────────────────────────────────────
 
     #[test]
@@ -765,13 +575,5 @@ pipenet:
         assert_eq!(info2.auth_method, info.auth_method);
         assert_eq!(info2.status, info.status);
         assert_eq!(info2.tunnel_type, info.tunnel_type);
-    }
-
-    // ── TailscaleIdentity empty map edge case ─────────────────────────────────
-
-    #[test]
-    fn tailscale_identity_from_empty_headers_returns_none() {
-        let headers: HashMap<String, String> = HashMap::new();
-        assert!(TailscaleIdentity::from_headers(&headers).is_none());
     }
 }


### PR DESCRIPTION
## What

Salvages three SSE/transport security hardening fixes from an abandoned worktree branch and rebuilds them on current main. The branch was based on an older tree, so these were cherry-picked and one of them needed manual conflict resolution against main's restructured transport code.

## The three fixes

1. **SSE endpoint SSRF bypass via authority-relative URLs.** The SSE message endpoint is backend-controlled and arrives on the stream. The old code classified it by string prefix (`starts_with("http://")`) and passed absolute values through unchanged. WHATWG URL resolution treats `//host/x` and backslash shapes as authority-relative references, so a malicious backend could return `data: //169.254.169.254/latest/meta-data/...` and the gateway would POST the JSON-RPC request plus the per-user identity credential header to an attacker-chosen internal host. Every endpoint shape is now resolved against the base URL first, then the resolved origin is checked for same-origin equality before any credential is sent.

2. **64 KiB bound on the SSE handshake buffer.** Defence in depth against an unbounded read during the handshake.

3. **Removal of the dead Tailscale identity-header auth path.** 198 lines of unused code that widened the attack surface without a live caller.

## Conflict resolution note

The SSRF fix (commit 1) touched `resolve_message_url` and a neighboring helper that main had independently rewritten, so the 3-way merge could not auto-carry the `same_origin` helper or the new function body. Both are restored in the final commit. The pre-existing `resolve_message_url_absolute_http` test asserted the old cross-origin pass-through, so it is updated to assert the secure cross-origin rejection instead.

## Deferred

A fourth commit from the source branch (percent-encode positional path params, LOW severity) conflicts on the capability executor, which main split from a file into a directory and rewrote. It is left out of this PR to keep the security fixes clean. It can be ported separately if wanted.

## Verification

- `cargo test --lib transport::http` — 43 pass
- Full `cargo test --lib` via the pre-push hook — green (fmt, clippy `-D warnings`, and the full lib suite)
