### PR TITLE
fix(oauth): send RFC 8707 resource indicator on all OAuth requests (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.2] - 2026-07-15
+
+### Fixed
+
+- **OAuth: send the RFC 8707 resource indicator on every OAuth request (#369).**
+  The MCP authorization spec (rev 2025-06-18) requires clients to include the
+  `resource` parameter on the authorization request and on every token request
+  so the authorization server can audience-bind the issued token to the target
+  MCP server. The gateway discovered the protected-resource metadata but never
+  sent `resource` back, so spec-strict providers (e.g. kapa.ai) rejected the
+  login flow with `server_error`. The discovered resource identifier (falling
+  back to the configured MCP endpoint URL when a server publishes no
+  protected-resource metadata) is now threaded into all four OAuth requests:
+  the authorization URL, the `authorization_code` exchange, `refresh_token`,
+  and `client_credentials`. Reported by @crepererum.
+
 ## [3.2.1] - 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the authorization URL, the `authorization_code` exchange, `refresh_token`,
   and `client_credentials`. Reported by @crepererum.
 
+### Changed
+
+- **Helm charts track the gateway release.** `deploy/helm/mcp-gateway` and
+  `deploy/helm/mcp-gateway-crds` `appVersion` and the default image `tag` now
+  point at `3.3.2` (were stale at `2.19.0`); both chart `version`s bumped to
+  `0.1.1`.
+
 ## [3.2.1] - 2026-07-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.3.1"
+version = "3.3.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   to author these resources as typed config. Helm does not manage CRD
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
-version: 0.1.0
-appVersion: "2.19.0"
+version: 0.1.1
+appVersion: "3.3.2"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:
   - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -3,8 +3,8 @@ name: mcp-gateway
 description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
-version: 0.1.0
-appVersion: "2.19.0"
+version: 0.1.1
+appVersion: "3.3.2"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:
   - https://github.com/MikkoParkkola/mcp-gateway

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mikkoparkkola/mcp-gateway
   # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
   # When `digest` is set it takes precedence over `tag`.
-  tag: "2.19.0"
+  tag: "3.3.2"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -4,7 +4,6 @@
 //!
 //! Main OAuth client implementation with PKCE support.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -399,13 +398,7 @@ impl OAuthClient {
             .clone()
             .ok_or_else(|| Error::OAuth("No client ID for client_credentials".to_string()))?;
 
-        let scope_str = self.scopes.join(" ");
-        let mut params = HashMap::new();
-        params.insert("grant_type", "client_credentials");
-        params.insert("client_id", client_id.as_str());
-        if !scope_str.is_empty() {
-            params.insert("scope", scope_str.as_str());
-        }
+        let params = self.client_credentials_params(&client_id);
 
         let response = self
             .http_client
@@ -530,6 +523,127 @@ impl OAuthClient {
         })
     }
 
