### PR TITLE
Runtime provenance claim-capture: opt-in shadow sink + real-corpus scoring (MIK-6908 RUNG3.1 + RUNG3.4)

### DIFF
--- a/src/config/features/security.rs
+++ b/src/config/features/security.rs
@@ -364,6 +364,37 @@ impl ContextIntegrityConfig {
     }
 }
 
+// ── ClaimCaptureConfig ───────────────────────────────────────────────────────
+
+/// Shadow claim-capture at the tool-result stamping chokepoint (MIK-6908,
+/// rung 3.1). Only takes effect when [`SecurityConfig::provenance_stamping`]
+/// is also `true` — capture has nothing to record without a signed receipt.
+///
+/// ```yaml
+/// security:
+///   provenance_stamping: true
+///   claim_capture:
+///     enabled: true
+///     path: "~/.mcp-gateway/claim-capture/claims.jsonl"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClaimCaptureConfig {
+    /// Enable shadow claim capture. Default: `false` (opt-in).
+    pub enabled: bool,
+    /// Path to the append-only NDJSON capture file (`~` is expanded at startup).
+    pub path: String,
+}
+
+impl Default for ClaimCaptureConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: "~/.mcp-gateway/claim-capture/claims.jsonl".to_string(),
+        }
+    }
+}
+
 // ── SecurityConfig ────────────────────────────────────────────────────────────
 
 /// Security configuration for the gateway.
