### PR TITLE
docs(readme): distinguish the hardened Helm chart from experimental CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ This table compares public, user-facing behavior, not internal roadmap scoring. 
 | Policy and governance | Policy, grants, audit events, read-only control-plane tab/API, enterprise evidence boundary | Docker org/catalog/profile policy model | Centralized access control for teams | No broad governance plane; use with another policy layer when needed |
 | Imports and bridges | Native MCP backends plus REST capability YAML and protocol-import planning | Docker-packaged MCP server catalog | MCP server aggregation | Strong bridge story for OpenAPI, SSE, WebSocket, and stdio compatibility |
 | Ranking and routing | Safety-aware ranking, explanations, cost/latency/trust/health signals | Catalog/profile selection, not an MCP tool ranker | Gateway-level routing to configured servers | Transport routing, not semantic tool ranking |
-| Deployment | Local, team gateway, Docker Compose, systemd, launchd, and enterprise Kubernetes alpha manifests | Docker Desktop, Docker CLI, Docker Hub/catalog workflow | Local or shared self-hosted gateway | Local or remote bridge process beside the target MCP server |
+| Deployment | Local, team gateway, Docker Compose, systemd, launchd, a security-hardened Helm chart (non-root, seccomp, read-only rootfs), and experimental (v1alpha1) Kubernetes CRDs | Docker Desktop, Docker CLI, Docker Hub/catalog workflow | Local or shared self-hosted gateway | Local or remote bridge process beside the target MCP server |
 | Licensing | Noncommercial-default (PolyForm-NC) with a small MIT core of generic building blocks; commercial use of the runnable gateway requires a license | Docker product and repository licensing apply | See project repository license | See each bridge repository license |
 
 ### vs Anthropic MCP tunnels


### PR DESCRIPTION
## What

The deployment comparison cell described the whole Kubernetes story as "enterprise Kubernetes alpha manifests". That hides the fact that `deploy/helm/mcp-gateway` ships a security-hardened chart, while lumping it with the genuinely experimental CRDs.

New cell text:
> Local, team gateway, Docker Compose, systemd, launchd, a security-hardened Helm chart (non-root, seccomp, read-only rootfs), and experimental (v1alpha1) Kubernetes CRDs

## Why

- The Helm chart's security context is real: `runAsNonRoot`, `seccompProfile`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]` (`deploy/helm/mcp-gateway/templates/deployment.yaml:34-92`). It was invisible in the comparison.
- The `v1alpha1` CRDs are correctly experimental (ADR-004) and stay labelled as such.

## Not claiming GA

The chart is deliberately not called GA: `Chart.yaml` is at version `0.1.1` and it is not yet proven at scale. This corrects an understatement without introducing an overclaim.

Docs-only, one line (`README.md:371`). Rust pre-push gate skipped as vacuous for a README-only diff (audit-logged).