### PR TITLE
feat(trust): richer runtime claim derivation with ground-truth extractor (MIK-6914)

### DIFF
--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -184,6 +184,20 @@ fn enforce_output_schema(
     }
 }
 
+/// Strip and parse the MIK-6914 Option B claim-under-test (`_claim`) directive
+/// from an invocation's arguments, binding it to this call's `call_id`.
+///
+/// The directive is a gateway directive, not an upstream parameter, so it is
+/// removed from `arguments` (like `_full`) and never forwarded to a backend. A
+/// malformed or absent directive yields `None`, and capture then falls back to
+/// the honest `Claim::Succeeded` floor. The parsed claim is untrusted client
+/// input: it is only ever the claim-under-test, never the ground-truth leg.
+fn extract_client_claim(arguments: &mut Value, call_id: &str) -> Option<crate::trust::ClientClaim> {
+    let raw = arguments.as_object_mut()?.remove("_claim")?;
+    let claim = serde_json::from_value::<crate::trust::provenance_eval::Claim>(raw).ok()?;
+    Some(crate::trust::ClientClaim::untrusted(call_id, claim))
+}
+
 fn extract_output_validation_target(result: &Value) -> Option<Value> {
     if let Some(structured) = result.get("structuredContent") {
         return Some(structured.clone());
@@ -445,6 +459,13 @@ impl MetaMcp {
     /// receipt (no trace scope active) is skipped rather than captured
     /// un-joinable — consistent with `score_corpus`'s mis-join contract,
     /// which treats a missing join key as unscoreable, not as evidence.
+    ///
+    /// `client_claim` is the MIK-6914 Option B claim-under-test — an untrusted
+    /// typed claim the caller supplied for this call. When present it is
+    /// captured verbatim as the claim under scrutiny; when absent, capture
+    /// falls back to the honest `Claim::Succeeded` floor. It is never used as
+    /// the ground-truth leg (that is the receipt's extractor-observed
+    /// `row_count`).
     fn maybe_stamp_provenance(
         &self,
         value: Value,
@@ -452,6 +473,7 @@ impl MetaMcp {
         tool: &str,
         api_key_name: Option<&str>,
         cache: crate::trust::CacheOutcome,
+        client_claim: Option<&crate::trust::ClientClaim>,
     ) -> Value {
         let Some(ref signer) = self.provenance_signer else {
             return value;
@@ -465,7 +487,7 @@ impl MetaMcp {
         if let Some(sink) = &self.claim_capture
             && let Some(call_id) = signed_receipt.receipt.call_id.clone()
         {
-            let claim = crate::trust::derive_claim(&stamped, backend_ok);
+            let claim = crate::trust::derive_claim(client_claim);
             sink.capture(call_id, claim, signed_receipt);
         }
         stamped
@@ -491,6 +513,9 @@ impl MetaMcp {
             tool,
             api_key_name,
             crate::trust::CacheOutcome::Bypass,
+            // The direct passthrough carries no gateway-parsed `_claim`
+            // directive, so there is no client claim-under-test here.
+            None,
         )
     }
 
@@ -525,6 +550,15 @@ impl MetaMcp {
         if let Some(obj) = arguments.as_object_mut() {
             obj.remove("_full");
         }
+
+        // MIK-6914 Option B: the caller may attach an untrusted claim-under-test
+        // (`_claim`) about the result it will render. Like `_full` it is a
+        // gateway directive, stripped here — before the argument hash and cache
+        // key are computed — so it never reaches a backend and never fragments
+        // the cache. Bound to this call's `trace_id`, it is threaded to the
+        // provenance chokepoint and (with capture enabled) recorded as the claim
+        // under scrutiny. It is never the ground-truth leg.
+        let client_claim = extract_client_claim(&mut arguments, trace_id);
 
         // MIK-5877: in `experimental` mode the projected (treatment) and raw
         // (control) arms must NOT share response-cache / idempotency entries, or
@@ -716,6 +750,7 @@ impl MetaMcp {
                             tool,
                             api_key_name,
                             crate::trust::CacheOutcome::Hit,
+                            client_claim.as_ref(),
                         )
                     }));
                 }
@@ -756,6 +791,7 @@ impl MetaMcp {
                         tool,
                         api_key_name,
                         crate::trust::CacheOutcome::Hit,
+                        client_claim.as_ref(),
                     )
                 }));
             }