@@ -425,6 +456,10 @@ pub struct SecurityConfig {
     /// Additive metadata only; off by default so payloads are unchanged.
     #[serde(default)]
     pub provenance_stamping: bool,
+    /// Shadow-capture derived claims alongside signed receipts for offline
+    /// scoring (MIK-6908, rung 3.1). Default: disabled.
+    #[serde(default)]
+    pub claim_capture: ClaimCaptureConfig,
 }
 
 const fn default_trust_configured_backends() -> bool {
@@ -449,6 +484,7 @@ impl Default for SecurityConfig {
             context_integrity: ContextIntegrityConfig::default(),
             remote_server_signing: RemoteServerSigningConfig::default(),
             provenance_stamping: false,
+            claim_capture: ClaimCaptureConfig::default(),
         }
     }
 }

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -437,6 +437,14 @@ impl MetaMcp {
     ///
     /// `backend_ok` is derived from the result's `isError` flag so cache hits
     /// carrying a stored error are reported honestly.
+    ///
+    /// When shadow claim capture is also enabled (MIK-6908, rung 3.1), this
+    /// is the single chokepoint both the meta and direct-route call paths
+    /// funnel through, so a call whose receipt carries a `call_id` is
+    /// shadow-captured here alongside the derived claim. A `call_id`-less
+    /// receipt (no trace scope active) is skipped rather than captured
+    /// un-joinable — consistent with `score_corpus`'s mis-join contract,
+    /// which treats a missing join key as unscoreable, not as evidence.
     fn maybe_stamp_provenance(
         &self,
         value: Value,
@@ -445,15 +453,22 @@ impl MetaMcp {
         api_key_name: Option<&str>,
         cache: crate::trust::CacheOutcome,
     ) -> Value {
-        if let Some(ref signer) = self.provenance_signer {
-            let backend_ok = !value
-                .get("isError")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-            augment_with_provenance(value, signer, server, tool, api_key_name, cache, backend_ok)
-        } else {
-            value
+        let Some(ref signer) = self.provenance_signer else {
+            return value;
+        };
+        let backend_ok = !value
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let (stamped, signed_receipt) =
+            augment_with_provenance(value, signer, server, tool, api_key_name, cache, backend_ok);
+        if let Some(sink) = &self.claim_capture
+            && let Some(call_id) = signed_receipt.receipt.call_id.clone()
+        {
+            let claim = crate::trust::derive_claim(&stamped, backend_ok);
+            sink.capture(call_id, claim, signed_receipt);
         }
+        stamped
     }
 
     /// Stamp provenance onto a direct per-backend route result (the

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -226,6 +226,13 @@ pub struct MetaMcp {
     /// are byte-identical to the un-stamped path (rung 1.2 guarantee).
     pub(super) provenance_signer: Option<Arc<BnautAttestationSigner>>,
 
+    /// Shadow claim-capture sink (MIK-6908, rung 3.1).
+    ///
+    /// `Some` when `security.claim_capture.enabled = true`; `None` otherwise.
+    /// Only ever consulted alongside `provenance_signer` — capture has
+    /// nothing to record without a signed receipt.
+    pub(super) claim_capture: Option<Arc<crate::trust::ClaimCaptureSink>>,
+
     /// When `true`, requests without a `nonce` are rejected with JSON-RPC -32001.
     ///
     /// Corresponds to `security.message_signing.require_nonce` in config.
@@ -348,6 +355,7 @@ impl MetaMcp {
             message_signer: None,
             nonce_store: None,
             provenance_signer: None,
+            claim_capture: None,
             require_nonce: false,
             transparency_logger: None,
             response_inspection_action_mode: false,
@@ -524,6 +532,15 @@ impl MetaMcp {
     /// otherwise.
     pub fn enable_provenance_stamping(&mut self, signer: BnautAttestationSigner) {
         self.provenance_signer = Some(Arc::new(signer));
+    }
+
+    /// Enable shadow claim capture (MIK-6908, rung 3.1).
+    ///
+    /// Only has an observable effect once `provenance_signer` is also
+    /// `Some` — capture runs alongside stamping at the same chokepoint, not
+    /// independently of it.
+    pub fn enable_claim_capture(&mut self, sink: Arc<crate::trust::ClaimCaptureSink>) {
+        self.claim_capture = Some(sink);
     }
 
     /// Attach a transparency logger (issue #133, D3).

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -239,6 +239,12 @@ fn auth_context_ref_hash(name: &str) -> String {
 /// content is touched. Facts observed at the gateway — backend, tool, auth-ref,
 /// cache outcome, backend success — are recorded and signed; nothing is
 /// inferred (rung 1.4).
+///
+/// Also returns the [`SignedResultProvenance`] alongside the stamped value —
+/// this is the same object embedded in `_meta.provenance`, returned again so
+/// the caller (`maybe_stamp_provenance`, MIK-6908 rung 3.1) can hand it to the
+/// shadow claim-capture sink without re-deriving or re-parsing it out of the
+/// JSON it was just serialized into.
 pub(super) fn augment_with_provenance(
     mut result: Value,
     signer: &crate::attestation::signer::BnautAttestationSigner,
@@ -247,7 +253,7 @@ pub(super) fn augment_with_provenance(
     api_key_name: Option<&str>,
     cache: crate::trust::CacheOutcome,
     backend_ok: bool,
-) -> Value {
+) -> (Value, crate::trust::SignedResultProvenance) {
     use crate::trust::RuntimeProvenanceReceipt;
 
     let observed_at = chrono::Utc::now().to_rfc3339();
@@ -271,11 +277,11 @@ pub(super) fn augment_with_provenance(
         if let Value::Object(meta_map) = meta {
             meta_map.insert(
                 "provenance".to_string(),
-                serde_json::to_value(signed_receipt).unwrap_or(Value::Null),
+                serde_json::to_value(signed_receipt.clone()).unwrap_or(Value::Null),
             );
         }
     }
-    result
+    (result, signed_receipt)
 }
 
 #[cfg(test)]

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -605,6 +605,29 @@ impl Gateway {
             }
         }
 
+        // ── Shadow claim capture (MIK-6908, rung 3.1) ─────────────────────────
+        // Off by default. When enabled, shadow-captures the derived claim
+        // alongside each signed provenance receipt to an append-only NDJSON
+        // file, for offline scoring via `provenance-eval` (rung 3.4). Has no
+        // observable effect unless `provenance_stamping` is also enabled —
+        // capture piggybacks on that chokepoint rather than adding a new one.
+        if self.config.security.claim_capture.enabled {
+            let capture_path = expand_home_path(&self.config.security.claim_capture.path);
+            match crate::trust::ClaimCaptureSink::open(&capture_path) {
+                Ok(sink) => {
+                    Arc::get_mut(&mut meta_mcp)
+                        .expect("no other Arc references at this point")
+                        .enable_claim_capture(Arc::new(sink));
+                    info!(
+                        "Shadow claim capture enabled — capturing derived claims for offline scoring"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to open claim-capture sink — continuing without it");
+                }
+            }
+        }
+
         // ── Response inspection action mode (issue #133, D2) ──────────────────
         if self.config.security.response_inspection.enabled
             && self.config.security.response_inspection.action_mode

--- a/src/trust/claim_capture.rs
+++ b/src/trust/claim_capture.rs
@@ -143,6 +143,17 @@ mod tests {
         BnautAttestationSigner::new(KEY.to_vec(), "unit")
     }
 
+    /// The receipt-domain subkey derived from the same raw key material as
+    /// [`signer`]. Provenance receipts are signed with the HKDF receipt-domain
+    /// subkey (`RESULT_PROVENANCE_DOMAIN_INFO`), not the raw key — mirroring
+    /// production `resolve_provenance_signer`, which the validator's internal
+    /// `receipt_signer` re-derives from the same base key when verifying
+    /// (MIK-6909 domain separation). Signing receipts with the raw key would
+    /// make them fail verification and score as `Rejected`.
+    fn receipt_signer() -> BnautAttestationSigner {
+        signer().derive_domain(crate::attestation::RESULT_PROVENANCE_DOMAIN_INFO)
+    }
+
     fn signed_receipt(call_id: &str, backend_ok: bool) -> SignedResultProvenance {
         RuntimeProvenanceReceipt::observed(
             "demo",
@@ -152,7 +163,7 @@ mod tests {
             backend_ok,
         )
         .with_call_id(call_id)
-        .sign(&signer())
+        .sign(&receipt_signer())
     }
 
     fn read_lines(path: &std::path::Path) -> Vec<String> {

--- a/src/trust/claim_capture.rs
+++ b/src/trust/claim_capture.rs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Shadow claim-capture at the agent/tool boundary (MIK-6908, RUNG3.1).
+//!
+//! [`super::provenance_eval`] (rung 2) scores an agent-visible *claim* against
+//! the gateway's signed [`super::result_provenance::RuntimeProvenanceReceipt`]
+//! for the same call, but until now the only claims it could score were
+//! hand-authored fixture literals — there was no real corpus, because nothing
+//! captured "this call asserted X" at the moment the gateway actually saw the
+//! result.
+//!
+//! This module is that capture point. [`ClaimCaptureSink`] writes one
+//! [`CorpusRecord`] per observed call to an append-only NDJSON file — the
+//! exact shape [`super::provenance_eval::score_corpus`] already consumes, so
+//! feeding a captured file through the existing scorer (`provenance-eval
+//! <captured-file.jsonl>`, RUNG3.4) requires no format translation.
+//!
+//! ## Why only `Claim::Succeeded` is captured
+//!
+//! The claim has to be *derived*, not asserted by the client — the MCP
+//! protocol carries no "here is what I'm claiming about this result" channel,
+//! so the gateway is the only party positioned to record it, and it can only
+//! record what it can honestly observe at the stamping chokepoint
+//! ([`crate::gateway::meta_mcp::support::augment_with_provenance`]).
+//!
+//! `backend_ok` (`!isError`) is observed directly there and needs no
+//! interpretation, so [`Claim::Succeeded`] is always sound to derive.
+//! [`Claim::AuthoritativeEmpty`] and [`Claim::FoundRows`] would require a
+//! `row_count` — but the chokepoint is generic across 30+ heterogeneous
+//! backends with no per-tool result schema. Guessing a row count from
+//! whatever shape a given backend's JSON happens to have (a top-level array
+//! length, a `"results"`/`"items"`/`"rows"` field, ...) is exactly the kind of
+//! inferred-not-observed judgment [`super::result_provenance`]'s module
+//! contract forbids: "facts, not judgments... an absent row count means 'not
+//! observed', never zero". A wrong guess here would poison the eval corpus
+//! with fabricated ground truth — the same failure mode the RUNG2 design
+//! note (MIK-5854) already burned once. See `derive_claim` for the single
+//! narrow point where this decision is made.
+//!
+//! ## Deployment
+//!
+//! Opt-in, off by default (`security.claim_capture.enabled`, default
+//! `false`). Only takes effect when provenance stamping
+//! (`security.provenance_stamping`) is also enabled — capture has nothing to
+//! record without a signed receipt. Write failures are swallowed (this is
+//! best-effort observability, not a hot-path dependency), mirroring
+//! [`crate::security::firewall::audit::AuditLogger`]'s `Mutex<Box<dyn Write +
+//! Send>>` idiom rather than inventing a new sink abstraction.
+
+use std::fs::OpenOptions;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+use super::SignedResultProvenance;
+use super::provenance_eval::{Claim, CorpusRecord};
+
+/// Append-only NDJSON sink for real `(call_id, claim, receipt)` triples
+/// observed at the gateway's tool-result stamping chokepoint.
+pub struct ClaimCaptureSink {
+    writer: Mutex<Box<dyn Write + Send>>,
+}
+
+impl ClaimCaptureSink {
+    /// Open a capture file for append-only writing.
+    ///
+    /// The parent directory is created if it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the file cannot be opened or the parent
+    /// directory cannot be created.
+    pub fn open(path: &Path) -> io::Result<Self> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self::from_writer(BufWriter::new(file)))
+    }
+
+    /// Build a sink over an arbitrary writer (tests, or an alternate sink
+    /// backend in future).
+    #[must_use]
+    pub fn from_writer(writer: impl Write + Send + 'static) -> Self {
+        Self {
+            writer: Mutex::new(Box::new(writer)),
+        }
+    }
+
+    /// Record one shadow-capture line.
+    ///
+    /// Best-effort: a serialization or write failure is swallowed rather than
+    /// propagated, because capture must never be able to fail a live tool
+    /// call. Mirrors `AuditLogger::write_entry`.
+    pub fn capture(&self, call_id: String, claim: Claim, receipt: SignedResultProvenance) {
+        let record = CorpusRecord {
+            call_id,
+            claim,
+            receipt,
+        };
+        if let Ok(json) = serde_json::to_string(&record)
+            && let Ok(mut w) = self.writer.lock()
+        {
+            let _ = writeln!(w, "{json}");
+            let _ = w.flush();
+        }
+    }
+}
+
+/// Derive the claim a shadow-capture record should carry for one observed
+/// tool call, from exactly the facts already available at the provenance
+/// stamping chokepoint.
+///
+/// Deliberately ignores the tool result body (`_result` is unused): see the
+/// module doc for why a generic, backend-agnostic chokepoint cannot soundly
+/// infer a row/item count, and therefore always derives [`Claim::Succeeded`]
+/// — the one claim `backend_ok` alone supports without guessing at
+/// domain-specific result shape. `Claim::Succeeded` is deliberately captured
+/// even when `backend_ok` is `false`: scoring it `Unsupported` against a
+/// failed receipt is the exact silent-failure signal RUNG2 exists to catch,
+/// so suppressing capture on failure would hide the highest-value case.
+#[must_use]
+pub fn derive_claim(_result: &Value, _backend_ok: bool) -> Claim {
+    Claim::Succeeded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attestation::signer::BnautAttestationSigner;
+    use crate::trust::provenance_eval::score_corpus;
+    use crate::trust::{CacheOutcome, RuntimeProvenanceReceipt};
+    use serde_json::json;
+    use std::io::BufRead as _;
+
+    const KEY: &[u8] = b"claim-capture-test-key";
+
+    fn signer() -> BnautAttestationSigner {
+        BnautAttestationSigner::new(KEY.to_vec(), "unit")
+    }
+
+    fn signed_receipt(call_id: &str, backend_ok: bool) -> SignedResultProvenance {
+        RuntimeProvenanceReceipt::observed(
+            "demo",
+            "search",
+            "2026-07-13T10:15:30Z",
+            CacheOutcome::Miss,
+            backend_ok,
+        )
+        .with_call_id(call_id)
+        .sign(&signer())
+    }
+
+    fn read_lines(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect()
+    }
+
+    /// `derive_claim` always returns `Succeeded` regardless of the result
+    /// body shape — proving structurally (not just by doc comment) that this
+    /// chokepoint never parses tool-result content to guess a row count.
+    #[test]
+    fn derive_claim_ignores_result_body_shape() {
+        let array_like = json!({"content": [{"type": "text", "text": "[1,2,3]"}]});
+        let object_like = json!({"content": [{"type": "text", "text": "{}"}]});
+        assert_eq!(derive_claim(&array_like, true), Claim::Succeeded);
+        assert_eq!(derive_claim(&object_like, true), Claim::Succeeded);
+    }
+
+    /// `derive_claim` still returns `Succeeded` on a failed backend call — the
+    /// claim under scrutiny is "the call succeeded", and capturing it here is
+    /// exactly what lets `score_corpus` later flag it `Unsupported`.
+    #[test]
+    fn derive_claim_on_failed_backend_is_still_succeeded_for_scoring() {
+        let claim = derive_claim(&json!({"isError": true}), false);
+        assert_eq!(claim, Claim::Succeeded);
+    }
+
+    /// A captured record is valid NDJSON and round-trips into the exact
+    /// `CorpusRecord` shape `score_corpus` consumes (RUNG3.1 -> RUNG3.4 format
+    /// compatibility, proven structurally rather than asserted in a comment).
+    #[test]
+    fn capture_writes_one_valid_corpus_record_line() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sink = ClaimCaptureSink::open(tmp.path()).unwrap();
+        let receipt = signed_receipt("gw-call-1", true);
+        sink.capture("gw-call-1".to_string(), Claim::Succeeded, receipt.clone());
+
+        let lines = read_lines(tmp.path());
+        assert_eq!(lines.len(), 1);
+        let record: CorpusRecord = serde_json::from_str(&lines[0]).expect("valid CorpusRecord");
+        assert_eq!(record.call_id, "gw-call-1");
+        assert_eq!(record.claim, Claim::Succeeded);
+        assert_eq!(record.receipt, receipt);
+    }
+
+    /// Multiple captures append as separate lines (append-only contract).
+    #[test]
+    fn capture_appends_multiple_records_as_separate_lines() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sink = ClaimCaptureSink::open(tmp.path()).unwrap();
+        for i in 0..3 {
+            let call_id = format!("gw-call-{i}");
+            sink.capture(
+                call_id.clone(),
+                Claim::Succeeded,
+                signed_receipt(&call_id, true),
+            );
+        }
+        let lines = read_lines(tmp.path());
+        assert_eq!(lines.len(), 3);
+    }
+
+    /// End-to-end RUNG3.1 -> RUNG3.4: records captured through the real sink,
+    /// with real HMAC-signed receipts, feed directly into the real
+    /// `score_corpus` scorer (RUNG3.2) and produce a correct, non-synthetic
+    /// `EvalReport` — no fixture involved anywhere in this test.
+    #[test]
+    fn captured_records_score_correctly_through_score_corpus() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sink = ClaimCaptureSink::open(tmp.path()).unwrap();
+
+        // A genuinely successful call.
+        sink.capture(
+            "gw-call-ok".to_string(),
+            derive_claim(&json!({"isError": false}), true),
+            signed_receipt("gw-call-ok", true),
+        );
+        // A genuinely failed call — the claim is still `Succeeded` (that's
+        // what "the call succeeded" asserts), and the receipt says otherwise.
+        sink.capture(
+            "gw-call-fail".to_string(),
+            derive_claim(&json!({"isError": true}), false),
+            signed_receipt("gw-call-fail", false),
+        );
+
+        let file = std::fs::File::open(tmp.path()).unwrap();
+        let records: Vec<CorpusRecord> = std::io::BufReader::new(file)
+            .lines()
+            .map(|l| serde_json::from_str(&l.unwrap()).unwrap())
+            .collect();
+        assert_eq!(records.len(), 2);
+
+        let validator = crate::attestation::validator::AttestationValidator::new(signer());
+        let (report, mis_joined) = score_corpus(&records, &validator);
+        assert_eq!(mis_joined, 0);
+        assert_eq!(report.total, 2);
+        assert_eq!(report.supported, 1, "the genuinely successful call");
+        assert_eq!(
+            report.unsupported, 1,
+            "the failed call whose claim was still 'succeeded'"
+        );
+        assert_eq!(report.rejected, 0, "both receipts were validly signed");
+    }
+}

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 mod assistant;
+pub mod claim_capture;
 mod descriptor;
 mod inference;
 pub mod provenance_eval;
@@ -29,6 +30,7 @@ pub use assistant::{
     TrustAssistantAutomationAction, TrustAssistantAutomationStatus, TrustAssistantPrompt,
     TrustAssistantPromptKind, TrustCardAssistant, TrustCardAssistantPlan,
 };
+pub use claim_capture::{ClaimCaptureSink, derive_claim};
 pub use descriptor::{
     TOOL_DESCRIPTOR_TRUST_CARD_KEY, ToolDescriptorTrustCard, cbom_digest_sha256,
     project_tool_descriptor_trust_card, project_tool_descriptors_trust_cards,


### PR DESCRIPTION
## Summary

This adds an opt-in shadow claim-capture sink to the provenance pipeline, and proves the offline scorer works against real captured data instead of only the committed fixture.

## What it does

When `security.claim_capture.enabled` is turned on in config, the gateway writes one line of NDJSON to a local file for every tool call that gets a signed provenance receipt. Each line pairs the call's trace ID, a claim about that call, and the signed receipt. This lets an operator later run the existing `provenance-eval` binary against real traffic instead of only the hand-built fixture used in earlier RUNG3 work.

The feature is off by default. It only takes effect when `security.provenance_stamping` is also enabled, since capture has nothing to sign without that. With both settings off, response payloads and gateway behavior are unchanged.

## What claim gets captured, and what does not

The only claim this change captures is `Succeeded`, meaning "the call completed" as observed by `backend_ok` (the inverse of the response's `isError` flag). That flag is something the gateway genuinely observes at the point it stamps a receipt, so recording it is honest.

The scoring model already has two richer claims, `AuthoritativeEmpty` (the call found nothing) and `FoundRows` (the call found N rows). This change does not attempt to derive either one, and that is a deliberate choice, not an oversight. The gateway sits in front of more than 30 different backends with no shared result schema. Guessing a row count from a JSON shape, an array length, a `results` field, whatever a given backend happens to return, would mean recording something the gateway did not actually observe. That kind of guess had already caused a problem once in this codebase, a scoring pipeline that ended up validating itself instead of ground truth, so this change avoids repeating it.

The function that derives the captured claim, `derive_claim`, takes the result body and the success flag as arguments but does not read either one to decide anything beyond "did it succeed." That is intentional. It keeps the boundary visible in the code rather than only in a comment, and it flags that the next step needs an explicit decision from whoever owns this system rather than a heuristic bolted on quietly. That follow-up could go one of three ways. A per-backend extractor could learn to read each backend's own result shape. The calling agent could state the claim itself. Or a backend could declare its own row count in its response envelope.

## Proving the scorer works on real data

A new test, `captured_records_score_correctly_through_score_corpus`, writes real HMAC-signed receipts through the actual capture sink, reads them back, and runs them through the existing scorer used by the `provenance-eval` binary. No part of that test uses a fixture. It signs, captures, and scores a genuinely successful call and a genuinely failed call, and checks the scorer reports them correctly.

## Where this touches shared code

The wiring in `src/gateway/server/mod.rs` is a single new block appended after the existing provenance-stamping setup. No existing lines in that file were changed. That file is also being edited on a separate branch in this repository right now, so keeping this change purely additive there was intentional, to make a later merge or rebase straightforward.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --lib --bins --tests --no-deps -- -D warnings`
- `cargo test --lib` (3393 passed)
- `cargo test --test provenance_eval_binary` (5 passed, 1 ignored fixture generator, unchanged from before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
