### PR TITLE
chore(release): 3.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.3.0"
+version = "3.3.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]


### PR DESCRIPTION
Release commit for 3.3.1. Bumps the package version in Cargo.toml and Cargo.lock so the tag, crates.io publish, and Homebrew formula all agree on the same number.

## What ships in 3.3.1

origin/main sits five commits past v3.3.0. All are fixes, CI, or docs, so this is a patch release:

- SSE SSRF and transport hardening (#356)
- Fail-closed handling on identity-propagation audit write failure (#355)
- CWE-532 secret-leak lint gate, wired into the release gate (#354)
- npm-publish job bumped to Node 22 (#352)
- README restructure for newcomer flow and licensing clarity (#357)

No new runtime features, so the minor stays put and the patch increments.

## After merge

Tag v3.3.1 on the merge commit and push it. The release workflow runs the OSV scan and CWE-532 leak lint, then publishes to crates.io, npm, and the Homebrew tap.

## Verification

Local pre-push gate green: cargo fmt check, clippy --lib -D warnings, cargo test --lib.