+    /// RFC 8707 resource indicator for this backend.
+    ///
+    /// MCP's authorization spec (rev 2025-06-18) mandates Resource Indicators
+    /// (RFC 8707): the `resource` parameter MUST be sent on both the
+    /// authorization request and every token request so the authorization
+    /// server can audience-bind the issued token to this specific MCP server.
+    /// Omitting it makes strict providers reject the flow with `server_error`
+    /// (see issue #369).
+    ///
+    /// Prefers the canonical identifier advertised by discovered
+    /// protected-resource metadata (RFC 9728 `resource` field); falls back to
+    /// the configured MCP endpoint URL when metadata discovery did not run or
+    /// omitted it.
+    fn resource_indicator(&self) -> &str {
+        self.resource_metadata
+            .as_ref()
+            .map_or(self.resource_url.as_str(), |m| m.resource.as_str())
+    }
+
+    /// Build the OAuth 2.0 authorization-request URL (RFC 6749 §4.1.1 + PKCE
+    /// RFC 7636 + Resource Indicators RFC 8707).
+    ///
+    /// Pure and side-effect free so the query parameters — critically the
+    /// `resource` indicator required by the MCP auth spec (issue #369) — are
+    /// unit-testable without standing up a browser or callback server.
+    fn build_authorize_url(
+        &self,
+        authorization_endpoint: &str,
+        client_id: &str,
+        callback_url: &str,
+        state: &str,
+        code_challenge: &str,
+    ) -> Result<Url> {
+        let mut auth_url = Url::parse(authorization_endpoint)
+            .map_err(|e| Error::OAuth(format!("Invalid auth endpoint: {e}")))?;
+
+        {
+            let mut params = auth_url.query_pairs_mut();
+            params.append_pair("response_type", "code");
+            params.append_pair("client_id", client_id);
+            params.append_pair("redirect_uri", callback_url);
+            params.append_pair("state", state);
+            params.append_pair("code_challenge", code_challenge);
+            params.append_pair("code_challenge_method", "S256");
+
+            if !self.scopes.is_empty() {
+                params.append_pair("scope", &self.scopes.join(" "));
+            }
+
+            // RFC 8707 Resource Indicator (mandated by the MCP authorization
+            // spec). Audience-binds the issued token to this MCP server; strict
+            // providers reject the flow without it (issue #369).
+            params.append_pair("resource", self.resource_indicator());
+        }
+
+        Ok(auth_url)
+    }
+
+    /// Form parameters for the `authorization_code` → token exchange
+    /// (RFC 6749 §4.1.3 + PKCE RFC 7636 + Resource Indicators RFC 8707).
+    ///
+    /// Pure builder so the request body — including the `resource` indicator
+    /// (issue #369) — is unit-testable without a live token endpoint.
+    fn token_exchange_params(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        client_id: &str,
+        code_verifier: &str,
+    ) -> Vec<(&'static str, String)> {
+        let mut params = vec![
+            ("grant_type", "authorization_code".to_string()),
+            ("code", code.to_string()),
+            ("redirect_uri", redirect_uri.to_string()),
+            ("client_id", client_id.to_string()),
+            ("code_verifier", code_verifier.to_string()),
+        ];
+        // Include client_secret when the provider requires it (Slack, Figma, …).
+        if let Some(ref secret) = self.client_secret {
+            params.push(("client_secret", secret.clone()));
+        }
+        // RFC 8707 Resource Indicator — must match the authorization request so
+        // the AS issues an audience-bound token (issue #369).
+        params.push(("resource", self.resource_indicator().to_string()));
+        params
+    }
+
+    /// Form parameters for the `refresh_token` grant (RFC 6749 §6 + RFC 8707).
+    fn refresh_params(&self, refresh_token: &str, client_id: &str) -> Vec<(&'static str, String)> {
+        let mut params = vec![
+            ("grant_type", "refresh_token".to_string()),
+            ("refresh_token", refresh_token.to_string()),
+            ("client_id", client_id.to_string()),
+        ];
+        if let Some(ref secret) = self.client_secret {
+            params.push(("client_secret", secret.clone()));
+        }
+        // RFC 8707 Resource Indicator — keep the refreshed token audience-bound
+        // to this MCP server, matching the original grant (issue #369).
+        params.push(("resource", self.resource_indicator().to_string()));
+        params
+    }
+
+    /// Form parameters for the `client_credentials` grant (RFC 6749 §4.4 +
+    /// RFC 8707). No `client_secret` is added here: this path historically
+    /// authenticates public/dynamically-registered clients without one.
+    fn client_credentials_params(&self, client_id: &str) -> Vec<(&'static str, String)> {
+        let mut params = vec![
+            ("grant_type", "client_credentials".to_string()),
+            ("client_id", client_id.to_string()),
+        ];
+        let scope_str = self.scopes.join(" ");
+        if !scope_str.is_empty() {
+            params.push(("scope", scope_str));
+        }
+        // RFC 8707 Resource Indicator — audience-bind the client_credentials
+        // token to this MCP server, matching the other grants (issue #369).
+        params.push(("resource", self.resource_indicator().to_string()));
+        params
+    }
+
     /// Perform the authorization flow
     ///
     /// # Errors