@@ -1229,6 +1265,7 @@ impl MetaMcp {
             tool,
             api_key_name,
             crate::trust::CacheOutcome::Miss,
+            client_claim.as_ref(),
         );
         if let Some(ref signer) = self.message_signer {
             final_result = signer.sign_response(final_result, request_nonce);

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -262,6 +262,15 @@ pub(super) fn augment_with_provenance(
     if let Some(name) = api_key_name {
         receipt = receipt.with_auth_context_ref(auth_context_ref_hash(name));
     }
+    // Option A ground truth (MIK-6914): when a per-backend extractor recognises
+    // this `(backend, tool)` and can read a genuine authoritative count from the
+    // result, record it as the observed `row_count`. Every unrecognised backend
+    // returns `None`, so the receipt keeps the honest "not observed" floor and
+    // no count is ever fabricated (the MIK-5854 stop-line).
+    if let Some(row_count) = crate::trust::extract_row_count(backend_id, tool, &result, backend_ok)
+    {
+        receipt = receipt.with_row_count(row_count);
+    }
     // Join key: the active call's trace_id (also returned to the client as
     // `result.trace_id`), so the receipt is self-joinable to the agent's claim.
     // Absent on paths with no trace scope (e.g. direct backend route).

--- a/src/trust/claim_capture.rs
+++ b/src/trust/claim_capture.rs
@@ -15,27 +15,31 @@
 //! feeding a captured file through the existing scorer (`provenance-eval
 //! <captured-file.jsonl>`, RUNG3.4) requires no format translation.
 //!
-//! ## Why only `Claim::Succeeded` is captured
+//! ## Ground truth vs claim-under-test (MIK-6914)
 //!
-//! The claim has to be *derived*, not asserted by the client — the MCP
-//! protocol carries no "here is what I'm claiming about this result" channel,
-//! so the gateway is the only party positioned to record it, and it can only
-//! record what it can honestly observe at the stamping chokepoint
-//! ([`crate::gateway::meta_mcp::support::augment_with_provenance`]).
+//! RUNG3.1 could only capture [`Claim::Succeeded`], because the generic
+//! stamping chokepoint has no per-tool result schema and guessing a row count
+//! from whatever shape a backend's JSON happens to have would fabricate ground
+//! truth — the MIK-5854 failure mode. MIK-6914 keeps that stop-line and splits
+//! the two legs instead of collapsing them:
 //!
-//! `backend_ok` (`!isError`) is observed directly there and needs no
-//! interpretation, so [`Claim::Succeeded`] is always sound to derive.
-//! [`Claim::AuthoritativeEmpty`] and [`Claim::FoundRows`] would require a
-//! `row_count` — but the chokepoint is generic across 30+ heterogeneous
-//! backends with no per-tool result schema. Guessing a row count from
-//! whatever shape a given backend's JSON happens to have (a top-level array
-//! length, a `"results"`/`"items"`/`"rows"` field, ...) is exactly the kind of
-//! inferred-not-observed judgment [`super::result_provenance`]'s module
-//! contract forbids: "facts, not judgments... an absent row count means 'not
-//! observed', never zero". A wrong guess here would poison the eval corpus
-//! with fabricated ground truth — the same failure mode the RUNG2 design
-//! note (MIK-5854) already burned once. See `derive_claim` for the single
-//! narrow point where this decision is made.
+//! - **Ground truth** is an *observed* authoritative count, produced only by a
+//!   per-backend Option A extractor ([`super::extract_row_count`]) for a
+//!   backend whose result shape genuinely carries one, and recorded in the
+//!   signed receipt's
+//!   [`row_count`](super::result_provenance::RuntimeProvenanceReceipt::row_count).
+//!   Absent such an extractor the count stays `None` — "not observed", never
+//!   zero.
+//! - **Claim-under-test** is what the client said it rendered — an untrusted
+//!   [`ClientClaim`] (Option B), captured verbatim by [`derive_claim`] and
+//!   never used as the ground-truth leg. Absent a client claim, [`derive_claim`]
+//!   still falls back to [`Claim::Succeeded`], the honest floor.
+//!
+//! Because the two legs are sourced independently, a client over-claim
+//! (`FoundRows` over an authoritatively empty source) scores `Unsupported`, and
+//! a claim the gateway could not check (`AuthoritativeEmpty` over a backend that
+//! exposes no count) scores `Abstain` — the distinction this whole line of work
+//! exists to make.
 //!
 //! ## Deployment
 //!
@@ -51,8 +55,6 @@ use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use std::sync::Mutex;
-
-use serde_json::Value;
 
 use super::SignedResultProvenance;
 use super::provenance_eval::{Claim, CorpusRecord};
@@ -111,21 +113,68 @@ impl ClaimCaptureSink {
     }
 }
 
-/// Derive the claim a shadow-capture record should carry for one observed
-/// tool call, from exactly the facts already available at the provenance
-/// stamping chokepoint.
+/// A claim about a tool result supplied by the client (the agent), joined to
+/// the gateway's ground-truth receipt by `call_id`.
 ///
-/// Deliberately ignores the tool result body (`_result` is unused): see the
-/// module doc for why a generic, backend-agnostic chokepoint cannot soundly
-/// infer a row/item count, and therefore always derives [`Claim::Succeeded`]
-/// — the one claim `backend_ok` alone supports without guessing at
-/// domain-specific result shape. `Claim::Succeeded` is deliberately captured
-/// even when `backend_ok` is `false`: scoring it `Unsupported` against a
-/// failed receipt is the exact silent-failure signal RUNG2 exists to catch,
-/// so suppressing capture on failure would hide the highest-value case.
+/// This is the *claim-under-test* — MIK-6914 Option B. It is **untrusted
+/// input**: the client asserts what it intends to render about a result ("no
+/// results", "found N rows"), and the offline eval scores that assertion
+/// against the gateway-observed receipt. It is *never* the ground-truth leg.
+/// The newtype exists precisely so a client-supplied claim cannot be mistaken
+/// for an observed gateway fact at a call site — the ground truth is the
+/// receipt's [`RuntimeProvenanceReceipt::row_count`](super::result_provenance::RuntimeProvenanceReceipt::row_count),
+/// populated only by the gateway's Option A extractor
+/// ([`super::extract_row_count`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientClaim {
+    call_id: String,
+    claim: Claim,
+}
+
+impl ClientClaim {
+    /// Wrap a client-supplied claim as the untrusted claim-under-test for
+    /// `call_id`. The name makes the trust boundary unmissable at the call site.
+    #[must_use]
+    pub fn untrusted(call_id: impl Into<String>, claim: Claim) -> Self {
+        Self {
+            call_id: call_id.into(),
+            claim,
+        }
+    }
+
+    /// The call this claim is about — the join key to the ground-truth receipt.
+    #[must_use]
+    pub fn call_id(&self) -> &str {
+        &self.call_id
+    }
+
+    /// The untrusted claim itself.
+    #[must_use]
+    pub fn claim(&self) -> &Claim {
+        &self.claim
+    }
+}
+
+/// Derive the *claim-under-test* to capture for one observed tool call.
+///
+/// MIK-6914 splits the ground truth from the claim under test, and this
+/// function supplies only the latter. The ground truth — an authoritative row
+/// count — is observed independently by the gateway's Option A extractor and
+/// lives in the signed receipt ([`super::extract_row_count`] →
+/// [`RuntimeProvenanceReceipt::row_count`](super::result_provenance::RuntimeProvenanceReceipt::row_count)).
+///
+/// When the client supplied a typed [`ClientClaim`] for this call (Option B),
+/// that untrusted claim is captured verbatim as the claim-under-test. Absent a
+/// client claim, the derivation falls back to [`Claim::Succeeded`] — the honest
+/// floor that `backend_ok` alone supports without inspecting result shape, and
+/// the same value the RUNG3.1 sink captured before richer claims existed.
+///
+/// The claim is never derived from the ground-truth count, so the two legs stay
+/// independent — the property MIK-6914.AC.2 requires and the reason a client
+/// over-claim can be scored `Unsupported` at all.
 #[must_use]
