### PR TITLE
Signed runtime provenance stamping and offline eval harness (MIK-6905, MIK-6906)

### DIFF
--- a/src/attestation/validator.rs
+++ b/src/attestation/validator.rs
@@ -504,6 +504,24 @@ impl AttestationValidator {
     pub fn rotations_total(&self) -> u64 {
         self.rotations_total.load(Ordering::Relaxed)
     }
+
+    /// Verify a signed runtime provenance receipt against this validator's key
+    /// material (MIK-6905, rung 1.3).
+    ///
+    /// Provenance receipts are not attestation tokens — they carry no expiry,
+    /// rotation, or capability semantics — so they do not flow through
+    /// [`Self::validate_boundary_call`]. This method is the validation authority
+    /// for the `_meta.provenance` channel: it re-derives the receipt's canonical
+    /// bytes and constant-time-compares the detached HMAC. Returns `true` only
+    /// when the signature is well-formed and matches.
+    #[must_use]
+    pub fn verify_result_provenance(&self, signed: &crate::trust::SignedResultProvenance) -> bool {
+        let Some(signature) = signed.signature_bytes() else {
+            return false;
+        };
+        self.signer
+            .verify_bytes(&signed.receipt.canonical_bytes(), &signature)
+    }
 }
 
 #[cfg(test)]
@@ -518,6 +536,54 @@ mod tests {
             8,
             TimeDelta::seconds(30),
         )