@@ -563,22 +677,13 @@ impl OAuthClient {
         let client_id = self.ensure_client_id_with_redirect(&callback_url).await?;
 
         // Build authorization URL with the ACTUAL callback URL
-        let mut auth_url = Url::parse(&auth_meta.authorization_endpoint)
-            .map_err(|e| Error::OAuth(format!("Invalid auth endpoint: {e}")))?;
-
-        {
-            let mut params = auth_url.query_pairs_mut();
-            params.append_pair("response_type", "code");
-            params.append_pair("client_id", &client_id);
-            params.append_pair("redirect_uri", &callback_url);
-            params.append_pair("state", &state);
-            params.append_pair("code_challenge", &code_challenge);
-            params.append_pair("code_challenge_method", "S256");
-
-            if !self.scopes.is_empty() {
-                params.append_pair("scope", &self.scopes.join(" "));
-            }
-        }
+        let auth_url = self.build_authorize_url(
+            &auth_meta.authorization_endpoint,
+            &client_id,
+            &callback_url,
+            &state,
+            &code_challenge,
+        )?;
 
         // Open browser
         let auth_url_str = auth_url.to_string();
@@ -625,17 +730,7 @@ impl OAuthClient {
             .clone()
             .ok_or_else(|| Error::OAuth("No client ID".to_string()))?;
 
-        let mut params = HashMap::new();
-        params.insert("grant_type", "authorization_code");
-        params.insert("code", code);
-        params.insert("redirect_uri", redirect_uri);
-        params.insert("client_id", &client_id);
-        params.insert("code_verifier", code_verifier);
-        // Include client_secret when the provider requires it (Slack, Figma, etc.)
-        let secret_ref: Option<String> = self.client_secret.clone();
-        if let Some(ref secret) = secret_ref {
-            params.insert("client_secret", secret.as_str());
-        }
+        let params = self.token_exchange_params(code, redirect_uri, &client_id, code_verifier);
 
         let response = self
             .http_client
@@ -697,14 +792,7 @@ impl OAuthClient {
             .clone()
             .ok_or_else(|| Error::OAuth("No client ID".to_string()))?;
 
-        let mut params = HashMap::new();
-        params.insert("grant_type", "refresh_token");
-        params.insert("refresh_token", refresh_token);
-        params.insert("client_id", &client_id);
-        let secret_ref: Option<String> = self.client_secret.clone();
-        if let Some(ref secret) = secret_ref {
-            params.insert("client_secret", secret.as_str());
-        }
+        let params = self.refresh_params(refresh_token, &client_id);
 
         let response = self
             .http_client

--- a/src/oauth/client/tests.rs
+++ b/src/oauth/client/tests.rs
@@ -539,3 +539,200 @@ fn purge_is_noop_without_invalid_client_marker() {
     // THEN: nothing is purged.
     assert_eq!(client.client_id.read().clone(), Some("keep-me".to_string()));
 }
+
+// =========================================================================
+// RFC 8707 Resource Indicator (issue #369)
+// =========================================================================
+
+fn resource_test_client(resource_url: &str) -> OAuthClient {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    OAuthClient::new(
+        Client::new(),
+        "res-test".to_string(),
+        resource_url.to_string(),
+        vec!["openid".to_string()],
+        storage,
+        OAuthClientConfig {
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    )
+}
+
+fn protected_resource(resource: &str) -> ProtectedResourceMetadata {
+    ProtectedResourceMetadata {
+        resource: resource.to_string(),
+        authorization_servers: vec![],
+        bearer_methods_supported: vec![],
+        scopes_supported: vec![],
+    }
+}
+
+/// The authorization URL MUST carry the RFC 8707 `resource` parameter, using
+/// the canonical identifier from discovered protected-resource metadata. This
+/// is the exact regression from issue #369: without it, strict providers
+/// (e.g. kapa.ai) reject the flow with `server_error`.
+#[test]
+fn authorize_url_includes_resource_indicator_from_metadata() {
+    let mut client = resource_test_client("https://influxdb-docs.mcp.kapa.ai");
+    client.resource_metadata = Some(protected_resource("https://influxdb-docs.mcp.kapa.ai/"));
+
+    let url = client
+        .build_authorize_url(
+            "https://mcp.kapa.ai/auth/public/authorize",
+            "client-abc",
+            "http://localhost:36721/oauth/callback",
+            "state-xyz",
+            "challenge-123",
+        )
+        .expect("URL should build");
+
+    let resource = url
+        .query_pairs()
+        .find(|(k, _)| k == "resource")
+        .map(|(_, v)| v.into_owned());
+    assert_eq!(
+        resource.as_deref(),
+        Some("https://influxdb-docs.mcp.kapa.ai/"),
+        "authorize URL must include the RFC 8707 resource indicator (issue #369)"
+    );
+
+    // Sanity: the pre-existing params survive the extraction refactor.
+    let keys: Vec<String> = url.query_pairs().map(|(k, _)| k.into_owned()).collect();
+    for expected in [
+        "response_type",
+        "client_id",
+        "redirect_uri",
+        "state",
+        "code_challenge",
+        "code_challenge_method",
+        "scope",
+        "resource",
+    ] {
+        assert!(keys.contains(&expected.to_string()), "missing {expected}");
+    }
+}
+
+/// When protected-resource metadata was never discovered, the indicator falls
+/// back to the configured MCP endpoint URL rather than being dropped.
+#[test]
+fn authorize_url_resource_falls_back_to_endpoint_url() {
+    let client = resource_test_client("https://example.test/mcp");
+
+    let url = client
+        .build_authorize_url(
+            "https://auth.example.test/authorize",
+            "cid",
+            "http://localhost:5000/oauth/callback",
+            "st",
+            "ch",
+        )
+        .expect("URL should build");
+
+    let resource = url
+        .query_pairs()
+        .find(|(k, _)| k == "resource")
+        .map(|(_, v)| v.into_owned());
+    assert_eq!(resource.as_deref(), Some("https://example.test/mcp"));
+}
+
+/// Metadata `resource` wins over the raw endpoint URL when both are available.
+#[test]
+fn resource_indicator_prefers_metadata_over_url() {
+    let mut client = resource_test_client("https://raw.example.test/mcp");
+    assert_eq!(client.resource_indicator(), "https://raw.example.test/mcp");
+
+    client.resource_metadata = Some(protected_resource("https://canonical.example.test/"));
+    assert_eq!(
+        client.resource_indicator(),
+        "https://canonical.example.test/"
+    );
+}
+
+fn param<'a>(params: &'a [(&'static str, String)], key: &str) -> Option<&'a str> {
+    params
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, v)| v.as_str())
+}
+
+fn secret_client(resource_url: &str, secret: &str) -> OAuthClient {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Arc::new(TokenStorage::new(dir.path().to_path_buf()).unwrap());
+    OAuthClient::new(
+        Client::new(),
+        "res-test".to_string(),
+        resource_url.to_string(),
+        vec!["openid".to_string()],
+        storage,
+        OAuthClientConfig {
+            client_secret: Some(secret.to_string()),
+            token_refresh_buffer_secs: 300,
+            ..Default::default()
+        },
+    )
+}
+
+/// The `authorization_code` token-exchange body MUST carry `resource` (issue
+/// #369) alongside the standard grant params.
+#[test]
+fn token_exchange_params_include_resource() {
+    let mut client = resource_test_client("https://mcp.example.test/");
+    client.resource_metadata = Some(protected_resource("https://canonical.example.test/"));
+
+    let params = client.token_exchange_params(
+        "auth-code",
+        "http://localhost:9/oauth/callback",
+        "cid",
+        "verifier",
+    );
+
+    assert_eq!(param(&params, "grant_type"), Some("authorization_code"));
+    assert_eq!(param(&params, "code"), Some("auth-code"));
+    assert_eq!(param(&params, "code_verifier"), Some("verifier"));
+    assert_eq!(
+        param(&params, "resource"),
+        Some("https://canonical.example.test/"),
+        "token exchange must send the RFC 8707 resource indicator"
+    );
+    // No secret configured -> no client_secret leaked into the body.
+    assert_eq!(param(&params, "client_secret"), None);
+}
+
+/// The `refresh_token` body MUST carry `resource` so refreshed tokens stay
+/// audience-bound (issue #369), and forward a configured `client_secret`.
+#[test]
+fn refresh_params_include_resource_and_secret() {
+    let client = secret_client("https://mcp.example.test/", "s3cr3t");
+
+    let params = client.refresh_params("refresh-abc", "cid");
+
+    assert_eq!(param(&params, "grant_type"), Some("refresh_token"));
+    assert_eq!(param(&params, "refresh_token"), Some("refresh-abc"));
+    assert_eq!(param(&params, "client_secret"), Some("s3cr3t"));
+    assert_eq!(
+        param(&params, "resource"),
+        Some("https://mcp.example.test/"),
+        "refresh must send the RFC 8707 resource indicator"
+    );
+}
+
+/// The `client_credentials` body MUST carry `resource` — the exact gap the
+/// external review caught before ship (issue #369).
+#[test]
+fn client_credentials_params_include_resource() {
+    let mut client = resource_test_client("https://mcp.example.test/");
+    client.resource_metadata = Some(protected_resource("https://canonical.example.test/"));
+
+    let params = client.client_credentials_params("cid");
+
+    assert_eq!(param(&params, "grant_type"), Some("client_credentials"));
+    assert_eq!(param(&params, "client_id"), Some("cid"));
+    assert_eq!(param(&params, "scope"), Some("openid"));
+    assert_eq!(
+        param(&params, "resource"),
+        Some("https://canonical.example.test/"),
+        "client_credentials must send the RFC 8707 resource indicator"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #369. The MCP authorization spec (rev 2025-06-18) requires clients to send the RFC 8707 `resource` parameter on the authorization request and on every token request, so the authorization server can audience-bind the issued token to the target MCP server. The gateway discovered the protected-resource metadata but never sent `resource` back, so spec-strict providers (the reporter's kapa.ai endpoint) rejected the login flow with `server_error`.

## Change

- New `resource_indicator()` helper: uses the discovered protected-resource `resource` value, falling back to the configured MCP endpoint URL when a server publishes no protected-resource metadata.
- Threads the indicator into all four OAuth requests: authorization URL, `authorization_code` exchange, `refresh_token`, and `client_credentials`.
- Extracts pure param builders (`build_authorize_url`, `token_exchange_params`, `refresh_params`, `client_credentials_params`) so the request bodies are unit-testable without a live endpoint.

## Tests

- 6 new unit tests covering the authorization URL and all three token-grant bodies, plus the metadata-vs-endpoint fallback and precedence. Run in CI via `cargo test --all-features`.
- Validated end-to-end against the reporter's exact repro (`influxdb-docs.mcp.kapa.ai`): the generated authorization URL now carries `resource=https%3A%2F%2Finfluxdb-docs.mcp.kapa.ai%2F`, derived live from metadata discovery.

## Release

Ships as **v3.3.2**: `Cargo.toml`/`Cargo.lock` bump, CHANGELOG entry, and Helm charts updated (`appVersion` + default image tag `2.19.0` → `3.3.2`; both chart versions to `0.1.1`).

Reported by @crepererum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)