### PR TITLE
security: harden export poison recovery, off-path _meta strip, header parse (MIK-6909)

### DIFF
--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -121,7 +121,7 @@ use super::MetaMcp;
 use super::prompt_cache::{CacheKeyDeriver, extract_cached_tokens, inject_cache_key};
 use super::support::{
     MetaMcpInvoker, augment_with_predictions, augment_with_provenance, augment_with_trace,
-    resolve_idempotency_key,
+    resolve_idempotency_key, strip_backend_provenance,
 };
 
 async fn call_capability_tool_with_identity(
@@ -454,7 +454,12 @@ impl MetaMcp {
         cache: crate::trust::CacheOutcome,
     ) -> Value {
         let Some(ref signer) = self.provenance_signer else {
-            return value;
+            // Stamping disabled: the gateway authors no receipt, so any
+            // `_meta.provenance` here was injected by the backend. Strip it so a
+            // naive reader cannot mistake a backend-forged receipt for a
+            // gateway-signed one (MIK-6909). Honest backends set no such key, so
+            // this stays a no-op and the off path remains byte-identical.
+            return strip_backend_provenance(value);
         };
         let backend_ok = !value
             .get("isError")

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -284,10 +284,97 @@ pub(super) fn augment_with_provenance(
     (result, signed_receipt)
 }
 
+/// Remove a backend-supplied `_meta.provenance` receipt from `result`.
+///
+/// The gateway authors provenance receipts only when stamping is enabled. With
+/// stamping OFF, any `_meta.provenance` present was injected by the backend, and
+/// a naive reader could mistake a backend-forged receipt for a gateway-signed
+/// one (MIK-6909). Stripping it on the off path closes that spoofing surface so
+/// the `_meta.provenance` channel means "gateway-authored" or nothing.
+///
+/// Honest backends never set this key, so the common case is a no-op and the
+/// "byte-identical with the feature off" guarantee still holds. Only the
+/// `provenance` key is removed — other `_meta` entries (e.g. cache keys) are
+/// preserved — and an `_meta` object left empty by the removal is dropped so no
+/// stray `{}` appears where the backend sent none.
+pub(super) fn strip_backend_provenance(mut result: Value) -> Value {
+    if let Value::Object(ref mut map) = result
+        && let Some(Value::Object(meta_map)) = map.get_mut("_meta")
+        && meta_map.remove("provenance").is_some()
+        && meta_map.is_empty()
+    {
+        map.remove("_meta");
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::internal_invoke_args;
+    use super::strip_backend_provenance;
     use serde_json::json;
+
+    /// A backend-forged `_meta.provenance` block MUST be removed on the
+    /// stamping-off path so a naive reader cannot trust a receipt the gateway
+    /// never signed (MIK-6909, AC.4). Sibling `_meta` keys survive.
+    #[test]
+    fn strip_backend_provenance_removes_forged_receipt_keeps_siblings() {
+        let forged = json!({
+            "content": [{"type": "text", "text": "ok"}],
+            "_meta": {
+                "provenance": {"backend": "evil", "sig": "forged"},
+                "prompt_cache_key": "keep-me"
+            }
+        });
+
+        let cleaned = strip_backend_provenance(forged);
+
+        assert!(
+            cleaned.pointer("/_meta/provenance").is_none(),
+            "forged provenance must be stripped, got: {cleaned}"
+        );
+        assert_eq!(
+            cleaned.pointer("/_meta/prompt_cache_key"),
+            Some(&json!("keep-me")),
+            "unrelated _meta siblings must be preserved"
+        );
+        assert_eq!(
+            cleaned.pointer("/content/0/text"),
+            Some(&json!("ok")),
+            "tool content must be untouched"
+        );
+    }
+
+    /// When `provenance` was the only `_meta` entry, the now-empty `_meta`
+    /// object is dropped so the result stays clean rather than carrying `{}`.
+    #[test]
+    fn strip_backend_provenance_drops_emptied_meta() {
+        let forged = json!({
+            "content": [],
+            "_meta": {"provenance": {"sig": "forged"}}
+        });
+
+        let cleaned = strip_backend_provenance(forged);
+
+        assert!(
+            cleaned.get("_meta").is_none(),
+            "emptied _meta must be removed entirely, got: {cleaned}"
+        );
+    }
+
+    /// An honest backend that sends no provenance is left byte-identical: the
+    /// strip is a pure no-op, preserving the feature-off guarantee.
+    #[test]
+    fn strip_backend_provenance_is_noop_for_honest_result() {
+        let honest = json!({
+            "content": [{"type": "text", "text": "hi"}],
+            "_meta": {"prompt_cache_key": "k"}
+        });
+
+        let cleaned = strip_backend_provenance(honest.clone());
+
+        assert_eq!(cleaned, honest, "no provenance key means no change");
+    }
 
     /// The projection opt-out (`_full`) for internal chain/playbook invocations
     /// MUST live INSIDE `arguments` — that is where `invoke_tool_traced` reads

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -2021,6 +2021,51 @@ mod attestation_wiring {
     }
 
     #[tokio::test]
+    async fn provenance_flag_off_strips_backend_injected_meta_provenance() {
+        use crate::backend::Backend;
+        use crate::config::{BackendConfig, FailsafeConfig};
+        use crate::transport::Transport;
+
+        // A malicious backend injects a forged `_meta.provenance` receipt plus an
+        // unrelated `_meta` entry. With stamping OFF the gateway authors no
+        // receipt, so a naive reader could trust the forgery as gateway-signed.
+        // The off path must strip the forged receipt while leaving other `_meta`
+        // fields intact (MIK-6909, AC.4).
+        let registry = Arc::new(BackendRegistry::new());
+        let backend = Arc::new(Backend::new(
+            "remote_docs",
+            BackendConfig::default(),
+            &FailsafeConfig::default(),
+            Duration::from_secs(300),
+        ));
+        let transport: Arc<dyn Transport> = Arc::new(ToolCallTestTransport {
+            result: json!({
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": false,
+                "_meta": {
+                    "provenance": {"backend_id": "trusted-looking", "forged": true},
+                    "cache_key": "keep-me"
+                }
+            }),
+        });
+        backend.set_transport_for_test(transport);
+        registry.register(backend);
+
+        let meta = MetaMcp::new(registry);
+        let result = invoke_docs_search(&meta).await;
+
+        assert!(
+            result.pointer("/_meta/provenance").is_none(),
+            "off path must strip a backend-injected _meta.provenance, got: {result}"
+        );
+        assert_eq!(
+            result.pointer("/_meta/cache_key").and_then(|v| v.as_str()),
+            Some("keep-me"),
+            "unrelated _meta keys must survive the strip, got: {result}"
+        );
+    }
+
+    #[tokio::test]
     async fn provenance_flag_on_stamps_signed_verifiable_receipt() {
         use crate::attestation::{
             AttestationValidator, BnautAttestationSigner, RESULT_PROVENANCE_DOMAIN_INFO,

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1852,8 +1852,11 @@ mod tests {
         let sink: Arc<dyn ExportSink> = collecting.clone();
         let status = SourceExportStatus::default();
 
-        // Before the fix this panicked on `.expect(...)` over the poisoned lock;
-        // now it must recover the guard and complete the poll.
+        // A pre-recovery `.expect(...)` over the poisoned lock would panic inside
+        // `spawn_blocking`; tokio catches that as a `JoinError`, which the `Err(e)`
+        // arm here turns into a logged failure with nothing delivered — so the
+        // regression signal is `delivered().len() == 0`, not a panicking test.
+        // With recovery in place the guard is reclaimed and the poll completes.
         poll_export_source(&exporter, &sink, &status, "invocation").await;
 
         assert_eq!(

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1798,6 +1798,71 @@ mod tests {
         }
     }
 
+    // ── SIEM export poison recovery (MIK-6909, AC.2) ─────────────────────────
+    // A panic elsewhere while the export mutex is held must not crash the export
+    // path: `poll_export_source` recovers the guard via `PoisonError::into_inner`
+    // and keeps forwarding. This proves the recovery both survives the poison
+    // AND still does useful work (forwards the pending log entry).
+    #[tokio::test]
+    async fn export_poll_recovers_from_a_poisoned_exporter_mutex() {
+        use std::sync::Mutex;
+
+        use super::poll_export_source;
+        use crate::control_plane::{
+            CollectingSink, ExportSink, ExportSource, LogExporter, SourceExportStatus,
+        };
+        use crate::security::TransparencyLogger;
+        use crate::security::transparency_log::TransparencyLogConfig;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("inv.jsonl");
+        let logger = TransparencyLogger::open(Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path: log_path.to_string_lossy().into_owned(),
+            key_id: "test".to_string(),
+            shared_secret: String::new(),
+        }))
+        .expect("open transparency log");
+        logger
+            .log_invocation("s1", "caller", "srv", "tool", "req:1", "resp:1")
+            .expect("append one entry");
+
+        let exporter = Arc::new(Mutex::new(
+            LogExporter::open(
+                ExportSource::Invocation,
+                log_path.clone(),
+                dir.path().join("cursor.json"),
+            )
+            .expect("open exporter"),
+        ));
+
+        // Poison the mutex: a separate thread panics while holding the guard.
+        let poison_target = Arc::clone(&exporter);
+        let _ = std::thread::spawn(move || {
+            let _guard = poison_target.lock().expect("acquire lock before poisoning");
+            panic!("intentional poison for the test");
+        })
+        .join();
+        assert!(
+            exporter.is_poisoned(),
+            "precondition: the export mutex must be poisoned"
+        );
+
+        let collecting = Arc::new(CollectingSink::new());
+        let sink: Arc<dyn ExportSink> = collecting.clone();
+        let status = SourceExportStatus::default();
+
+        // Before the fix this panicked on `.expect(...)` over the poisoned lock;
+        // now it must recover the guard and complete the poll.
+        poll_export_source(&exporter, &sink, &status, "invocation").await;
+
+        assert_eq!(
+            collecting.delivered().len(),
+            1,
+            "recovered poll must forward the pending log entry"
+        );
+    }
+
     #[test]
     fn passthrough_only_deployment_installs_no_minting_strategy() {
         use crate::identity_propagation::PropagationStrategyKind;

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -193,6 +193,19 @@ enum HeaderMode<'a> {
     Close,
 }
 
+/// Build the `Authorization: Bearer …` header value for `token`.
+///
+/// Returns a clean [`Error::OAuth`] instead of panicking when the token carries
+/// bytes illegal in an HTTP header value — control characters or bytes outside
+/// visible ASCII (MIK-6909). A backend credential is attacker-influenceable in
+/// federated/token-exchange deployments, so a malformed token must fail the
+/// request as an auth error, never abort the process. The token is never echoed
+/// into the error, keeping the credential out of logs (CWE-532).
+fn bearer_header_value(token: &str) -> Result<header::HeaderValue> {
+    header::HeaderValue::from_str(&format!("Bearer {token}"))
+        .map_err(|_| Error::OAuth("OAuth token is not a valid HTTP header value".into()))
+}
+
 impl HttpTransport {
     /// Create a new HTTP transport
     ///
@@ -500,10 +513,9 @@ impl HttpTransport {
         // isolation decision has already been made. `insert` replaces (never
         // appends) Authorization, so no caller-supplied header is duplicated.
         if let Some(token) = self.get_oauth_token().await? {
-            headers.insert(
-                header::AUTHORIZATION,
-                format!("Bearer {token}").parse().unwrap(),
-            );
+            // A token carrying bytes illegal in an HTTP header value must fail as
+            // a clean auth error, never panic the request path (MIK-6909).
+            headers.insert(header::AUTHORIZATION, bearer_header_value(&token)?);
             if matches!(mode, HeaderMode::Sse) {
                 debug!(url = %self.base_url, "SSE connection with OAuth token");
             }

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -1476,3 +1476,35 @@ async fn stateful_backend_partitions_sessions_across_identities() {
 
     server.abort();
 }
+
+// =========================================================================
+// bearer_header_value — invalid-byte token must not panic (MIK-6909, AC.5)
+// =========================================================================
+
+#[test]
+fn bearer_header_value_accepts_a_well_formed_token() {
+    // GIVEN a token containing only header-legal bytes
+    // WHEN we build the Authorization value
+    // THEN it succeeds and carries the Bearer prefix.
+    let value = bearer_header_value("abc123.DEF-456").expect("valid token must produce a header");
+    assert_eq!(value.to_str().unwrap(), "Bearer abc123.DEF-456");
+}
+
+#[test]
+fn bearer_header_value_rejects_invalid_bytes_without_panicking() {
+    // GIVEN a token with bytes illegal in an HTTP header value (newline, NUL, CR)
+    // WHEN we build the Authorization value
+    // THEN it returns a clean OAuth error rather than panicking, and the error
+    //      never echoes the token (credential hygiene, CWE-532).
+    for bad in ["tok\nen", "tok\0en", "tok\ren"] {
+        let err = bearer_header_value(bad).expect_err("invalid token must be rejected");
+        assert!(
+            matches!(err, Error::OAuth(_)),
+            "expected a clean OAuth error, got {err:?}"
+        );
+        assert!(
+            !format!("{err}").contains(bad),
+            "error must not leak the raw token"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Three tail hardening items closing the remaining MIK-6909 acceptance criteria. Each ships with a test.

### AC.2 — export mutex poison recovery
The SIEM export path already recovers a poisoned exporter lock through `PoisonError::into_inner`, so a panic elsewhere while the lock is held does not crash export. This adds the missing test. It poisons the mutex from a panicking thread, then asserts `poll_export_source` recovers the guard and still forwards the pending log entry.

- Code: `src/gateway/server/mod.rs:252` (pre-existing recovery)
- Test: `export_poll_recovers_from_a_poisoned_exporter_mutex`

### AC.4 — off-path provenance spoofing
With runtime provenance stamping disabled the gateway authors no receipt, so a backend-supplied `_meta.provenance` would flow straight through and a naive reader could trust it as gateway-signed. The off path now strips any backend-injected `_meta.provenance`. Honest backends never set that key, so the strip is a no-op and the off path stays byte-identical. Sibling `_meta` entries are preserved and an emptied `_meta` object is dropped.

- Code: `src/gateway/meta_mcp/invoke.rs:456`, helper `strip_backend_provenance` in `src/gateway/meta_mcp/support.rs`
- Tests: `provenance_flag_off_strips_backend_injected_meta_provenance` plus three helper unit tests

### AC.5 — Authorization header parse
The outgoing OAuth `Authorization` header was built with `parse().unwrap()`, which panics when the token carries bytes invalid for an HTTP header value. The value now routes through a `bearer_header_value` helper that maps the invalid-byte case to a clean `Error::OAuth` and never echoes the token into the error.

- Code: `src/transport/http/mod.rs:204` and call site near line 515
- Tests: `bearer_header_value_accepts_a_well_formed_token`, `bearer_header_value_rejects_invalid_bytes_without_panicking`

## Gates
- `cargo fmt` clean
- `cargo clippy --all-targets --no-deps -- -D warnings` clean
- `cargo test --lib` 3406 passed, 0 failed (baseline 3399 plus 7 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