+    }
+
+    fn sample_receipt() -> crate::trust::RuntimeProvenanceReceipt {
+        crate::trust::RuntimeProvenanceReceipt::observed(
+            "github",
+            "search_issues",
+            "2026-07-13T10:15:30Z",
+            crate::trust::CacheOutcome::Miss,
+            true,
+        )
+    }
+
+    #[test]
+    fn result_provenance_round_trips_sign_then_verify() {
+        let v = validator();
+        // Twin signer sharing the validator's key material.
+        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let signed = sample_receipt().sign(&signer);
+        assert_eq!(signed.algorithm, crate::attestation::SIGNING_ALGORITHM);
+        assert_eq!(signed.key_id, "bnaut/unit");
+        assert!(v.verify_result_provenance(&signed));
+    }
+
+    #[test]
+    fn tampered_receipt_fails_verification() {
+        let v = validator();
+        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let mut signed = sample_receipt().sign(&signer);
+        // Flip a fact after signing — the HMAC must no longer match.
+        signed.receipt.backend_ok = false;
+        assert!(!v.verify_result_provenance(&signed));
+    }
+
+    #[test]
+    fn wrong_key_fails_verification() {
+        let v = validator();
+        let other = BnautAttestationSigner::new(b"a-different-key".to_vec(), "unit");
+        let signed = sample_receipt().sign(&other);
+        assert!(!v.verify_result_provenance(&signed));
+    }
+
+    #[test]
+    fn malformed_signature_encoding_fails_verification() {
+        let v = validator();
+        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let mut signed = sample_receipt().sign(&signer);
+        signed.signature = "not valid base64url!!".to_string();
+        assert!(!v.verify_result_provenance(&signed));
     }
 
     fn issue(now: DateTime<Utc>) -> AttestationToken {

--- a/src/attestation/validator.rs
+++ b/src/attestation/validator.rs
@@ -552,8 +552,8 @@ mod tests {
     fn result_provenance_round_trips_sign_then_verify() {
         let v = validator();
         // Twin signer sharing the validator's key material.
-        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
-        let signed = sample_receipt().sign(&signer);
+        let twin = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let signed = sample_receipt().sign(&twin);
         assert_eq!(signed.algorithm, crate::attestation::SIGNING_ALGORITHM);
         assert_eq!(signed.key_id, "bnaut/unit");
         assert!(v.verify_result_provenance(&signed));
@@ -562,8 +562,8 @@ mod tests {
     #[test]
     fn tampered_receipt_fails_verification() {
         let v = validator();
-        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
-        let mut signed = sample_receipt().sign(&signer);
+        let twin = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let mut signed = sample_receipt().sign(&twin);
         // Flip a fact after signing — the HMAC must no longer match.
         signed.receipt.backend_ok = false;
         assert!(!v.verify_result_provenance(&signed));
@@ -580,8 +580,8 @@ mod tests {
     #[test]
     fn malformed_signature_encoding_fails_verification() {
         let v = validator();
-        let signer = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
-        let mut signed = sample_receipt().sign(&signer);
+        let twin = BnautAttestationSigner::new(b"validator-test-key".to_vec(), "unit");
+        let mut signed = sample_receipt().sign(&twin);
         signed.signature = "not valid base64url!!".to_string();
         assert!(!v.verify_result_provenance(&signed));
     }

--- a/src/config/features/security.rs
+++ b/src/config/features/security.rs
@@ -369,6 +369,7 @@ impl ContextIntegrityConfig {
 /// Security configuration for the gateway.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+#[allow(clippy::struct_excessive_bools)] // config surface: independent on/off feature flags
 pub struct SecurityConfig {
     /// Enable input sanitization (null byte rejection, control char stripping, NFC).
     pub sanitize_input: bool,
@@ -419,6 +420,11 @@ pub struct SecurityConfig {
     /// Remote MCP server provenance verification (OWASP ASI04). Default: disabled.
     #[serde(default)]
     pub remote_server_signing: RemoteServerSigningConfig,
+    /// Sign a runtime provenance receipt into `_meta.provenance` on every
+    /// aggregated tool result (MIK-6905). Reuses the attestation signing key.
+    /// Additive metadata only; off by default so payloads are unchanged.
+    #[serde(default)]
+    pub provenance_stamping: bool,
 }
 
 const fn default_trust_configured_backends() -> bool {
@@ -442,6 +448,7 @@ impl Default for SecurityConfig {
             identity_grants: IdentityGrantsConfig::default(),
             context_integrity: ContextIntegrityConfig::default(),
             remote_server_signing: RemoteServerSigningConfig::default(),
+            provenance_stamping: false,
         }
     }
 }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -456,6 +456,29 @@ impl MetaMcp {
         }
     }
 
+    /// Stamp provenance onto a direct per-backend route result (the
+    /// `/mcp/{name}` passthrough, which bypasses the meta chokepoint — rung 3).
+    ///
+    /// Tagged [`CacheOutcome::Bypass`] because the direct route never consults
+    /// the meta response cache. No-op when stamping is disabled, so the
+    /// passthrough stays byte-identical with the feature off.
+    #[must_use]
+    pub fn stamp_direct_result(
+        &self,
+        result: Value,
+        backend_id: &str,
+        tool: &str,
+        api_key_name: Option<&str>,
+    ) -> Value {
+        self.maybe_stamp_provenance(
+            result,
+            backend_id,
+            tool,
+            api_key_name,
+            crate::trust::CacheOutcome::Bypass,
+        )
+    }
+
     /// Inner implementation executed within a trace-ID scope.
     ///
     /// Returns a [`GuardedValue`]: every success path must produce one, so the

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -431,6 +431,31 @@ impl MetaMcp {
         .await
     }
 
+    /// Stamp a signed runtime-provenance receipt into `value._meta` when
+    /// provenance stamping is enabled (MIK-6905). No-op when the signer is
+    /// absent, so payloads stay byte-identical with the feature off.
+    ///
+    /// `backend_ok` is derived from the result's `isError` flag so cache hits
+    /// carrying a stored error are reported honestly.
+    fn maybe_stamp_provenance(
+        &self,
+        value: Value,
+        server: &str,
+        tool: &str,
+        api_key_name: Option<&str>,
+        cache: crate::trust::CacheOutcome,
+    ) -> Value {
+        if let Some(ref signer) = self.provenance_signer {
+            let backend_ok = !value
+                .get("isError")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            augment_with_provenance(value, signer, server, tool, api_key_name, cache, backend_ok)
+        } else {
+            value
+        }
+    }
+
     /// Inner implementation executed within a trace-ID scope.
     ///
     /// Returns a [`GuardedValue`]: every success path must produce one, so the
@@ -645,7 +670,15 @@ impl MetaMcp {
                     .increment(1);
                     let predictions = self.record_and_predict(session_id, &tool_key);
                     return Ok(GuardedValue::from_cache(cached).augment(|v| {
-                        augment_with_trace(augment_with_predictions(v, predictions), trace_id)
+                        let v =
+                            augment_with_trace(augment_with_predictions(v, predictions), trace_id);
+                        self.maybe_stamp_provenance(
+                            v,
+                            server,
+                            tool,
+                            api_key_name,
+                            crate::trust::CacheOutcome::Hit,
+                        )
                     }));
                 }
                 GuardOutcome::Proceed => {
@@ -678,7 +711,14 @@ impl MetaMcp {
                 }
                 let predictions = self.record_and_predict(session_id, &tool_key);
                 return Ok(GuardedValue::from_cache(cached).augment(|v| {
-                    augment_with_trace(augment_with_predictions(v, predictions), trace_id)
+                    let v = augment_with_trace(augment_with_predictions(v, predictions), trace_id);
+                    self.maybe_stamp_provenance(
+                        v,
+                        server,
+                        tool,
+                        api_key_name,
+                        crate::trust::CacheOutcome::Hit,
+                    )
                 }));
             }
         }
@@ -1139,27 +1179,19 @@ impl MetaMcp {
         let mut final_result =
             augment_with_trace(augment_with_predictions(result, predictions), trace_id);
         // Runtime provenance stamp (MIK-6905): off by default. Inserted BEFORE
-        // response signing so the message MAC also covers the receipt. This is
-        // the live-fetch (cache-miss) path — cache hits at the early returns
-        // above are not stamped.
-        // ponytail: cache-hit + direct-backend stamping deferred to a follow-up;
-        // stamp cache=Hit at invoke.rs:647/680 and wire backend_handlers.rs when
-        // provenance is needed on those paths.
-        if let Some(ref signer) = self.provenance_signer {
-            let backend_ok = !final_result
-                .get("isError")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            final_result = augment_with_provenance(
-                final_result,
-                signer,
-                server,
-                tool,
-                api_key_name,
-                crate::trust::CacheOutcome::Miss,
-                backend_ok,
-            );
-        }
+        // response signing so the message MAC also covers the receipt. Cache
+        // hits at the early returns above are stamped with cache=Hit; this is
+        // the live-fetch (cache-miss) path.
+        // ponytail: direct-backend HTTP passthrough (router/backend_handlers.rs)
+        // is a separate surface — it has no MetaMcpInvoker/signer; wire when
+        // provenance is needed there (threads signer through GatewayState).
+        final_result = self.maybe_stamp_provenance(
+            final_result,
+            server,
+            tool,
+            api_key_name,
+            crate::trust::CacheOutcome::Miss,
+        );
         if let Some(ref signer) = self.message_signer {
             final_result = signer.sign_response(final_result, request_nonce);
         }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -120,7 +120,8 @@ use super::super::trace;
 use super::MetaMcp;
 use super::prompt_cache::{CacheKeyDeriver, extract_cached_tokens, inject_cache_key};
 use super::support::{
-    MetaMcpInvoker, augment_with_predictions, augment_with_trace, resolve_idempotency_key,
+    MetaMcpInvoker, augment_with_predictions, augment_with_provenance, augment_with_trace,
+    resolve_idempotency_key,
 };
 
 async fn call_capability_tool_with_identity(
@@ -1137,6 +1138,28 @@ impl MetaMcp {
         // response body so consumers can detect any tampering.
         let mut final_result =
             augment_with_trace(augment_with_predictions(result, predictions), trace_id);
+        // Runtime provenance stamp (MIK-6905): off by default. Inserted BEFORE
+        // response signing so the message MAC also covers the receipt. This is
+        // the live-fetch (cache-miss) path — cache hits at the early returns
+        // above are not stamped.
+        // ponytail: cache-hit + direct-backend stamping deferred to a follow-up;
+        // stamp cache=Hit at invoke.rs:647/680 and wire backend_handlers.rs when
+        // provenance is needed on those paths.
+        if let Some(ref signer) = self.provenance_signer {
+            let backend_ok = !final_result
+                .get("isError")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            final_result = augment_with_provenance(
+                final_result,
+                signer,
+                server,
+                tool,
+                api_key_name,
+                crate::trust::CacheOutcome::Miss,
+                backend_ok,
+            );
+        }
         if let Some(ref signer) = self.message_signer {
             final_result = signer.sign_response(final_result, request_nonce);
         }

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -21,6 +21,7 @@ use parking_lot::RwLock;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
+use crate::attestation::signer::BnautAttestationSigner;
 use crate::backend::BackendRegistry;
 use crate::cache::ResponseCache;
 use crate::capability::CapabilityBackend;
@@ -218,6 +219,13 @@ pub struct MetaMcp {
     /// Populated alongside `message_signer`; both are `Some` or both `None`.
     pub(super) nonce_store: Option<Arc<NonceStore>>,
 
+    /// Runtime provenance receipt signer (MIK-6905).
+    ///
+    /// `Some` when `security.provenance_stamping = true`; `None` otherwise.
+    /// When `None` the stamping block is skipped entirely, so result payloads
+    /// are byte-identical to the un-stamped path (rung 1.2 guarantee).
+    pub(super) provenance_signer: Option<Arc<BnautAttestationSigner>>,
+
     /// When `true`, requests without a `nonce` are rejected with JSON-RPC -32001.
     ///
     /// Corresponds to `security.message_signing.require_nonce` in config.
@@ -339,6 +347,7 @@ impl MetaMcp {
             session_state: SessionStateStore::new(),
             message_signer: None,
             nonce_store: None,
+            provenance_signer: None,
             require_nonce: false,
             transparency_logger: None,
             response_inspection_action_mode: false,
@@ -505,6 +514,16 @@ impl MetaMcp {
         self.message_signer = Some(Arc::new(signer));
         self.nonce_store = Some(nonce_store);
         self.require_nonce = require_nonce;
+    }
+
+    /// Enable signed runtime provenance stamping (MIK-6905, rung 1.2).
+    ///
+    /// When set, every aggregated tool result is stamped with a signed
+    /// `_meta.provenance` receipt. Off by default; the field is `None` unless
+    /// this is called, so the stamping branch never runs on the hot path
+    /// otherwise.
+    pub fn enable_provenance_stamping(&mut self, signer: BnautAttestationSigner) {
+        self.provenance_signer = Some(Arc::new(signer));
     }
 
     /// Attach a transparency logger (issue #133, D3).

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -256,6 +256,12 @@ pub(super) fn augment_with_provenance(
     if let Some(name) = api_key_name {
         receipt = receipt.with_auth_context_ref(auth_context_ref_hash(name));
     }
+    // Join key: the active call's trace_id (also returned to the client as
+    // `result.trace_id`), so the receipt is self-joinable to the agent's claim.
+    // Absent on paths with no trace scope (e.g. direct backend route).
+    if let Some(trace_id) = crate::gateway::trace::current() {
+        receipt = receipt.with_call_id(trace_id);
+    }
     let signed_receipt = receipt.sign(signer);
 
     if let Value::Object(ref mut map) = result {

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -221,6 +221,57 @@ pub(super) fn augment_with_trace(mut result: Value, trace_id: &str) -> Value {
     result
 }
 
+/// Opaque, non-reversible reference to an auth-context label.
+///
+/// The gateway's `api_key_name` is a config-chosen label, not a credential, but
+/// the receipt contract stores only a *reference* — never a raw identifier — so
+/// nothing sensitive can ever reach the `_meta` channel (CWE-532, rung 1.5).
+fn auth_context_ref_hash(name: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(name.as_bytes());
+    format!("sha256:{}", hex::encode(&digest[..8]))
+}
+
+/// Stamp a signed runtime provenance receipt into `result._meta.provenance`
+/// (MIK-6905, rung 1.2/1.4).
+///
+/// Additive only: the receipt lands under the MCP `_meta` channel and no tool
+/// content is touched. Facts observed at the gateway — backend, tool, auth-ref,
+/// cache outcome, backend success — are recorded and signed; nothing is
+/// inferred (rung 1.4).
+pub(super) fn augment_with_provenance(
+    mut result: Value,
+    signer: &crate::attestation::signer::BnautAttestationSigner,
+    backend_id: &str,
+    tool: &str,
+    api_key_name: Option<&str>,
+    cache: crate::trust::CacheOutcome,
+    backend_ok: bool,
+) -> Value {
+    use crate::trust::RuntimeProvenanceReceipt;
+
+    let observed_at = chrono::Utc::now().to_rfc3339();
+    let mut receipt =
+        RuntimeProvenanceReceipt::observed(backend_id, tool, observed_at, cache, backend_ok);
+    if let Some(name) = api_key_name {
+        receipt = receipt.with_auth_context_ref(auth_context_ref_hash(name));
+    }
+    let signed_receipt = receipt.sign(signer);
+
+    if let Value::Object(ref mut map) = result {
+        let meta = map
+            .entry("_meta")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Value::Object(meta_map) = meta {
+            meta_map.insert(
+                "provenance".to_string(),
+                serde_json::to_value(signed_receipt).unwrap_or(Value::Null),
+            );
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::internal_invoke_args;

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -1971,4 +1971,111 @@ mod attestation_wiring {
                 .is_ok()
         );
     }
+
+    // ── Runtime provenance stamping (MIK-6905, rung 1.2/1.4/1.5) ──────────────
+
+    fn provenance_test_backend() -> Arc<BackendRegistry> {
+        use crate::backend::Backend;
+        use crate::config::{BackendConfig, FailsafeConfig};
+        use crate::transport::Transport;
+
+        let registry = Arc::new(BackendRegistry::new());
+        let backend = Arc::new(Backend::new(
+            "remote_docs",
+            BackendConfig::default(),
+            &FailsafeConfig::default(),
+            Duration::from_secs(300),
+        ));
+        let transport: Arc<dyn Transport> = Arc::new(ToolCallTestTransport {
+            result: json!({"content": [{"type": "text", "text": "ok"}], "isError": false}),
+        });
+        backend.set_transport_for_test(transport);
+        registry.register(backend);
+        registry
+    }
+
+    async fn invoke_docs_search(meta: &MetaMcp) -> serde_json::Value {
+        meta.invoke_tool(
+            &json!({"server": "remote_docs", "tool": "search", "arguments": {}}),
+            Some("session-1"),
+            Some("alice"),
+            Some("agent-1"),
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn provenance_flag_off_emits_no_meta_provenance() {
+        // Default MetaMcp has no provenance signer → the stamping branch never
+        // runs and no `_meta.provenance` appears (rung 1.2 byte-identical path).
+        let meta = MetaMcp::new(provenance_test_backend());
+        let result = invoke_docs_search(&meta).await;
+        let provenance = result.get("_meta").and_then(|m| m.get("provenance"));
+        assert!(
+            provenance.is_none(),
+            "flag off must not emit _meta.provenance, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provenance_flag_on_stamps_signed_verifiable_receipt() {
+        use crate::attestation::{AttestationValidator, BnautAttestationSigner};
+        use crate::trust::{SignedResultProvenance, TrustEvidenceKind};
+
+        let mut meta = MetaMcp::new(provenance_test_backend());
+        meta.enable_provenance_stamping(BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"));
+        let result = invoke_docs_search(&meta).await;
+
+        let provenance = result
+            .get("_meta")
+            .and_then(|m| m.get("provenance"))
+            .expect("flag on must emit _meta.provenance");
+        let signed: SignedResultProvenance =
+            serde_json::from_value(provenance.clone()).expect("provenance must deserialize");
+
+        // Facts recorded (rung 1.4: observed only).
+        assert_eq!(signed.receipt.backend_id, "remote_docs");
+        assert_eq!(signed.receipt.tool, "search");
+        assert!(signed.receipt.backend_ok);
+        assert_eq!(signed.receipt.evidence_kind, TrustEvidenceKind::Observed);
+
+        // Signature verifies under a twin validator sharing the key (rung 1.3).
+        let validator =
+            AttestationValidator::new(BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"));
+        assert!(validator.verify_result_provenance(&signed));
+    }
+
+    #[tokio::test]
+    async fn provenance_receipt_leaks_no_secret_or_raw_identity() {
+        // Rung 1.5 (CWE-532): the raw api_key_name ("alice") and any key
+        // material must never appear in the stamped receipt — only an opaque
+        // sha256 auth-context reference.
+        use crate::attestation::BnautAttestationSigner;
+
+        let mut meta = MetaMcp::new(provenance_test_backend());
+        meta.enable_provenance_stamping(BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"));
+        let result = invoke_docs_search(&meta).await;
+
+        let provenance = result
+            .get("_meta")
+            .and_then(|m| m.get("provenance"))
+            .expect("flag on must emit _meta.provenance");
+        let serialized = serde_json::to_string(provenance).unwrap();
+
+        assert!(
+            !serialized.contains("alice"),
+            "raw api_key_name must be hashed, not emitted verbatim: {serialized}"
+        );
+        assert!(
+            !serialized.contains("prov-key"),
+            "signing key material must never appear in _meta"
+        );
+        assert!(
+            serialized.contains("sha256:"),
+            "auth-context reference should be an opaque sha256 handle"
+        );
+    }
 }

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -2078,4 +2078,56 @@ mod attestation_wiring {
             "auth-context reference should be an opaque sha256 handle"
         );
     }
+
+    #[tokio::test]
+    async fn provenance_stamps_cache_hits_with_hit_outcome() {
+        // Rung 2: cache-served results must also carry a signed receipt, tagged
+        // cache=Hit. First invoke populates the response cache (un-stamped);
+        // the second is served from cache and stamped fresh with cache=Hit.
+        use crate::attestation::{AttestationValidator, BnautAttestationSigner};
+        use crate::cache::ResponseCache;
+        use crate::trust::{CacheOutcome, SignedResultProvenance};
+
+        let mut meta = MetaMcp::with_features(
+            provenance_test_backend(),
+            Some(Arc::new(ResponseCache::new())),
+            None,
+            None,
+            Duration::from_secs(300),
+        );
+        meta.enable_provenance_stamping(BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"));
+
+        let first = invoke_docs_search(&meta).await;
+        assert_eq!(
+            first
+                .get("_meta")
+                .and_then(|m| m.get("provenance"))
+                .and_then(|p| p.get("receipt"))
+                .and_then(|r| r.get("cache"))
+                .and_then(serde_json::Value::as_str),
+            Some("miss"),
+            "first (live-fetch) call must stamp cache=miss"
+        );
+
+        let second = invoke_docs_search(&meta).await;
+        let provenance = second
+            .get("_meta")
+            .and_then(|m| m.get("provenance"))
+            .expect("cache hit must still emit _meta.provenance");
+        let signed: SignedResultProvenance =
+            serde_json::from_value(provenance.clone()).expect("provenance must deserialize");
+
+        assert_eq!(
+            signed.receipt.cache,
+            CacheOutcome::Hit,
+            "cache-served result must be tagged cache=Hit"
+        );
+        assert_eq!(signed.receipt.backend_id, "remote_docs");
+        assert!(signed.receipt.backend_ok);
+
+        // The cache-hit receipt is independently signed and verifies.
+        let validator =
+            AttestationValidator::new(BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"));
+        assert!(validator.verify_result_provenance(&signed));
+    }
 }

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -750,6 +750,13 @@ pub(super) async fn backend_handler(
                             client.as_ref(),
                             &mut response,
                         );
+                        stamp_direct_provenance(
+                            &state,
+                            &name,
+                            params.as_ref(),
+                            client.as_ref(),
+                            &mut response,
+                        );
                         build_http_response(&response, StatusCode::OK)
                     }
                     Err(e) => {
@@ -793,6 +800,13 @@ pub(super) async fn backend_handler(
                     client.as_ref(),
                     &mut response,
                 );
+                stamp_direct_provenance(
+                    &state,
+                    &name,
+                    params.as_ref(),
+                    client.as_ref(),
+                    &mut response,
+                );
             }
             build_http_response(&response, StatusCode::OK)
         }
@@ -809,6 +823,37 @@ fn record_client_success(state: &AppState, client: Option<&AuthenticatedClient>)
     if let Some(client) = client {
         state.auth_config.record_client_success(&client.name);
     }
+}
+
+/// Stamp a signed runtime-provenance receipt onto a direct-route `tools/call`
+/// result (MIK-6905 rung 3). The `/mcp/{name}` passthrough bypasses the meta
+/// chokepoint, so without this a client could route around provenance simply
+/// by choosing the direct URL. No-op unless the tool name is present (a
+/// `tools/call`) and stamping is enabled on the shared `MetaMcp`.
+fn stamp_direct_provenance(
+    state: &AppState,
+    backend_name: &str,
+    params: Option<&Value>,
+    client: Option<&AuthenticatedClient>,
+    response: &mut JsonRpcResponse,
+) {
+    let tool = params
+        .and_then(|p| p.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if tool.is_empty() {
+        return;
+    }
+    let Some(result) = response.result.take() else {
+        return;
+    };
+    let api_key_name = client.map(|c| c.name.as_str());
+    response.result = Some(state.meta_mcp.stamp_direct_result(
+        result,
+        backend_name,
+        tool,
+        api_key_name,
+    ));
 }
 
 fn record_client_failure(state: &AppState, client: Option<&AuthenticatedClient>) {

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -173,6 +173,59 @@ fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
     state
 }
 
+/// `AppState` whose shared Meta-MCP has provenance stamping enabled, for
+/// exercising the direct `/mcp/{name}` route's rung-3 stamping (MIK-6905).
+/// Uses a fixed signer key so a twin validator can verify the receipt.
+fn test_router_app_state_with_provenance_backend(backend: Arc<Backend>) -> Arc<AppState> {
+    let backends = Arc::new(BackendRegistry::new());
+    backends.register(backend);
+    let mut meta = MetaMcp::new(Arc::clone(&backends));
+    meta.enable_provenance_stamping(crate::attestation::BnautAttestationSigner::new(
+        b"prov-key".to_vec(),
+        "unit",
+    ));
+    let meta_mcp = Arc::new(meta);
+    let streaming_config = StreamingConfig::default();
+    let multiplexer = Arc::new(NotificationMultiplexer::new(
+        Arc::clone(&backends),
+        streaming_config.clone(),
+    ));
+    let proxy_manager = Arc::new(ProxyManager::new(Arc::clone(&multiplexer)));
+    let auth_config = Arc::new(ResolvedAuthConfig::from_config(&AuthConfig::default()));
+    let agent_auth = AgentAuthState::new(false, Arc::new(AgentRegistry::new()));
+    let gateway_key_pair = Arc::new(GatewayKeyPair::generate().expect("gateway key generation"));
+
+    Arc::new(AppState {
+        backends,
+        meta_mcp,
+        meta_mcp_enabled: true,
+        multiplexer,
+        proxy_manager,
+        streaming_config,
+        auth_config,
+        key_server: None,
+        tool_policy: Arc::new(crate::security::ToolPolicy::default()),
+        mtls_policy: Arc::new(MtlsPolicy::from_config(&MtlsConfig::default())),
+        sanitize_input: false,
+        ssrf_protection: false,
+        trust_configured_backends: false,
+        inflight: Arc::new(tokio::sync::Semaphore::new(8)),
+        agent_auth,
+        gateway_key_pair,
+        capability_dirs: Vec::new(),
+        config_path: None,
+        #[cfg(feature = "firewall")]
+        firewall: None,
+        agent_identity_config: crate::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
+        live_config: std::sync::Arc::new(crate::config_reload::LiveConfig::new(
+            crate::config::Config::default(),
+        )),
+        export_status: None,
+        transparency_log: None,
+    })
+}
+
 /// `AppState` whose Meta-MCP has an identity-propagation strategy wired (so a
 /// `required` backend actually MINTS a per-user credential) AND a transparency
 /// log on the Meta-MCP side (so the shared mint chokepoint's own audit
@@ -1178,6 +1231,106 @@ async fn backend_handler_tools_call_enforces_api_key_tool_scope() {
             .is_some_and(|message| message.contains("allowlist"))
     );
     assert!(transport.request_methods.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn backend_handler_direct_route_stamps_bypass_provenance() {
+    // Rung 3: the direct /mcp/{name} passthrough must also carry a signed
+    // provenance receipt, tagged cache=Bypass (it never consults the meta
+    // cache). Without this a client routes around provenance by URL choice.
+    use crate::trust::{CacheOutcome, SignedResultProvenance};
+
+    let backend = Arc::new(Backend::new(
+        "demo",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let transport: Arc<dyn Transport> = Arc::new(RouterNotificationTestTransport::success());
+    backend.set_transport_for_test(transport);
+
+    let state = test_router_app_state_with_provenance_backend(backend);
+    let router = create_router(state);
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": { "name": "search", "arguments": {} }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+
+    let provenance = json
+        .pointer("/result/_meta/provenance")
+        .expect("direct route must stamp _meta.provenance on tools/call");
+    let signed: SignedResultProvenance =
+        serde_json::from_value(provenance.clone()).expect("provenance must deserialize");
+
+    assert_eq!(
+        signed.receipt.cache,
+        CacheOutcome::Bypass,
+        "direct route bypasses the meta cache → cache=Bypass"
+    );
+    assert_eq!(signed.receipt.backend_id, "demo");
+    assert_eq!(signed.receipt.tool, "search");
+
+    let validator = crate::attestation::AttestationValidator::new(
+        crate::attestation::BnautAttestationSigner::new(b"prov-key".to_vec(), "unit"),
+    );
+    assert!(
+        validator.verify_result_provenance(&signed),
+        "direct-route receipt must verify under a twin validator"
+    );
+}
+
+#[tokio::test]
+async fn backend_handler_direct_route_no_provenance_when_disabled() {
+    // Flag off (default MetaMcp, no signer): the direct route stays
+    // byte-identical — no _meta.provenance appears.
+    let backend = Arc::new(Backend::new(
+        "demo",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let transport: Arc<dyn Transport> = Arc::new(RouterNotificationTestTransport::success());
+    backend.set_transport_for_test(transport);
+
+    let router = create_router(test_router_app_state_with_backend(backend));
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": { "name": "search", "arguments": {} }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json.pointer("/result/_meta/provenance").is_none(),
+        "flag off must not stamp provenance, got: {json}"
+    );
 }
 
 #[tokio::test]

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -529,6 +529,29 @@ impl Gateway {
             }
         }
 
+        // ── Runtime provenance stamping (MIK-6905) ────────────────────────────
+        // Off by default. When enabled, sign a facts-only receipt into
+        // `_meta.provenance` on every aggregated tool result, reusing the
+        // gateway's attestation signing key (one signing identity, B4-PLATFORM).
+        if self.config.security.provenance_stamping {
+            let key =
+                std::env::var(crate::attestation::ATTESTATION_SIGNING_KEY_ENV).unwrap_or_default();
+            if key.is_empty() {
+                warn!(
+                    env = crate::attestation::ATTESTATION_SIGNING_KEY_ENV,
+                    "provenance_stamping enabled without a signing key; receipts will be \
+                     signed with an empty key and cannot be meaningfully verified"
+                );
+            }
+            let key_id = std::env::var(crate::attestation::ATTESTATION_KEY_ID_ENV)
+                .unwrap_or_else(|_| "gateway".to_string());
+            let signer = crate::attestation::BnautAttestationSigner::new(key.into_bytes(), key_id);
+            Arc::get_mut(&mut meta_mcp)
+                .expect("no other Arc references at this point")
+                .enable_provenance_stamping(signer);
+            info!("Runtime provenance stamping enabled — signed _meta.provenance on tool results");
+        }
+
         // ── Response inspection action mode (issue #133, D2) ──────────────────
         if self.config.security.response_inspection.enabled
             && self.config.security.response_inspection.action_mode

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 mod assistant;
 mod descriptor;
 mod inference;
+pub mod provenance_eval;
 mod result_provenance;
 
 pub use assistant::{

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 mod assistant;
 mod descriptor;
 mod inference;
+mod result_provenance;
 
 pub use assistant::{
     TrustAssistantAutomationAction, TrustAssistantAutomationStatus, TrustAssistantPrompt,
@@ -32,6 +33,7 @@ pub use descriptor::{
     project_tool_descriptor_trust_card, project_tool_descriptors_trust_cards,
     tools_list_result_with_trust_cards, trust_card_digest_sha256,
 };
+pub use result_provenance::{CacheOutcome, RuntimeProvenanceReceipt, SignedResultProvenance};
 
 use inference::{
     infer_data_classes, infer_permissions, infer_risk_class, source_uri_from_capability,

--- a/src/trust/provenance_eval.rs
+++ b/src/trust/provenance_eval.rs
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Offline provenance-eval harness (MIK-6906, rung 2).
+//!
+//! Rung 1 ([`super::result_provenance`]) stamps a signed, facts-only receipt of
+//! every observed tool call. This harness is the first *consumer* of those
+//! receipts: it replays real tool traffic, treats the signed receipts as the
+//! ground truth of what the gateway actually observed, and scores whether the
+//! agent-visible *claim* attached to each result is supported by those facts.
+//!
+//! The metric it produces is the unsupported-claim rate — how often an agent
+//! emits a claim the observed evidence does not back. That is the number the
+//! MIK-5854 spike only pretended to measure: its ground truth was a hand-mirror
+//! of its own classifier (`expected_verdict = classify(input)`), so it measured
+//! nothing. Here the ground truth is the *receipt* — real observed data produced
+//! by a separate component — and the fixture labels are independent literals.
+//! [`tests::ground_truth_is_not_a_scorer_mirror`] proves the labels genuinely
+//! discriminate rather than echoing the scorer.
+//!
+//! Design contract:
+//! - **Offline / shadow only.** Pure functions, no async, no network, no wiring
+//!   into any request path. Nothing here runs on the production hot path
+//!   (MIK-6904.RUNG2.4).
+//! - **Consumes signed receipts.** [`replay`] verifies each receipt's signature
+//!   through the same [`AttestationValidator`] the gateway uses before it will
+//!   score it; an unverifiable receipt is *rejected*, never scored, because
+//!   untrusted ground truth is not ground truth (MIK-6904.RUNG2.1).
+//! - **Abstain is first-class.** "The source could not be checked" is reported
+//!   separately from "the source was checked and authoritatively empty"
+//!   (MIK-6904.RUNG2.3). Conflating the two is the exact silent failure this
+//!   whole line of work targets.
+
+use serde::{Deserialize, Serialize};
+
+use super::result_provenance::{RuntimeProvenanceReceipt, SignedResultProvenance};
+use crate::attestation::validator::AttestationValidator;
+
+/// What the agent surfaced to the user about a tool result — the claim under
+/// scrutiny. Every variant is a statement the receipt facts can support,
+/// contradict, or be silent on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum Claim {
+    /// "The source was queried and authoritatively returned nothing."
+    /// Supported only by an *observed* empty result on a successful call.
+    AuthoritativeEmpty,
+    /// "The source returned exactly `count` matching rows/items."
+    FoundRows {
+        /// The exact row/item count the agent asserted.
+        count: u64,
+    },
+    /// "The call succeeded." Asserts nothing about the row count.
+    Succeeded,
+}
+
+/// The scorer's verdict on one claim, given the receipt facts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimVerdict {
+    /// The receipt facts entail the claim.
+    Supported,
+    /// The receipt facts contradict the claim.
+    Unsupported,
+    /// The receipt lacks the facts needed to adjudicate the claim
+    /// ("could-not-check"). Distinct from an authoritative negative.
+    Abstain,
+}
+
+/// Score one claim against the facts in a receipt.
+///
+/// This is the whole adjudication logic. It reads *only* observed facts
+/// (`backend_ok`, `row_count`) and never infers meaning the receipt does not
+/// carry — in particular an absent `row_count` is treated as "not observed"
+/// (→ `Abstain`), never as zero. A failed call can never support any positive
+/// claim, which is the checked-empty-vs-could-not-check distinction made
+/// structural.
+#[must_use]
+pub fn score(claim: &Claim, receipt: &RuntimeProvenanceReceipt) -> ClaimVerdict {
+    // A call the backend reported as failed cannot support any claim about what
+    // the source "said" — this is could-not-check, never an authoritative fact.
+    if !receipt.backend_ok {
+        return match claim {
+            // "It succeeded" against a failed call is a direct contradiction.
+            Claim::Succeeded => ClaimVerdict::Unsupported,
+            // Any positive/negative content claim is unsupported by a failure.
+            Claim::AuthoritativeEmpty | Claim::FoundRows { .. } => ClaimVerdict::Unsupported,
+        };
+    }
+
+    match claim {
+        // Success is directly observed.
+        Claim::Succeeded => ClaimVerdict::Supported,
+        Claim::AuthoritativeEmpty => match receipt.row_count {
+            Some(0) => ClaimVerdict::Supported,
+            Some(_) => ClaimVerdict::Unsupported,
+            // Count not observed → cannot confirm the source was actually empty.
+            None => ClaimVerdict::Abstain,
+        },
+        Claim::FoundRows { count } => match receipt.row_count {
+            Some(observed) if observed == *count => ClaimVerdict::Supported,
+            Some(_) => ClaimVerdict::Unsupported,
+            None => ClaimVerdict::Abstain,
+        },
+    }
+}
+
+/// One replayed unit: a claim the agent surfaced plus the signed receipt of the
+/// call that produced it.
+#[derive(Debug, Clone)]
+pub struct ReplayCase {
+    /// What the agent claimed about the result.
+    pub claim: Claim,
+    /// The signed provenance receipt rung 1 stamped for that call.
+    pub signed: SignedResultProvenance,
+}
+
+/// Tally of a replay run. Every count is disjoint; `total == supported +
+/// unsupported + abstained + rejected`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalReport {
+    /// Cases seen.
+    pub total: usize,
+    /// Claims the receipt facts entailed.
+    pub supported: usize,
+    /// Claims the receipt facts contradicted.
+    pub unsupported: usize,
+    /// Claims the receipt could not adjudicate (could-not-check).
+    pub abstained: usize,
+    /// Cases whose receipt signature did not verify — excluded from scoring
+    /// because untrusted ground truth cannot back a metric.
+    pub rejected: usize,
+}
+
+impl EvalReport {
+    /// Unsupported-claim rate over *adjudicated* cases only (supported +
+    /// unsupported). Abstained and rejected cases are excluded from the
+    /// denominator: an abstain is "insufficient evidence to judge", not a
+    /// scoring failure, and must not be blended into the rate. Returns `None`
+    /// when nothing was adjudicated.
+    #[must_use]
+    pub fn unsupported_rate(&self) -> Option<f64> {
+        let adjudicated = self.supported + self.unsupported;
+        if adjudicated == 0 {
+            return None;
+        }
+        // Cast is safe: counts are small relative to f64's integer precision.
+        #[allow(clippy::cast_precision_loss)]
+        Some(self.unsupported as f64 / adjudicated as f64)
+    }
+}
+
+/// Replay a set of cases against the observed receipts, verifying each
+/// receipt's signature before scoring it.
+///
+/// Offline only. `validator` must hold the key the receipts were signed with;
+/// receipts that fail verification are counted as `rejected` and never scored.
+#[must_use]
+pub fn replay(cases: &[ReplayCase], validator: &AttestationValidator) -> EvalReport {
+    let mut report = EvalReport::default();
+    for case in cases {
+        report.total += 1;
+        if !validator.verify_result_provenance(&case.signed) {
+            report.rejected += 1;
+            continue;
+        }
+        match score(&case.claim, &case.signed.receipt) {
+            ClaimVerdict::Supported => report.supported += 1,
+            ClaimVerdict::Unsupported => report.unsupported += 1,
+            ClaimVerdict::Abstain => report.abstained += 1,
+        }
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attestation::signer::BnautAttestationSigner;
+    use crate::trust::result_provenance::CacheOutcome;
+
+    const KEY: &[u8] = b"provenance-eval-test-key";
+
+    fn signer() -> BnautAttestationSigner {
+        BnautAttestationSigner::new(KEY.to_vec(), "unit")
+    }
+
+    fn validator() -> AttestationValidator {
+        AttestationValidator::new(signer())
+    }
+
+    /// Build a signed receipt from observed facts. `row_count = None` models a
+    /// backend that exposes no count.
+    fn signed_receipt(
+        backend_ok: bool,
+        row_count: Option<u64>,
+        cache: CacheOutcome,
+    ) -> SignedResultProvenance {
+        let mut r = RuntimeProvenanceReceipt::observed(
+            "demo",
+            "search",
+            "2026-07-13T10:15:30Z",
+            cache,
+            backend_ok,
+        );
+        if let Some(n) = row_count {
+            r = r.with_row_count(n);
+        }
+        r.sign(&signer())
+    }
+
+    /// The labelled ground-truth set. Every `expected` is a hand-authored
+    /// literal — NOT computed by `score` — so the fixture is an independent
+    /// oracle, not a mirror of the classifier (MIK-6904.RUNG2.3).
+    fn ground_truth() -> Vec<(ReplayCase, ClaimVerdict)> {
+        vec![
+            // Source queried, genuinely empty → the "no results" claim is honest.
+            (
+                ReplayCase {
+                    claim: Claim::AuthoritativeEmpty,
+                    signed: signed_receipt(true, Some(0), CacheOutcome::Miss),
+                },
+                ClaimVerdict::Supported,
+            ),
+            // The core silent failure: call FAILED but agent rendered "no results".
+            (
+                ReplayCase {
+                    claim: Claim::AuthoritativeEmpty,
+                    signed: signed_receipt(false, None, CacheOutcome::Miss),
+                },
+                ClaimVerdict::Unsupported,
+            ),
+            // Backend exposes no count → cannot confirm authoritative-empty.
+            (
+                ReplayCase {
+                    claim: Claim::AuthoritativeEmpty,
+                    signed: signed_receipt(true, None, CacheOutcome::Hit),
+                },
+                ClaimVerdict::Abstain,
+            ),
+            // Honest count claim.
+            (
+                ReplayCase {
+                    claim: Claim::FoundRows { count: 3 },
+                    signed: signed_receipt(true, Some(3), CacheOutcome::Miss),
+                },
+                ClaimVerdict::Supported,
+            ),
+            // Inflated count claim.
+            (
+                ReplayCase {
+                    claim: Claim::FoundRows { count: 10 },
+                    signed: signed_receipt(true, Some(3), CacheOutcome::Miss),
+                },
+                ClaimVerdict::Unsupported,
+            ),
+            // Success genuinely observed.
+            (
+                ReplayCase {
+                    claim: Claim::Succeeded,
+                    signed: signed_receipt(true, None, CacheOutcome::Bypass),
+                },
+                ClaimVerdict::Supported,
+            ),
+            // "Succeeded" over a failed call.
+            (
+                ReplayCase {
+                    claim: Claim::Succeeded,
+                    signed: signed_receipt(false, None, CacheOutcome::Miss),
+                },
+                ClaimVerdict::Unsupported,
+            ),
+        ]
+    }
+
+    /// MIK-6904.RUNG2.2 — the scorer flags a known unsupported claim and passes
+    /// a known supported one on the fixed labelled fixture.
+    #[test]
+    fn scorer_matches_every_ground_truth_label() {
+        for (case, expected) in ground_truth() {
+            assert_eq!(
+                score(&case.claim, &case.signed.receipt),
+                expected,
+                "scorer disagreed with independent label for {:?}",
+                case.claim
+            );
+        }
+    }
+
+    /// MIK-6904.RUNG2.3 — the labels are not a hand-copy of the verdict rules.
+    /// A degenerate scorer that blindly returns `Supported` must FAIL the
+    /// fixture; if it passed, the labels would carry no independent signal and
+    /// the metric would be unfalsifiable (the exact spike failure).
+    #[test]
+    fn ground_truth_is_not_a_scorer_mirror() {
+        let const_supported = |_: &Claim, _: &RuntimeProvenanceReceipt| ClaimVerdict::Supported;
+        let disagreements = ground_truth()
+            .iter()
+            .filter(|(case, expected)| {
+                const_supported(&case.claim, &case.signed.receipt) != *expected
+            })
+            .count();
+        assert!(
+            disagreements > 0,
+            "a constant scorer reproduced the fixture — labels do not discriminate"
+        );
+    }
+
+    /// MIK-6904.RUNG2.3 — the report keeps could-not-check separate from
+    /// authoritative-negative. The fixture contains at least one of each and
+    /// they land in different buckets.
+    #[test]
+    fn report_separates_abstain_from_authoritative_negative() {
+        let cases: Vec<ReplayCase> = ground_truth().into_iter().map(|(c, _)| c).collect();
+        let report = replay(&cases, &validator());
+        // At least one abstain (could-not-check) and one authoritative-empty
+        // (supported) — proving the two are counted distinctly, not merged.
+        assert!(report.abstained >= 1, "no could-not-check case counted");
+        assert!(
+            report.supported >= 1,
+            "no authoritative-negative/positive case counted"
+        );
+        assert_eq!(
+            report.total,
+            report.supported + report.unsupported + report.abstained + report.rejected
+        );
+    }
+
+    /// MIK-6904.RUNG2.1 — replay consumes *signed* receipts: a tampered receipt
+    /// whose signature no longer verifies is rejected, never scored.
+    #[test]
+    fn replay_rejects_unverifiable_receipts() {
+        let mut case = ReplayCase {
+            claim: Claim::Succeeded,
+            signed: signed_receipt(true, None, CacheOutcome::Miss),
+        };
+        // Tamper: flip an observed fact without re-signing.
+        case.signed.receipt.backend_ok = false;
+        let report = replay(&[case], &validator());
+        assert_eq!(report.rejected, 1);
+        assert_eq!(report.supported + report.unsupported + report.abstained, 0);
+    }
+
+    /// A receipt signed with a different key is not trusted ground truth.
+    #[test]
+    fn replay_rejects_foreign_key_signatures() {
+        let foreign = BnautAttestationSigner::new(b"someone-elses-key".to_vec(), "unit");
+        let mut receipt = RuntimeProvenanceReceipt::observed(
+            "demo",
+            "search",
+            "2026-07-13T10:15:30Z",
+            CacheOutcome::Miss,
+            true,
+        );
+        receipt = receipt.with_row_count(0);
+        let case = ReplayCase {
+            claim: Claim::AuthoritativeEmpty,
+            signed: receipt.sign(&foreign),
+        };
+        let report = replay(&[case], &validator());
+        assert_eq!(report.rejected, 1);
+    }
+
+    /// The unsupported-claim rate is computed over adjudicated cases only, with
+    /// abstain and rejected excluded from the denominator.
+    #[test]
+    fn unsupported_rate_excludes_abstain_and_rejected() {
+        let cases: Vec<ReplayCase> = ground_truth().into_iter().map(|(c, _)| c).collect();
+        let report = replay(&cases, &validator());
+        // Fixture: 3 supported, 3 unsupported, 1 abstain, 0 rejected.
+        assert_eq!(report.supported, 3);
+        assert_eq!(report.unsupported, 3);
+        assert_eq!(report.abstained, 1);
+        assert_eq!(report.rejected, 0);
+        let rate = report.unsupported_rate().expect("adjudicated cases exist");
+        assert!((rate - 3.0 / 6.0).abs() < 1e-9, "rate was {rate}");
+    }
+
+    #[test]
+    fn empty_replay_has_no_rate() {
+        assert_eq!(EvalReport::default().unsupported_rate(), None);
+    }
+}

--- a/src/trust/provenance_eval.rs
+++ b/src/trust/provenance_eval.rs
@@ -78,13 +78,9 @@ pub enum ClaimVerdict {
 pub fn score(claim: &Claim, receipt: &RuntimeProvenanceReceipt) -> ClaimVerdict {
     // A call the backend reported as failed cannot support any claim about what
     // the source "said" — this is could-not-check, never an authoritative fact.
+    // Every claim (success, empty, count) is unsupported by a failure.
     if !receipt.backend_ok {
-        return match claim {
-            // "It succeeded" against a failed call is a direct contradiction.
-            Claim::Succeeded => ClaimVerdict::Unsupported,
-            // Any positive/negative content claim is unsupported by a failure.
-            Claim::AuthoritativeEmpty | Claim::FoundRows { .. } => ClaimVerdict::Unsupported,
-        };
+        return ClaimVerdict::Unsupported;
     }
 
     match claim {

--- a/src/trust/result_provenance.rs
+++ b/src/trust/result_provenance.rs
@@ -69,6 +69,12 @@ pub struct RuntimeProvenanceReceipt {
     pub row_count: Option<u64>,
     /// Whether the backend reported success (`isError == false`).
     pub backend_ok: bool,
+    /// Opaque gateway call id (`gw-<uuid>`), equal to the result-level
+    /// `trace_id` this receipt describes. This is the join key that ties the
+    /// receipt to the agent's rendered claim about the same call. `None` when no
+    /// trace scope was active (e.g. the direct backend route).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
     /// Evidence quality. Always [`TrustEvidenceKind::Observed`].
     pub evidence_kind: TrustEvidenceKind,
 }
@@ -95,6 +101,7 @@ impl RuntimeProvenanceReceipt {
             cache,
             row_count: None,
             backend_ok,
+            call_id: None,
             evidence_kind: TrustEvidenceKind::Observed,
         }
     }
@@ -103,6 +110,14 @@ impl RuntimeProvenanceReceipt {
     #[must_use]
     pub fn with_auth_context_ref(mut self, auth_context_ref: impl Into<String>) -> Self {
         self.auth_context_ref = Some(auth_context_ref.into());
+        self
+    }
+
+    /// Attach the gateway call id (`trace_id`) that joins this receipt to the
+    /// agent's rendered claim about the same call.
+    #[must_use]
+    pub fn with_call_id(mut self, call_id: impl Into<String>) -> Self {
+        self.call_id = Some(call_id.into());
         self
     }
 
@@ -228,5 +243,27 @@ mod tests {
         let json = serde_json::to_string(&r).unwrap();
         let back: RuntimeProvenanceReceipt = serde_json::from_str(&json).unwrap();
         assert_eq!(r, back);
+    }
+
+    #[test]
+    fn call_id_is_the_join_key_and_optional() {
+        // Absent call_id → canonical bytes byte-identical to today, so existing
+        // signatures and the flag-off/direct-route paths are unaffected.
+        let plain = sample();
+        assert!(plain.call_id.is_none());
+        assert_eq!(plain.canonical_bytes(), sample().canonical_bytes());
+        let json = serde_json::to_string(&plain).unwrap();
+        assert!(!json.contains("call_id"));
+
+        // Present → carried in the signed canonical bytes and round-trips.
+        let joined = sample().with_call_id("gw-11112222-3333-4444-5555-666677778888");
+        assert_ne!(joined.canonical_bytes(), plain.canonical_bytes());
+        let back: RuntimeProvenanceReceipt =
+            serde_json::from_str(&serde_json::to_string(&joined).unwrap()).unwrap();
+        assert_eq!(joined, back);
+        assert_eq!(
+            back.call_id.as_deref(),
+            Some("gw-11112222-3333-4444-5555-666677778888")
+        );
     }
 }

--- a/src/trust/result_provenance.rs
+++ b/src/trust/result_provenance.rs
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Runtime result-provenance receipts.
+//!
+//! The gateway is the one component that observes un-fakeable *runtime*
+//! provenance of every proxied tool call: which backend answered, when, under
+//! which auth context, whether the response came from cache, and whether the
+//! backend reported an error. This module models that as a facts-only receipt.
+//!
+//! Design contract (MIK-6905, rung 1):
+//! - **Facts, not judgments.** A receipt records what was observed. It never
+//!   infers meaning. In particular an absent [`RuntimeProvenanceReceipt::row_count`]
+//!   means "not observed", never "zero rows"; an empty successful result is
+//!   never rendered as an authoritative negative. Consumers decide what the
+//!   facts mean.
+//! - **Observed evidence only.** Every receipt carries
+//!   [`TrustEvidenceKind::Observed`] and [`CbomSubjectKind::Runtime`] — this is
+//!   the data-plane sibling of the capability-definition provenance already
+//!   modelled in [`super`].
+//! - **No secrets.** Only a *reference* to the auth context (an opaque
+//!   handle/hash chosen by the caller) is ever stored, never a raw credential,
+//!   token, or backend-internal string (keeps the CWE-532 leak lint green).
+
+use serde::{Deserialize, Serialize};
+
+use super::{CbomSubjectKind, TrustEvidenceKind};
+use crate::attestation::SIGNING_ALGORITHM;
+use crate::attestation::signer::BnautAttestationSigner;
+use crate::hashing::canonical_json;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Where a proxied result came from with respect to the response cache.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheOutcome {
+    /// Served from a warm cache entry.
+    Hit,
+    /// Fetched live from the backend (no usable cache entry).
+    Miss,
+    /// Cache was intentionally bypassed for this call.
+    Bypass,
+}
+
+/// A facts-only receipt of one observed runtime tool call.
+///
+/// Serialized form is additive metadata destined for the MCP `_meta.provenance`
+/// channel. It carries no tool-result content and mutates no payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeProvenanceReceipt {
+    /// CBOM subject kind. Always [`CbomSubjectKind::Runtime`] for a receipt.
+    pub subject_kind: CbomSubjectKind,
+    /// Identifier of the backend/server that answered the call.
+    pub backend_id: String,
+    /// Name of the tool that was invoked.
+    pub tool: String,
+    /// RFC-3339 wall-clock instant the result was observed at the gateway.
+    pub observed_at: String,
+    /// Opaque reference to the caller's auth context (hash/handle), never a raw
+    /// credential. `None` when the call was unauthenticated or no reference was
+    /// available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_context_ref: Option<String>,
+    /// Whether the result was served from cache, fetched live, or bypassed cache.
+    pub cache: CacheOutcome,
+    /// Observed row/item count when the backend exposes one. `None` = not
+    /// observed (NOT zero — see module contract).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub row_count: Option<u64>,
+    /// Whether the backend reported success (`isError == false`).
+    pub backend_ok: bool,
+    /// Evidence quality. Always [`TrustEvidenceKind::Observed`].
+    pub evidence_kind: TrustEvidenceKind,
+}
+
+impl RuntimeProvenanceReceipt {
+    /// Construct a receipt from observed facts.
+    ///
+    /// `evidence_kind` and `subject_kind` are fixed to `Observed`/`Runtime` —
+    /// this constructor is the only sanctioned way to build a receipt, so those
+    /// invariants cannot be violated at a call site.
+    pub fn observed(
+        backend_id: impl Into<String>,
+        tool: impl Into<String>,
+        observed_at: impl Into<String>,
+        cache: CacheOutcome,
+        backend_ok: bool,
+    ) -> Self {
+        Self {
+            subject_kind: CbomSubjectKind::Runtime,
+            backend_id: backend_id.into(),
+            tool: tool.into(),
+            observed_at: observed_at.into(),
+            auth_context_ref: None,
+            cache,
+            row_count: None,
+            backend_ok,
+            evidence_kind: TrustEvidenceKind::Observed,
+        }
+    }
+
+    /// Attach an opaque auth-context reference (hash/handle, never a raw secret).
+    #[must_use]
+    pub fn with_auth_context_ref(mut self, auth_context_ref: impl Into<String>) -> Self {
+        self.auth_context_ref = Some(auth_context_ref.into());
+        self
+    }
+
+    /// Attach an observed row/item count.
+    #[must_use]
+    pub fn with_row_count(mut self, row_count: u64) -> Self {
+        self.row_count = Some(row_count);
+        self
+    }
+
+    /// Canonical (deterministic key-order) JSON bytes of this receipt.
+    ///
+    /// This is the exact payload signed by the attestation signer in rung 1.3,
+    /// so key ordering must be stable regardless of struct field order.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        // A receipt is a fixed flat struct of primitives — serialization to a
+        // `Value` cannot fail; fall back to an empty object if it ever did
+        // rather than panic on the hot path.
+        let value = serde_json::to_value(self).unwrap_or(serde_json::Value::Null);
+        canonical_json(&value).into_bytes()
+    }
+
+    /// Sign this receipt with the gateway's attestation signer.
+    ///
+    /// The HMAC covers [`Self::canonical_bytes`], so a receipt and its
+    /// signature travel together in `_meta.provenance`. Verification is owned by
+    /// [`crate::attestation::AttestationValidator::verify_result_provenance`].
+    #[must_use]
+    pub fn sign(&self, signer: &BnautAttestationSigner) -> SignedResultProvenance {
+        let signature = signer.sign_bytes(&self.canonical_bytes());
+        SignedResultProvenance {
+            receipt: self.clone(),
+            key_id: signer.key_id().to_string(),
+            algorithm: SIGNING_ALGORITHM.to_string(),
+            signature: URL_SAFE_NO_PAD.encode(signature),
+        }
+    }
+}
+
+/// A [`RuntimeProvenanceReceipt`] plus its detached HMAC signature.
+///
+/// This is the object that lands in the MCP `_meta.provenance` channel. It is
+/// additive metadata — it carries no tool-result content and mutates no payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignedResultProvenance {
+    /// The observed facts.
+    pub receipt: RuntimeProvenanceReceipt,
+    /// Namespaced identifier of the signing key (`bnaut/...`).
+    pub key_id: String,
+    /// Signing algorithm, e.g. `HS256`.
+    pub algorithm: String,
+    /// base64url(no-pad) HMAC over `receipt.canonical_bytes()`.
+    pub signature: String,
+}
+
+impl SignedResultProvenance {
+    /// Decode the detached signature back to raw bytes, or `None` if the
+    /// encoding is malformed.
+    #[must_use]
+    pub fn signature_bytes(&self) -> Option<Vec<u8>> {
+        URL_SAFE_NO_PAD.decode(self.signature.as_bytes()).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> RuntimeProvenanceReceipt {
+        RuntimeProvenanceReceipt::observed(
+            "github",
+            "search_issues",
+            "2026-07-13T10:15:30Z",
+            CacheOutcome::Miss,
+            true,
+        )
+    }
+
+    #[test]
+    fn observed_receipt_is_always_observed_runtime_evidence() {
+        let r = sample();
+        assert_eq!(r.evidence_kind, TrustEvidenceKind::Observed);
+        assert_eq!(r.subject_kind, CbomSubjectKind::Runtime);
+    }
+
+    #[test]
+    fn defaults_carry_no_optional_facts() {
+        let r = sample();
+        // Absent count means "not observed", never zero.
+        assert!(r.row_count.is_none());
+        assert!(r.auth_context_ref.is_none());
+    }
+
+    #[test]
+    fn builders_attach_optional_facts() {
+        let r = sample()
+            .with_auth_context_ref("sha256:deadbeef")
+            .with_row_count(0);
+        assert_eq!(r.auth_context_ref.as_deref(), Some("sha256:deadbeef"));
+        // Explicit zero IS representable — it is only *absence* that must not
+        // be read as zero.
+        assert_eq!(r.row_count, Some(0));
+    }
+
+    #[test]
+    fn canonical_bytes_are_key_order_stable() {
+        // Two receipts with identical facts produce byte-identical canonical
+        // JSON — the signing invariant for rung 1.3.
+        assert_eq!(sample().canonical_bytes(), sample().canonical_bytes());
+    }
+
+    #[test]
+    fn optional_fields_omitted_from_serialization_when_absent() {
+        let json = serde_json::to_string(&sample()).unwrap();
+        assert!(!json.contains("row_count"));
+        assert!(!json.contains("auth_context_ref"));
+    }
+
+    #[test]
+    fn serialization_round_trips() {
+        let r = sample().with_auth_context_ref("ref-1").with_row_count(42);
+        let json = serde_json::to_string(&r).unwrap();
+        let back: RuntimeProvenanceReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, back);
+    }
+}


### PR DESCRIPTION
## What this does

Adds signed runtime provenance to the MCP gateway in two layers that ship together.

**Rung 1 (MIK-6905) writes the receipts.** Every proxied tool call gets a facts-only receipt stamped into `_meta.provenance`: which backend answered, which tool, cache state, whether the backend reported success, and an observed row count when the backend exposes one. The receipt also carries the call's `trace_id` as a `call_id` join key, the same id returned to the client as `result.trace_id`, so a receipt can later be tied back to the agent's rendered claim about that exact call. The receipt is signed by the gateway's attestation key. It records what was observed and never infers meaning. An absent row count means "not observed", not zero.  Coverage spans every invocation path: stdio, the meta HTTP and SSE routes, cache hits, and the direct `/mcp/{name}` route that previously bypassed stamping.

**Rung 2 (MIK-6906) reads them.** A pure offline harness scores whether an agent-visible claim is backed by what the gateway actually observed. It returns one of three verdicts: supported, unsupported, or could-not-check. A failed call supports no positive claim, which turns the "checked and empty" versus "could not check" distinction into a structural property rather than a wording convention.

## Why both in one PR

Rung 1 on its own is a writer with no reader. Signed receipts that nothing consumes deliver nothing. Rung 2 is that first consumer, so the value only lands when the two are together. Shipping rung 1 alone would have been infrastructure ahead of its only use.

## How it stays honest

The earlier spike on this idea (MIK-5854) measured nothing because its ground truth was a hand-copy of its own classifier. This harness avoids that trap. Ground truth is the real receipt produced by a separate component, the fixture labels are independent literals, and a test proves a degenerate constant scorer fails the fixture. If the labels merely echoed the scorer, that test would pass and hide the circularity.

## Safety

Stamping is off by default. Output is byte-identical when the feature flag is off and when no signing key is configured. The `call_id` field is omitted from the signed bytes when no trace scope is active, so receipts on the direct route and with the flag off are unchanged from before. Nothing in rung 2 touches a request path. The harness is pure functions with no async and no network.

## What is deliberately not here

There is no live replay against real traffic yet. The gateway now supplies its half of the join, the `call_id` on each receipt, but a full corpus also needs the agent's rendered claim for the same call, and the gateway never sees that utterance. Pairing the two is the harness's job, tracked as a linked follow-up (MIK-6908). Building a binary now to read a capture that does not exist would be scaffolding for absent data.

## Verification

- `cargo test --lib` green, including the `trust::provenance_eval` harness tests, the `call_id` join-key test, and the rung 1 stamping tests across all four paths
- `cargo clippy --lib --tests -- -D warnings -D missing-docs` clean
- `cargo fmt --check` clean

## Tickets

- MIK-6905 (rung 1, stamping)
- MIK-6906 (rung 2, verifier and eval harness)
- MIK-6908 (live-traffic measurement, filed and linked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