-pub fn derive_claim(_result: &Value, _backend_ok: bool) -> Claim {
-    Claim::Succeeded
+pub fn derive_claim(client_claim: Option<&ClientClaim>) -> Claim {
+    client_claim.map_or(Claim::Succeeded, |c| c.claim().clone())
 }
 
 #[cfg(test)]
@@ -175,24 +224,20 @@ mod tests {
             .collect()
     }
 
-    /// `derive_claim` always returns `Succeeded` regardless of the result
-    /// body shape — proving structurally (not just by doc comment) that this
-    /// chokepoint never parses tool-result content to guess a row count.
+    /// With no client claim, `derive_claim` falls back to the honest floor
+    /// [`Claim::Succeeded`] — it never inspects a result body to guess a count.
     #[test]
-    fn derive_claim_ignores_result_body_shape() {
-        let array_like = json!({"content": [{"type": "text", "text": "[1,2,3]"}]});
-        let object_like = json!({"content": [{"type": "text", "text": "{}"}]});
-        assert_eq!(derive_claim(&array_like, true), Claim::Succeeded);
-        assert_eq!(derive_claim(&object_like, true), Claim::Succeeded);
+    fn derive_claim_without_client_claim_is_succeeded_floor() {
+        assert_eq!(derive_claim(None), Claim::Succeeded);
     }
 
-    /// `derive_claim` still returns `Succeeded` on a failed backend call — the
-    /// claim under scrutiny is "the call succeeded", and capturing it here is
-    /// exactly what lets `score_corpus` later flag it `Unsupported`.
+    /// A client-supplied claim (Option B) is captured verbatim as the
+    /// claim-under-test — this is the untrusted leg, not the ground truth.
     #[test]
-    fn derive_claim_on_failed_backend_is_still_succeeded_for_scoring() {
-        let claim = derive_claim(&json!({"isError": true}), false);
-        assert_eq!(claim, Claim::Succeeded);
+    fn derive_claim_uses_client_claim_when_present() {
+        let cc = ClientClaim::untrusted("gw-call-1", Claim::FoundRows { count: 5 });
+        assert_eq!(derive_claim(Some(&cc)), Claim::FoundRows { count: 5 });
+        assert_eq!(cc.call_id(), "gw-call-1");
     }
 
     /// A captured record is valid NDJSON and round-trips into the exact
@@ -242,14 +287,14 @@ mod tests {
         // A genuinely successful call.
         sink.capture(
             "gw-call-ok".to_string(),
-            derive_claim(&json!({"isError": false}), true),
+            derive_claim(None),
             signed_receipt("gw-call-ok", true),
         );
         // A genuinely failed call — the claim is still `Succeeded` (that's
         // what "the call succeeded" asserts), and the receipt says otherwise.
         sink.capture(
             "gw-call-fail".to_string(),
-            derive_claim(&json!({"isError": true}), false),
+            derive_claim(None),
             signed_receipt("gw-call-fail", false),
         );
 
@@ -270,5 +315,155 @@ mod tests {
             "the failed call whose claim was still 'succeeded'"
         );
         assert_eq!(report.rejected, 0, "both receipts were validly signed");
+    }
+
+    // === MIK-6914 AC.2: ground-truth (Option A) vs claim-under-test (Option B) ===
+
+    const GH_TOOL: &str = "github_search_repos";
+
+    /// A GitHub search result envelope carrying the backend's server-computed
+    /// `total_count` and `incomplete_results` flag.
+    fn github_result(total_count: u64, incomplete: bool) -> serde_json::Value {
+        json!({
+            "isError": false,
+            "structuredContent": {
+                "total_count": total_count,
+                "incomplete_results": incomplete,
+                "items": []
+            }
+        })
+    }
+
+    /// Build the *ground-truth* receipt exactly as the gateway does: run the
+    /// Option A extractor ([`crate::trust::extract_row_count`]) over the real
+    /// backend result and stamp the observed count onto the receipt. The
+    /// claim-under-test never participates — proving the two legs are sourced
+    /// independently.
+    fn ground_truth_receipt(
+        call_id: &str,
+        backend_ok: bool,
+        result: &serde_json::Value,
+    ) -> SignedResultProvenance {
+        let mut receipt = RuntimeProvenanceReceipt::observed(
+            "caps",
+            GH_TOOL,
+            "2026-07-13T10:15:30Z",
+            CacheOutcome::Miss,
+            backend_ok,
+        )
+        .with_call_id(call_id);
+        if let Some(n) = crate::trust::extract_row_count("caps", GH_TOOL, result, backend_ok) {
+            receipt = receipt.with_row_count(n);
+        }
+        receipt.sign(&receipt_signer())
+    }
+
+    /// Capture one `(claim, receipt)` pair through the real sink and score it
+    /// through the real `score_corpus` — the full RUNG3 path, no fixtures.
+    fn capture_and_score(
+        call_id: &str,
+        claim: Claim,
+        receipt: SignedResultProvenance,
+    ) -> (crate::trust::provenance_eval::EvalReport, usize) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sink = ClaimCaptureSink::open(tmp.path()).unwrap();
+        sink.capture(call_id.to_string(), claim, receipt);
+        let records: Vec<CorpusRecord> = read_lines(tmp.path())
+            .iter()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        let validator = crate::attestation::validator::AttestationValidator::new(signer());
+        score_corpus(&records, &validator)
+    }
+
+    /// MIK-6914.AC.2 (the rejected case) — a genuine unsupported claim: the
+    /// client claims it found rows, but the gateway-observed ground truth is an
+    /// authoritative empty (`total_count == 0`). The claim is scored
+    /// `Unsupported` — the claim-rejection outcome the metric exists to count.
+    #[test]
+    fn client_overclaim_over_authoritative_empty_scores_unsupported() {
+        let result = github_result(0, false);
+        let receipt = ground_truth_receipt("gw-oc", true, &result);
+        // Ground truth read from the RESULT, not the claim: authoritative zero.
+        assert_eq!(receipt.receipt.row_count, Some(0));
+
+        let claim = derive_claim(Some(&ClientClaim::untrusted(
+            "gw-oc",
+            Claim::FoundRows { count: 5 },
+        )));
+
+        let (report, mis_joined) = capture_and_score("gw-oc", claim, receipt);
+        assert_eq!(mis_joined, 0);
+        assert_eq!(
+            report.unsupported, 1,
+            "found-rows over-claim rejected against authoritative-empty ground truth"
+        );
+        assert_eq!(report.supported + report.abstained + report.rejected, 0);
+    }
+
+    /// MIK-6914.AC.2 (the abstain case) — a genuine could-not-check: the client
+    /// claims the source was authoritatively empty, but GitHub reported its
+    /// search did not complete (`incomplete_results == true`), so the gateway
+    /// observed no authoritative count. The claim is scored `Abstain`, kept
+    /// distinct from an authoritative negative.
+    #[test]
+    fn client_empty_claim_over_uncheckable_search_scores_abstain() {
+        let result = github_result(3, true);
+        let receipt = ground_truth_receipt("gw-ab", true, &result);
+        // Incomplete search → could-not-check → no observed count.
+        assert_eq!(receipt.receipt.row_count, None);
+
+        let claim = derive_claim(Some(&ClientClaim::untrusted(
+            "gw-ab",
+            Claim::AuthoritativeEmpty,
+        )));
+
+        let (report, mis_joined) = capture_and_score("gw-ab", claim, receipt);
+        assert_eq!(mis_joined, 0);
+        assert_eq!(report.abstained, 1, "no authoritative count → abstain");
+        assert_eq!(report.supported + report.unsupported + report.rejected, 0);
+    }
+
+    /// MIK-6914.AC.2 (independence) — the gateway-observed ground-truth count is
+    /// derived from the result and is invariant to whatever the client claims.
+    /// The same authoritatively-empty result yields `row_count == Some(0)` under
+    /// three contradictory client claims.
+    #[test]
+    fn ground_truth_is_independent_of_the_client_claim() {
+        let result = github_result(0, false);
+        for claim in [
+            Claim::Succeeded,
+            Claim::AuthoritativeEmpty,
+            Claim::FoundRows { count: 99 },
+        ] {
+            let receipt = ground_truth_receipt("gw-ind", true, &result);
+            // The claim-under-test is derived separately and cannot move the
+            // observed ground truth.
+            let _under_test = derive_claim(Some(&ClientClaim::untrusted("gw-ind", claim)));
+            assert_eq!(
+                receipt.receipt.row_count,
+                Some(0),
+                "ground truth must not depend on the client claim"
+            );
+        }
+    }
+
+    /// An honest client count matching the observed ground truth scores
+    /// `Supported` — the positive control for the two negative-path tests above.
+    #[test]
+    fn honest_client_count_over_matching_ground_truth_scores_supported() {
+        let result = github_result(2, false);
+        let receipt = ground_truth_receipt("gw-ok", true, &result);
+        assert_eq!(receipt.receipt.row_count, Some(2));
+
+        let claim = derive_claim(Some(&ClientClaim::untrusted(
+            "gw-ok",
+            Claim::FoundRows { count: 2 },
+        )));
+
+        let (report, mis_joined) = capture_and_score("gw-ok", claim, receipt);
+        assert_eq!(mis_joined, 0);
+        assert_eq!(report.supported, 1);
+        assert_eq!(report.unsupported + report.abstained + report.rejected, 0);
     }
 }

--- a/src/trust/mod.rs
+++ b/src/trust/mod.rs
@@ -24,18 +24,20 @@ pub mod claim_capture;
 mod descriptor;
 mod inference;
 pub mod provenance_eval;
+pub mod result_extractor;
 mod result_provenance;
 
 pub use assistant::{
     TrustAssistantAutomationAction, TrustAssistantAutomationStatus, TrustAssistantPrompt,
     TrustAssistantPromptKind, TrustCardAssistant, TrustCardAssistantPlan,
 };
-pub use claim_capture::{ClaimCaptureSink, derive_claim};
+pub use claim_capture::{ClaimCaptureSink, ClientClaim, derive_claim};
 pub use descriptor::{
     TOOL_DESCRIPTOR_TRUST_CARD_KEY, ToolDescriptorTrustCard, cbom_digest_sha256,
     project_tool_descriptor_trust_card, project_tool_descriptors_trust_cards,
     tools_list_result_with_trust_cards, trust_card_digest_sha256,
 };
+pub use result_extractor::extract_row_count;
 pub use result_provenance::{CacheOutcome, RuntimeProvenanceReceipt, SignedResultProvenance};
 
 use inference::{

--- a/src/trust/result_extractor.rs
+++ b/src/trust/result_extractor.rs
@@ -33,10 +33,12 @@
 //! - **`github_search_repos`** — GitHub's `/search/repositories` response
 //!   carries a server-computed `total_count` (the exact number of matching
 //!   repositories) alongside `incomplete_results`. `total_count == 0` is an
-//!   authoritative empty; `incomplete_results == true` means GitHub's search
-//!   did not finish, so the count is *not* authoritative and the extractor
-//!   yields [`None`] (could-not-check). This is the one strong candidate the
-//!   MIK-6914 catalog survey identified.
+//!   authoritative empty; `total_count` is trusted *only* when
+//!   `incomplete_results` is explicitly `false` — a positive completion
+//!   signal, not merely the absence of `true`. A missing, `null`, or
+//!   otherwise malformed `incomplete_results` field abstains rather than
+//!   assume completeness. This is the one strong candidate the MIK-6914
+//!   catalog survey identified.
 
 use serde_json::Value;
 
@@ -98,21 +100,28 @@ fn unwrap_payload(result: &Value) -> Option<Value> {
 
 /// Read GitHub's authoritative `total_count` from a search payload.
 ///
-/// `incomplete_results == true` means GitHub's search timed out before
-/// completing, so neither `total_count` nor `items` is authoritative — the
-/// extractor yields [`None`] (could-not-check), never a partial count dressed
-/// up as ground truth. Otherwise a numeric `total_count` (including `0`, an
-/// authoritative empty) is returned verbatim.
+/// `total_count` is trusted **only** when `incomplete_results` is present and
+/// explicitly `false` — a positive statement from GitHub that the search
+/// completed. Any other shape of that field (`true`, missing, `null`, or a
+/// non-boolean value) means completeness was never confirmed, so the count is
+/// *not* authoritative and the extractor yields [`None`] (could-not-check).
+/// Checking for the affirmative `Some(false)` rather than merely rejecting
+/// `Some(true)` matters: a malformed, truncated, or schema-drifted payload
+/// that simply lacks the field must abstain, not silently fall through to
+/// treating an unconfirmed count as ground truth. Otherwise a numeric
+/// `total_count` (including `0`, an authoritative empty) is returned verbatim.
 ///
 /// If a future projection ever wraps the payload, the untouched backend body is
 /// preserved under `_raw` (the [`crate::projection`] contract); the count is
 /// read from there when the top level does not carry it.
 fn github_search_row_count(payload: &Value) -> Option<u64> {
     let body = github_body(payload);
-    if body.get("incomplete_results").and_then(Value::as_bool) == Some(true) {
-        return None;
+    match body.get("incomplete_results").and_then(Value::as_bool) {
+        Some(false) => body.get("total_count").and_then(Value::as_u64),
+        // `Some(true)` (search timed out), missing, `null`, or non-boolean:
+        // completeness was never confirmed, so the count cannot be trusted.
+        _ => None,
     }
-    body.get("total_count").and_then(Value::as_u64)
 }
 
 /// Choose the object that actually carries `total_count`: the payload itself
@@ -217,6 +226,29 @@ mod tests {
     #[test]
     fn github_payload_without_total_count_abstains() {
         let result = structured(json!({ "items": [{}, {}], "message": "rate limited" }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), None);
+    }
+
+    /// GPT-5-Codex adversarial review (MIK-6914 PR #375, Q2): a payload that
+    /// carries `total_count` but omits `incomplete_results` entirely must
+    /// abstain, not silently treat an unconfirmed-completeness response as
+    /// authoritative. Checking for the affirmative `Some(false)` (not merely
+    /// rejecting `Some(true)`) is what closes this gap — a schema-drifted or
+    /// malformed payload that simply lacks the field is exactly the case the
+    /// MIK-5854 stop-line exists to catch.
+    #[test]
+    fn github_missing_incomplete_results_flag_abstains() {
+        let result = structured(json!({ "total_count": 42, "items": [{}, {}] }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), None);
+    }
+
+    /// Same gap, `null` instead of a missing field — `as_bool()` returns
+    /// `None` for a non-boolean JSON value, so this must abstain too.
+    #[test]
+    fn github_null_incomplete_results_flag_abstains() {
+        let result = structured(json!({
+            "total_count": 42, "incomplete_results": null, "items": [{}, {}]
+        }));
         assert_eq!(extract_row_count("caps", GH, &result, true), None);
     }
 

--- a/src/trust/result_extractor.rs
+++ b/src/trust/result_extractor.rs
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Option A: gateway-side per-backend ground-truth extractors (MIK-6914).
+//!
+//! [`super::claim_capture`] records a *claim-under-test* (what the agent said
+//! it rendered — untrusted client input, see [`super::claim_capture::ClientClaim`])
+//! and scores it against the gateway's signed
+//! [`super::result_provenance::RuntimeProvenanceReceipt`]. For that score to be
+//! anything other than "the call succeeded", the receipt needs an *observed*
+//! ground-truth fact the scorer can adjudicate against — concretely a
+//! [`RuntimeProvenanceReceipt::row_count`](super::result_provenance::RuntimeProvenanceReceipt::row_count).
+//!
+//! This module is the only place that fact is derived. It is deliberately a
+//! *closed* dispatch keyed on `(backend, tool)`: a backend gets an extractor
+//! **only** when its result shape carries a genuine authoritative count that
+//! reliably distinguishes "the source was queried and was empty" from "the
+//! count could not be checked". Every other backend returns [`None`], which the
+//! receipt records as `row_count = None` — "not observed", never zero (the
+//! [`super::result_provenance`] module contract).
+//!
+//! ## The stop-line (MIK-5854)
+//!
+//! The one invariant that makes this honest rather than a fabricated metric:
+//! **an extractor may only ever return [`None`] when it cannot cleanly read an
+//! authoritative count.** It never guesses a count from an arbitrary array
+//! length or a `"results"`/`"items"` field it happens to find. The worst case
+//! for an unrecognised or malformed payload is [`None`] → the scorer
+//! *abstains*; it can never be a wrong count → a fabricated authoritative
+//! negative. Guessing here is the MIK-5854 failure mode and is forbidden.
+//!
+//! ## Supported backends
+//!
+//! - **`github_search_repos`** — GitHub's `/search/repositories` response
+//!   carries a server-computed `total_count` (the exact number of matching
+//!   repositories) alongside `incomplete_results`. `total_count == 0` is an
+//!   authoritative empty; `incomplete_results == true` means GitHub's search
+//!   did not finish, so the count is *not* authoritative and the extractor
+//!   yields [`None`] (could-not-check). This is the one strong candidate the
+//!   MIK-6914 catalog survey identified.
+
+use serde_json::Value;
+
+/// Derive the authoritative observed row/item count for one tool result, if —
+/// and only if — a per-backend Option A extractor recognises the `(backend,
+/// tool)` pair and can read a genuine count from the payload.
+///
+/// Returns [`None`] ("not observed") for every unrecognised backend, for a
+/// failed call (`backend_ok == false` — nothing the source "said" is
+/// authoritative when the call errored), and whenever the recognised payload
+/// cannot be cleanly read. It never fabricates a count; see the module-level
+/// stop-line.
+#[must_use]
+pub fn extract_row_count(
+    backend: &str,
+    tool: &str,
+    result: &Value,
+    backend_ok: bool,
+) -> Option<u64> {
+    // `backend` is threaded for future per-backend disambiguation (two backends
+    // could expose a same-named tool with different shapes); today the tool name
+    // alone selects the extractor.
+    let _ = backend;
+    // A failed call carries no authoritative statement about the source's
+    // contents; the scorer already treats every positive claim over a failed
+    // call as unsupported, so there is nothing honest to observe here.
+    if !backend_ok {
+        return None;
+    }
+    let payload = unwrap_payload(result)?;
+    // Closed per-backend dispatch table: a backend is extracted only when its
+    // result shape carries a genuine authoritative count. Kept as a `match` (not
+    // an `if`) because it grows one arm per qualifying backend; the single-arm
+    // form is intentional and forward-looking, not an equality check.
+    #[allow(clippy::single_match_else)]
+    match tool {
+        "github_search_repos" => github_search_row_count(&payload),
+        _ => None,
+    }
+}
+
+/// Unwrap the inner capability payload from the MCP result envelope, mirroring
+/// the gateway's own `extract_output_validation_target`: prefer
+/// `structuredContent`, else a single `content[0].text` that parses as JSON.
+///
+/// Anything else (multi-part content, non-JSON text, a bare envelope) yields
+/// [`None`] — the extractor then abstains rather than guess.
+fn unwrap_payload(result: &Value) -> Option<Value> {
+    if let Some(structured) = result.get("structuredContent") {
+        return Some(structured.clone());
+    }
+    let content = result.get("content")?.as_array()?;
+    if content.len() != 1 {
+        return None;
+    }
+    let text = content[0].get("text")?.as_str()?;
+    serde_json::from_str::<Value>(text).ok()
+}
+
+/// Read GitHub's authoritative `total_count` from a search payload.
+///
+/// `incomplete_results == true` means GitHub's search timed out before
+/// completing, so neither `total_count` nor `items` is authoritative — the
+/// extractor yields [`None`] (could-not-check), never a partial count dressed
+/// up as ground truth. Otherwise a numeric `total_count` (including `0`, an
+/// authoritative empty) is returned verbatim.
+///
+/// If a future projection ever wraps the payload, the untouched backend body is
+/// preserved under `_raw` (the [`crate::projection`] contract); the count is
+/// read from there when the top level does not carry it.
+fn github_search_row_count(payload: &Value) -> Option<u64> {
+    let body = github_body(payload);
+    if body.get("incomplete_results").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    body.get("total_count").and_then(Value::as_u64)
+}
+
+/// Choose the object that actually carries `total_count`: the payload itself
+/// when it has the field, otherwise a projection-preserved `_raw` body when
+/// *that* has it, otherwise the payload unchanged (the caller then abstains).
+fn github_body(payload: &Value) -> &Value {
+    if payload.get("total_count").is_some() {
+        return payload;
+    }
+    match payload.get("_raw") {
+        Some(raw) if raw.get("total_count").is_some() => raw,
+        _ => payload,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const GH: &str = "github_search_repos";
+
+    fn structured(payload: Value) -> Value {
+        let mut map = serde_json::Map::new();
+        map.insert("isError".into(), Value::Bool(false));
+        map.insert("structuredContent".into(), payload);
+        Value::Object(map)
+    }
+
+    fn text_result(payload: &Value) -> Value {
+        json!({
+            "isError": false,
+            "content": [{ "type": "text", "text": serde_json::to_string(payload).unwrap() }]
+        })
+    }
+
+    /// A populated GitHub search yields its exact server-computed `total_count`
+    /// — the authoritative non-empty ground truth (`FoundRows`), read from
+    /// `structuredContent`.
+    #[test]
+    fn github_populated_search_returns_total_count() {
+        let result = structured(json!({
+            "total_count": 42, "incomplete_results": false, "items": [{}, {}]
+        }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), Some(42));
+    }
+
+    /// `total_count == 0` is an *authoritative empty*: the search ran and
+    /// matched nothing. This is the signal that lets a "no results" claim be
+    /// scored `Supported` instead of forcing an abstain.
+    #[test]
+    fn github_empty_search_returns_zero_not_none() {
+        let result = structured(json!({
+            "total_count": 0, "incomplete_results": false, "items": []
+        }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), Some(0));
+    }
+
+    /// `incomplete_results == true` means GitHub's search did not finish, so the
+    /// count is not authoritative — the extractor abstains (`None`) rather than
+    /// report a partial count as ground truth.
+    #[test]
+    fn github_incomplete_results_is_could_not_check() {
+        let result = structured(json!({
+            "total_count": 3, "incomplete_results": true, "items": [{}]
+        }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), None);
+    }
+
+    /// The count is read identically when the payload arrives as a single
+    /// JSON `content[0].text` block rather than `structuredContent`.
+    #[test]
+    fn github_count_read_from_content_text_json() {
+        let payload = json!({ "total_count": 7, "incomplete_results": false, "items": [] });
+        assert_eq!(
+            extract_row_count("caps", GH, &text_result(&payload), true),
+            Some(7)
+        );
+    }
+
+    /// A failed call is never an authoritative statement about the source, so no
+    /// count is observed regardless of what the (stale/error) body contains.
+    #[test]
+    fn failed_call_observes_no_count() {
+        let result = structured(json!({ "total_count": 9, "incomplete_results": false }));
+        assert_eq!(extract_row_count("caps", GH, &result, false), None);
+    }
+
+    /// An unrecognised tool has no Option A extractor: the honest floor is
+    /// `None` ("not observed"), never a guessed count from some array length.
+    #[test]
+    fn unknown_tool_never_guesses_a_count() {
+        let result = structured(json!({ "results": [1, 2, 3], "count": 3 }));
+        assert_eq!(
+            extract_row_count("caps", "some_other_search", &result, true),
+            None
+        );
+    }
+
+    /// A recognised backend whose payload is missing `total_count` abstains
+    /// rather than invent one — the stop-line made structural.
+    #[test]
+    fn github_payload_without_total_count_abstains() {
+        let result = structured(json!({ "items": [{}, {}], "message": "rate limited" }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), None);
+    }
+
+    /// Non-JSON `content` text cannot be a source payload: abstain.
+    #[test]
+    fn non_json_content_text_abstains() {
+        let result = json!({
+            "isError": false,
+            "content": [{ "type": "text", "text": "not json at all" }]
+        });
+        assert_eq!(extract_row_count("caps", GH, &result, true), None);
+    }
+
+    /// When a projection preserves the untouched body under `_raw`, the count is
+    /// read from there — future-proofing without ever reading a projected view.
+    #[test]
+    fn github_count_read_from_projected_raw_fallback() {
+        let result = structured(json!({
+            "actor": "torvalds",
+            "_raw": { "total_count": 5, "incomplete_results": false, "items": [] }
+        }));
+        assert_eq!(extract_row_count("caps", GH, &result, true), Some(5));
+    }
+}


### PR DESCRIPTION
## What

First honest increment of MIK-6914 "Richer runtime claim derivation". Separates two things the previous floor conflated: the gateway's own ground truth about a call, and the agent's claim about what it rendered from that call.

### Option A — ground truth (`src/trust/result_extractor.rs`, new)

A closed, per-backend dispatch keyed on `(backend, tool)` that derives an authoritative observed `row_count` onto the signed provenance receipt. A backend qualifies only when its result shape carries a genuine count that distinguishes "queried and empty" from "could not check".

The catalog survey (30 backends) qualified exactly one: `github_search_repos`. GitHub's `/search/repositories` returns a server-computed `total_count` (exact match count) alongside `incomplete_results`.

- `total_count == 0` is an authoritative empty (queried, matched nothing).
- `total_count` is trusted **only** when `incomplete_results` is explicitly `false` — a positive completion signal. `incomplete_results == true`, missing, `null`, or any non-boolean value all abstain (`None`); a payload just lacking the field is not proof the search completed.
- Any unrecognised backend or malformed payload yields `None` — the scorer abstains. The extractor never guesses a count from an array length or a `results`/`items` field it happens to find.

The worst case is always abstention, never a fabricated authoritative negative. This is what keeps the MIK-5854 stop-line intact: when no reliable authoritative-empty signal exists, the code observes nothing rather than inventing one.

### Option B — claim-under-test (`src/trust/claim_capture.rs`)

`ClientClaim` carries an untrusted client claim keyed on `call_id`. `derive_claim` now returns that claim or a `Succeeded` floor and no longer inspects the result body, so the gateway's ground truth is derived independently of what the agent claimed (AC.2). The `_claim` directive is stripped from arguments before the arg-hash and cache key and never reaches the backend (same handling as `_full`).

### Scoring

Reuses the existing `provenance_eval::score`. An over-claim over an authoritative empty scores `Unsupported`; an empty claim over an uncheckable search abstains; an honest count over matching ground truth scores `Supported`.

## Tests

15 new (11 extractor covering populated / authoritative-empty / incomplete-results / missing-completeness-flag / null-completeness-flag / failed-call / unknown-tool / missing-field / non-JSON / projected-`_raw`; 4 AC.2 claim-vs-ground-truth) plus updated `derive_claim` tests.

- `cargo test --lib`: 3414 passed, 0 failed, 2 ignored.
- `cargo clippy --all-targets --no-deps -- -D warnings`: clean.
- `cargo fmt`: clean.

## Review

Independent adversarial review by GPT-5-Codex (`codex exec`, non-Claude), five targeted questions on the trust boundary (ground-truth fabrication, payload safety, claim/ground-truth isolation, cache-key integrity, failed-call handling).

**Initial verdict: FIX.** One real finding (Q2, blocker): `github_search_row_count` rejected only `incomplete_results == Some(true)`, so a malformed or schema-drifted payload that omitted the field (or carried `null`) fell through to reading `total_count` as if completion had been confirmed — a missing field is not a completion signal, and treating it as one is exactly the guessing-under-uncertainty the MIK-5854 stop-line forbids. The other four questions (no fabrication in the happy path, safe payload unwrapping, claim/ground-truth isolation, `_claim` stripped before cache-key computation, failed calls never yield a count) passed with file:line evidence.

**Fix applied**: `total_count` is now trusted only on the affirmative `Some(false)`, not merely the absence of `Some(true)`. Two regression tests reproduce the exact gap (`github_missing_incomplete_results_flag_abstains`, `github_null_incomplete_results_flag_abstains`). Re-verified: 3414 tests pass, clippy clean.

## Scope / status

- AC.2 (ground truth independent of claim) satisfied and covered by named tests.
- AC.3 is **not** marked done — it needs a real held-out slice, not synthetic fixtures.
- Left intentionally open for adversarial review. Embeds a design decision (which backends qualify as authoritative), so it should not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

