### PR TITLE
feat(capability): path_selector for REST capabilities + backend hardening

### DIFF
--- a/capabilities/automation/desktop_event_bus.yaml
+++ b/capabilities/automation/desktop_event_bus.yaml
@@ -80,10 +80,10 @@ providers:
     cost_per_call: 0
     timeout: 30
     config:
-      command: /Users/mikko/.cargo/bin/axterminator
+      command: axterminator
       args:
-        - "--mode"
-        - "event-bus"
+        - "mcp"
+        - "serve"
       transport: stdio
 
 auth:

--- a/capabilities/search/trawl_extract.yaml
+++ b/capabilities/search/trawl_extract.yaml
@@ -39,18 +39,22 @@ schema:
       - url
       - fields
 
-handler:
-  type: command
-  command: "/Users/mikko/go/bin/trawl"
-  args_template: |
-    {{ url }}
-    --fields "{{ fields }}"
-    {% if query %}--query "{{ query }}"{% endif %}
-    --format {{ format | default: "json" }}
-    {% if js %}--js{% endif %}
-    {% if plan_only %}--plan{% endif %}
-    {% if no_cache %}--no-cache{% endif %}
-    {% if wait %}--wait {{ wait }}{% endif %}
+providers:
+  primary:
+    service: cli
+    cost_per_call: 1
+    timeout: 60
+    config:
+      command: "trawl"
+      args_template: |
+        {{ url }}
+        --fields "{{ fields }}"
+        {% if query %}--query "{{ query }}"{% endif %}
+        --format {{ format | default: "json" }}
+        {% if js %}--js{% endif %}
+        {% if plan_only %}--plan{% endif %}
+        {% if no_cache %}--no-cache{% endif %}
+        {% if wait %}--wait {{ wait }}{% endif %}
 
 metadata:
   cost_tier: 1

--- a/capabilities/verification/metacognition_verify.yaml
+++ b/capabilities/verification/metacognition_verify.yaml
@@ -45,14 +45,10 @@ providers:
   primary:
     service: cli
     config:
-      command: "/Users/mikko/github/metacognition-rs/target/release/metacog"
+      command: "metacognition"
       args:
-        - "verify"
+        - "--json"
         - "{text}"
-        - "--model"
-        - "/Users/mikko/github/metacognition-rs/models/nli-deberta-v3-xsmall"
-        - "--format"
-        - "json"
       timeout_ms: 5000
 
 examples:

--- a/src/capability/backend.rs
+++ b/src/capability/backend.rs
@@ -406,6 +406,13 @@ impl CapabilityBackend {
             self.multi_user.load(std::sync::atomic::Ordering::Relaxed),
         )?;
 
+        // Selector values choose an outbound URL path, so preserve their
+        // declared string type instead of allowing generic schema coercion
+        // (for example, JSON `1` becoming the string `"1"`).
+        if let Some(error_result) = path_selector_type_error(&capability, &arguments) {
+            return Ok(error_result);
+        }
+
         // Validate arguments against the YAML schema before making any HTTP call.
         let input_schema = &capability.schema.input;
         let validation = validate_arguments(&arguments, input_schema);
@@ -504,6 +511,33 @@ impl CapabilityBackend {
 
         detected
     }
+}
+
+fn path_selector_type_error(
+    capability: &CapabilityDefinition,
+    arguments: &Value,
+) -> Option<ToolsCallResult> {
+    let selector = capability
+        .primary_provider()?
+        .config
+        .path_selector
+        .as_ref()?;
+    let value = arguments.get(&selector.parameter)?;
+    if value.is_null() || value.is_string() {
+        return None;
+    }
+
+    Some(ToolsCallResult {
+        content: vec![Content::Text {
+            text: format!(
+                "Tool call validation failed:\n- Parameter '{}' must be a string.",
+                selector.parameter
+            ),
+            annotations: None,
+        }],
+        structured_content: None,
+        is_error: true,
+    })
 }
 
 fn build_success_tool_result(capability: &CapabilityDefinition, result: Value) -> ToolsCallResult {
@@ -812,6 +846,53 @@ providers:
 
         assert!(err.contains("caller identity is required"), "{err}");
         assert!(!err.contains("required_value"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn capability_backend_rejects_non_string_path_selector_before_coercion() {
+        let yaml = r"
+name: strict_selector
+description: Reject non-string selector values before schema coercion.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: ['1']
+        default: '1'
+auth:
+  required: true
+  type: api_key
+  key: env:PATH_SELECTOR_STRICT_TYPE_TEST_MISSING_20260718
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://example.com
+      path: /feeds/1
+      path_selector:
+        parameter: category
+        default: '1'
+        paths:
+          '1': /feeds/{category}
+";
+        let capability = crate::capability::parse_capability(yaml).unwrap();
+        let backend = make_backend();
+        backend.capabilities.write().upsert(capability);
+
+        let result = backend
+            .call_tool("strict_selector", json!({ "category": 1 }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        let Content::Text { text, .. } = &result.content[0] else {
+            panic!("expected a text validation error");
+        };
+        assert!(text.contains("category"), "{text}");
+        assert!(text.contains("must be a string"), "{text}");
+        assert!(!text.contains("PATH_SELECTOR_STRICT_TYPE_TEST"), "{text}");
     }
 
     #[tokio::test]

--- a/src/capability/definition/mod.rs
+++ b/src/capability/definition/mod.rs
@@ -338,9 +338,25 @@ pub struct RestConfig {
     #[serde(default)]
     pub base_url: String,
 
-    /// Path template (supports {param} substitution)
+    /// Path template (supports {param} substitution).
+    ///
+    /// When [`Self::path_selector`] is configured, this may repeat the
+    /// selector's default path as a compatibility fallback for older gateway
+    /// binaries that do not understand `path_selector`.
     #[serde(default)]
     pub path: String,
+
+    /// Select one of several path templates from a caller parameter.
+    ///
+    /// This is a safe, declarative alternative to executable request-transform
+    /// snippets for APIs whose route shape changes with an enum-like input.
+    /// The selected template receives the same `{param}` substitution as
+    /// [`Self::path`]. When the selector parameter is absent, `default` is
+    /// used; unknown values fail closed instead of becoming URL fragments.
+    /// `path`, when also present, must exactly match the selected default path
+    /// and is retained only as a rolling-upgrade fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_selector: Option<PathSelectorConfig>,
 
     /// Full endpoint URL (alternative to `base_url` + path)
     /// Takes precedence if set
@@ -428,6 +444,22 @@ pub struct RestConfig {
     /// ```
     #[serde(default)]
     pub body_content_type: String,
+}
+
+/// Declarative selection of a REST path template from an input parameter.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PathSelectorConfig {
+    /// Input property whose string value selects a path.
+    #[serde(default)]
+    pub parameter: String,
+
+    /// Selector value to use when the caller omits `parameter`.
+    #[serde(default)]
+    pub default: String,
+
+    /// Selector value to path-template mapping.
+    #[serde(default)]
+    pub paths: HashMap<String, String>,
 }
 
 impl RestConfig {

--- a/src/capability/executor/mod.rs
+++ b/src/capability/executor/mod.rs
@@ -462,12 +462,35 @@ impl CapabilityExecutor {
     }
 
     /// Build URL with path parameter substitution.
-    #[allow(clippy::unused_self, clippy::unnecessary_wraps)]
+    #[allow(clippy::unused_self)]
     fn build_url(&self, config: &RestConfig, params: &Value) -> Result<String> {
         let mut url = if config.uses_endpoint() {
             config.endpoint.clone()
         } else {
-            format!("{}{}", config.base_url, config.path)
+            let path = if let Some(selector) = &config.path_selector {
+                let selected = match params.get(&selector.parameter) {
+                    None | Some(Value::Null) => selector.default.as_str(),
+                    Some(Value::String(value)) => value.as_str(),
+                    Some(_) => {
+                        return Err(Error::Config(format!(
+                            "REST path selector parameter '{}' must be a string",
+                            selector.parameter
+                        )));
+                    }
+                };
+
+                let path = selector.paths.get(selected).ok_or_else(|| {
+                    Error::Config(format!(
+                        "No path is configured for REST path selector parameter '{}'",
+                        selector.parameter
+                    ))
+                })?;
+                path.replace(&format!("{{{}}}", selector.parameter), selected)
+            } else {
+                config.path.clone()
+            };
+
+            format!("{}{path}", config.base_url)
         };
 
         if let Value::Object(map) = params {

--- a/src/capability/executor_tests.rs
+++ b/src/capability/executor_tests.rs
@@ -33,6 +33,103 @@ fn test_build_url() {
     assert_eq!(url, "https://api.example.com/users/123/posts/456");
 }
 
+fn socialdeal_path_selector_config() -> RestConfig {
+    serde_yaml::from_str(
+        r"
+base_url: https://www.socialdeal.nl
+path: /sitemap/deals/lmd/{city}/deals.xml
+path_selector:
+  parameter: category
+  default: deals
+  paths:
+    deals: /sitemap/deals/lmd/{city}/deals.xml
+    all: /sitemap/deals/{city}/deals-and-companies.xml
+    expired: /sitemap/deals/lmd/{city}/expired-deals.xml
+",
+    )
+    .unwrap()
+}
+
+#[test]
+fn path_selector_routes_each_declared_value_to_its_path_template() {
+    let executor = CapabilityExecutor::new();
+    let config = socialdeal_path_selector_config();
+
+    let cases = [
+        (
+            "deals",
+            "https://www.socialdeal.nl/sitemap/deals/lmd/amsterdam/deals.xml",
+        ),
+        (
+            "all",
+            "https://www.socialdeal.nl/sitemap/deals/amsterdam/deals-and-companies.xml",
+        ),
+        (
+            "expired",
+            "https://www.socialdeal.nl/sitemap/deals/lmd/amsterdam/expired-deals.xml",
+        ),
+    ];
+
+    for (category, expected) in cases {
+        let params = serde_json::json!({"city": "amsterdam", "category": category});
+        assert_eq!(executor.build_url(&config, &params).unwrap(), expected);
+    }
+}
+
+#[test]
+fn path_selector_uses_declared_default_when_parameter_is_absent() {
+    let executor = CapabilityExecutor::new();
+    let config = socialdeal_path_selector_config();
+    let params = serde_json::json!({"city": "haarlem"});
+
+    assert_eq!(
+        executor.build_url(&config, &params).unwrap(),
+        "https://www.socialdeal.nl/sitemap/deals/lmd/haarlem/deals.xml"
+    );
+}
+
+#[test]
+fn path_selector_substitutes_selected_default_into_its_own_placeholder() {
+    let executor = CapabilityExecutor::new();
+    let config: RestConfig = serde_yaml::from_str(
+        r"
+base_url: https://api.example.com
+path: /feeds/current/{city}
+path_selector:
+  parameter: category
+  default: current
+  paths:
+    current: /feeds/{category}/{city}
+    archive: /feeds/{category}/{city}
+",
+    )
+    .unwrap();
+
+    for params in [
+        serde_json::json!({"city": "amsterdam"}),
+        serde_json::json!({"city": "amsterdam", "category": null}),
+    ] {
+        assert_eq!(
+            executor.build_url(&config, &params).unwrap(),
+            "https://api.example.com/feeds/current/amsterdam"
+        );
+    }
+}
+
+#[test]
+fn path_selector_rejects_values_without_a_declared_path() {
+    let executor = CapabilityExecutor::new();
+    let config = socialdeal_path_selector_config();
+    let params = serde_json::json!({"city": "utrecht", "category": "restaurants"});
+
+    let error = executor
+        .build_url(&config, &params)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("category"), "{error}");
+    assert!(error.contains("path selector"), "{error}");
+}
+
 #[test]
 fn test_substitute_string() {
     let executor = CapabilityExecutor::new();

--- a/src/capability/validator/checks.rs
+++ b/src/capability/validator/checks.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::capability::{CapabilityDefinition, RestConfig};
+use crate::capability::{CapabilityDefinition, PathSelectorConfig, RestConfig};
 use crate::validator::schema_helpers;
 
 use super::Issue;
@@ -159,6 +159,7 @@ pub(super) fn check_providers(cap: &CapabilityDefinition, issues: &mut Vec<Issue
             &provider.service,
             &ctx,
             &schema_props,
+            &cap.schema.input,
             issues,
         );
     }
@@ -170,6 +171,7 @@ pub(super) fn check_providers(cap: &CapabilityDefinition, issues: &mut Vec<Issue
             &provider.service,
             &ctx,
             &schema_props,
+            &cap.schema.input,
             issues,
         );
     }
@@ -193,6 +195,7 @@ fn check_rest_config(
     service: &str,
     context: &str,
     schema_props: &HashSet<String>,
+    input_schema: &serde_json::Value,
     issues: &mut Vec<Issue>,
 ) {
     let has_base_url = !config.base_url.is_empty();
@@ -252,6 +255,18 @@ fn check_rest_config(
     check_placeholders_in_text(&config.base_url, context, "base_url", schema_props, issues);
     check_placeholders_in_text(&config.endpoint, context, "endpoint", schema_props, issues);
 
+    if let Some(selector) = &config.path_selector {
+        check_path_selector(
+            selector,
+            config,
+            service,
+            context,
+            schema_props,
+            input_schema,
+            issues,
+        );
+    }
+
     for (key, value) in &config.params {
         check_placeholders_in_text(
             value,
@@ -279,6 +294,160 @@ fn check_rest_config(
         issues.push(Issue::warning(
             "CAP-007",
             format!("{context}: key '{overlap}' appears in both 'static_params' and 'params'; static_params will be overridden by caller"),
+        ));
+    }
+}
+
+fn check_path_selector(
+    selector: &PathSelectorConfig,
+    config: &RestConfig,
+    service: &str,
+    context: &str,
+    schema_props: &HashSet<String>,
+    input_schema: &serde_json::Value,
+    issues: &mut Vec<Issue>,
+) {
+    let selector_context = format!("{context}.path_selector");
+
+    if service != "rest" {
+        issues.push(Issue::error(
+            "CAP-005",
+            format!("{selector_context} is only supported for service 'rest'"),
+        ));
+    }
+
+    let default_path = selector.paths.get(&selector.default);
+    let selector_placeholder = format!("{{{}}}", selector.parameter);
+    let normalized_default_path =
+        default_path.map(|path| path.replace(&selector_placeholder, &selector.default));
+    let has_conflicting_path =
+        !config.path.is_empty() && normalized_default_path.as_deref() != Some(config.path.as_str());
+    if has_conflicting_path || !config.endpoint.is_empty() {
+        issues.push(Issue::error(
+            "CAP-005",
+            format!(
+                "{selector_context} cannot be combined with config.endpoint or a config.path that differs from its default path"
+            ),
+        ));
+    }
+
+    if selector.parameter.is_empty() || !schema_props.contains(&selector.parameter) {
+        issues.push(Issue::error(
+            "CAP-006",
+            format!(
+                "{selector_context}.parameter '{}' has no matching entry in schema.input.properties",
+                selector.parameter
+            ),
+        ));
+    }
+
+    let property_schema = input_schema
+        .get("properties")
+        .and_then(|properties| properties.get(&selector.parameter));
+
+    if property_schema
+        .and_then(|property| property.get("type"))
+        .and_then(serde_json::Value::as_str)
+        != Some("string")
+    {
+        issues.push(Issue::error(
+            "CAP-006",
+            format!(
+                "{selector_context}.parameter '{}' must reference a schema property with type 'string'",
+                selector.parameter
+            ),
+        ));
+    }
+
+    if selector.default.is_empty() || !selector.paths.contains_key(&selector.default) {
+        issues.push(Issue::error(
+            "CAP-005",
+            format!(
+                "{selector_context}.default '{}' has no matching entry in path_selector.paths",
+                selector.default
+            ),
+        ));
+    }
+
+    for (value, path) in &selector.paths {
+        if !path.starts_with('/') {
+            issues.push(Issue::error(
+                "CAP-008",
+                format!("{selector_context}.paths.{value} '{path}' should start with '/'"),
+            ));
+        }
+        check_placeholders_in_text(
+            path,
+            &selector_context,
+            &format!("paths.{value}"),
+            schema_props,
+            issues,
+        );
+    }
+
+    check_path_selector_schema(selector, &selector_context, property_schema, issues);
+}
+
+fn check_path_selector_schema(
+    selector: &PathSelectorConfig,
+    selector_context: &str,
+    property_schema: Option<&serde_json::Value>,
+    issues: &mut Vec<Issue>,
+) {
+    let enum_values = property_schema
+        .and_then(|property| property.get("enum"))
+        .and_then(serde_json::Value::as_array);
+    let enum_strings = enum_values.and_then(|values| {
+        let strings: Option<HashSet<&str>> = values.iter().map(serde_json::Value::as_str).collect();
+        strings.filter(|items| !items.is_empty())
+    });
+
+    if let Some(enum_strings) = enum_strings {
+        let path_keys: HashSet<&str> = selector.paths.keys().map(String::as_str).collect();
+        for missing in enum_strings.difference(&path_keys) {
+            issues.push(Issue::error(
+                "CAP-006",
+                format!("{selector_context}.paths has no entry for schema enum value '{missing}'"),
+            ));
+        }
+        for extra in path_keys.difference(&enum_strings) {
+            issues.push(Issue::error(
+                "CAP-006",
+                format!(
+                    "{selector_context}.paths entry '{extra}' is not declared in the schema enum"
+                ),
+            ));
+        }
+
+        if !enum_strings.contains(selector.default.as_str()) {
+            issues.push(Issue::error(
+                "CAP-006",
+                format!(
+                    "{selector_context}.default '{}' is not declared in the schema enum",
+                    selector.default
+                ),
+            ));
+        }
+    } else {
+        issues.push(Issue::error(
+            "CAP-006",
+            format!(
+                "{selector_context}.parameter '{}' must declare a non-empty string enum",
+                selector.parameter
+            ),
+        ));
+    }
+
+    let schema_default = property_schema
+        .and_then(|property| property.get("default"))
+        .and_then(serde_json::Value::as_str);
+    if schema_default != Some(selector.default.as_str()) {
+        issues.push(Issue::error(
+            "CAP-006",
+            format!(
+                "{selector_context}.default '{}' must match the schema default",
+                selector.default
+            ),
         ));
     }
 }

--- a/src/capability/validator/tests/yaml_roundtrip.rs
+++ b/src/capability/validator/tests/yaml_roundtrip.rs
@@ -70,6 +70,391 @@ providers:
 }
 
 #[test]
+fn path_selector_paths_are_checked_for_dangling_placeholders() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/{missing_input}
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues
+            .iter()
+            .any(|issue| { issue.code == "CAP-006" && issue.message.contains("{missing_input}") }),
+        "expected dangling path-selector placeholder to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_parameter_must_be_declared_in_input_schema() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      city:
+        type: string
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/{city}
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues.iter().any(|issue| {
+            issue.code == "CAP-006" && issue.message.contains("no matching entry")
+        }),
+        "expected undeclared path-selector parameter to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_default_must_have_a_declared_path() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          archive: /feeds/archive
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues
+            .iter()
+            .any(|issue| { issue.code == "CAP-005" && issue.message.contains(".default") }),
+        "expected missing default path to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_paths_must_start_with_a_slash() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: feeds/current
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues.iter().any(|issue| {
+            issue.severity == IssueSeverity::Error
+                && issue.code == "CAP-008"
+                && issue.message.contains("should start with '/'")
+        }),
+        "expected path-selector slash error: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_must_cover_declared_schema_enum_values() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current, archive]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/current
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues.iter().any(|issue| {
+            issue.code == "CAP-006" && issue.message.contains("schema enum value 'archive'")
+        }),
+        "expected uncovered enum value to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_requires_a_string_enum_input_property() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: integer
+        enum: [1, 2]
+        default: 1
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: one
+        paths:
+          one: /feeds/one
+          two: /feeds/two
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues
+            .iter()
+            .any(|issue| { issue.code == "CAP-006" && issue.message.contains("type 'string'") }),
+        "expected non-string selector schema to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_paths_must_exactly_match_schema_enum_values() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/current
+          hidden: /feeds/hidden
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues
+            .iter()
+            .any(|issue| { issue.code == "CAP-006" && issue.message.contains("'hidden'") }),
+        "expected extra selector path to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_default_must_match_schema_default() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current, archive]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: archive
+        paths:
+          current: /feeds/current
+          archive: /feeds/archive
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues.iter().any(|issue| {
+            issue.code == "CAP-006" && issue.message.contains("must match the schema default")
+        }),
+        "expected mismatched selector default to fail: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_rejects_a_conflicting_path_or_any_endpoint() {
+    for conflicting_field in [
+        "path: /different",
+        "endpoint: https://api.example.com/fixed",
+    ] {
+        let yaml = format!(
+            r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      {conflicting_field}
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/current
+"
+        );
+        let cap: CapabilityDefinition = serde_yaml::from_str(&yaml).unwrap();
+        let issues = validate_capability_definition(&cap, None);
+        assert!(
+            issues.iter().any(|issue| {
+                issue.code == "CAP-005" && issue.message.contains("cannot be combined")
+            }),
+            "expected {conflicting_field} conflict to fail: {issues:?}"
+        );
+    }
+}
+
+#[test]
+fn path_selector_allows_its_default_path_as_a_legacy_fallback() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current, archive]
+        default: current
+providers:
+  primary:
+    service: rest
+    config:
+      base_url: https://api.example.com
+      path: /feeds/current
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/{category}
+          archive: /archive/{category}
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        errors_of(&issues).is_empty(),
+        "matching legacy fallback should be valid: {issues:?}"
+    );
+}
+
+#[test]
+fn path_selector_is_only_valid_for_rest_providers() {
+    let yaml = r"
+name: category_feed
+description: Fetch a category-specific feed.
+schema:
+  input:
+    type: object
+    properties:
+      category:
+        type: string
+        enum: [current]
+        default: current
+providers:
+  primary:
+    service: graphql
+    config:
+      base_url: https://api.example.com
+      path_selector:
+        parameter: category
+        default: current
+        paths:
+          current: /feeds/current
+";
+    let cap: CapabilityDefinition = serde_yaml::from_str(yaml).unwrap();
+    let issues = validate_capability_definition(&cap, None);
+    assert!(
+        issues.iter().any(|issue| {
+            issue.code == "CAP-005" && issue.message.contains("only supported for service 'rest'")
+        }),
+        "expected non-REST path selector to fail: {issues:?}"
+    );
+}
+
+#[test]
 fn local_ml_service_without_url_passes() {
     // GIVEN: provider with service=local_ml and no base_url/endpoint
     // WHEN: validating

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -743,6 +743,11 @@ pub(super) async fn backend_handler(
                 return match forward {
                     Ok(mut response) => {
                         record_client_success(&state, client.as_ref());
+                        // The transport uses its own request IDs to correlate
+                        // concurrent upstream calls. Restore the caller's ID at
+                        // the HTTP boundary so the client can correlate this
+                        // response with its original JSON-RPC request.
+                        response.id = Some(id.clone());
                         scan_direct_backend_response(
                             &state,
                             &name,
@@ -789,6 +794,9 @@ pub(super) async fn backend_handler(
     match forward {
         Ok(mut response) => {
             record_client_success(&state, client.as_ref());
+            // Upstream transport IDs are private gateway correlation state;
+            // direct-route clients must receive the ID they supplied.
+            response.id = Some(id.clone());
             if method == "tools/list" {
                 normalize_tools_list_response(&name, &mut response);
                 scan_direct_tools_list_response(&state, &name, client.as_ref(), &mut response);

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -968,6 +968,47 @@ async fn backend_handler_missing_backend_returns_jsonrpc_not_found() {
 }
 
 #[tokio::test]
+async fn backend_handler_preserves_callers_jsonrpc_id_on_success() {
+    let backend = Arc::new(Backend::new(
+        "demo",
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let transport: Arc<dyn Transport> = Arc::new(RouterNotificationTestTransport::success());
+    backend.set_transport_for_test(transport);
+
+    let router = create_router(test_router_app_state_with_backend(backend));
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/mcp/demo")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            json!({
+                "jsonrpc": "2.0",
+                "id": "caller-initialize-41",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "1.0" }
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["jsonrpc"], "2.0");
+    assert_eq!(json["id"], "caller-initialize-41");
+    assert_eq!(json["result"], json!({"ok": true}));
+}
+
+#[tokio::test]
 async fn backend_handler_discovery_method_fails_closed_for_required_propagation() {
     // ADR-007 IDP.2/IDP.3 regression guard: a discovery method (resources/list)
     // on a propagation-`required` backend must fail closed (403) when the
@@ -1331,6 +1372,7 @@ async fn backend_handler_direct_route_no_provenance_when_disabled() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], 8);
     assert!(
         json.pointer("/result/_meta/provenance").is_none(),
         "flag off must not stamp provenance, got: {json}"

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -9,6 +9,7 @@
 //! supported version.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -27,6 +28,50 @@ use crate::protocol::{
     is_version_mismatch_error, negotiate_best_version, parse_supported_versions_from_error,
 };
 use crate::{Error, Result};
+
+#[cfg(unix)]
+const FALLBACK_EXEC_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
+#[cfg(windows)]
+const FALLBACK_EXEC_PATH: &str = r"C:\Windows\System32;C:\Windows";
+#[cfg(not(any(unix, windows)))]
+const FALLBACK_EXEC_PATH: &str = "";
+
+fn configure_child_environment(cmd: &mut Command, backend_env: &HashMap<String, String>) {
+    cmd.env_clear();
+
+    let path = std::env::var_os("PATH").unwrap_or_else(|| OsString::from(FALLBACK_EXEC_PATH));
+    cmd.env("PATH", path);
+
+    if let Some(home) = std::env::var_os("HOME")
+        .or_else(|| dirs::home_dir().map(std::path::PathBuf::into_os_string))
+    {
+        cmd.env("HOME", home);
+    }
+
+    let tmpdir =
+        std::env::var_os("TMPDIR").unwrap_or_else(|| std::env::temp_dir().into_os_string());
+    cmd.env("TMPDIR", tmpdir);
+
+    #[cfg(windows)]
+    for key in [
+        "USERPROFILE",
+        "TEMP",
+        "TMP",
+        "SYSTEMROOT",
+        "COMSPEC",
+        "PATHEXT",
+    ] {
+        if let Some(value) = std::env::var_os(key) {
+            cmd.env(key, value);
+        }
+    }
+
+    // Backend configuration is authoritative and may intentionally override
+    // a safe default such as PATH, HOME, or TMPDIR.
+    for (key, value) in backend_env {
+        cmd.env(key, value);
+    }
+}
 
 /// Stdio transport for subprocess MCP servers
 pub struct StdioTransport {
@@ -103,10 +148,10 @@ impl StdioTransport {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
 
-        // Set environment
-        for (key, value) in &self.env {
-            cmd.env(key, value);
-        }
+        // Backend processes get only the minimal execution environment plus
+        // values explicitly assigned to this backend. In particular, secrets
+        // loaded into the gateway process must not be inherited implicitly.
+        configure_child_environment(&mut cmd, &self.env);
 
         // Set working directory
         if let Some(ref cwd) = self.cwd {
@@ -474,6 +519,13 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    #[cfg(unix)]
+    const CHILD_SCENARIO_ENV: &str = "MCP_GATEWAY_TEST_CHILD_ENV_SCENARIO";
+    #[cfg(unix)]
+    const PARENT_SECRET_ENV: &str = "MCP_GATEWAY_TEST_PARENT_SECRET";
+    #[cfg(unix)]
+    const EXPLICIT_BACKEND_ENV: &str = "MCP_GATEWAY_TEST_EXPLICIT_BACKEND";
+
     fn make_transport(cmd: &str) -> Arc<StdioTransport> {
         StdioTransport::new(
             cmd,
@@ -645,5 +697,102 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Transport(message)) if message == "Not connected"));
         assert!(t.pending.is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn backend_subprocess_receives_only_safe_and_explicit_environment() {
+        let current_test_binary = std::env::current_exe().expect("resolve current test binary");
+        let scenario_name = "transport::stdio::tests::stdio_child_environment_isolation_scenario";
+        let output = std::process::Command::new(current_test_binary)
+            .args(["--exact", scenario_name, "--nocapture"])
+            .env(CHILD_SCENARIO_ENV, "1")
+            .env(
+                PARENT_SECRET_ENV,
+                "dummy-parent-secret-must-not-reach-backend",
+            )
+            .output()
+            .expect("run isolated child-environment scenario");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stdout.contains(scenario_name),
+            "nested test filter did not execute the environment scenario; stdout={stdout:?} stderr={stderr:?}"
+        );
+        assert!(
+            output.status.success(),
+            "stdio child environment scenario failed; stdout={stdout:?} stderr={stderr:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn stdio_child_environment_isolation_scenario() {
+        if std::env::var_os(CHILD_SCENARIO_ENV).is_none() {
+            return;
+        }
+        assert!(
+            std::env::var_os(PARENT_SECRET_ENV).is_some(),
+            "nested scenario must start with the parent-only sentinel present"
+        );
+
+        let workspace = tempfile::tempdir().expect("create stdio child workspace");
+        let server = workspace.path().join("server.sh");
+        std::fs::write(
+            &server,
+            r#"while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25"}}'
+            ;;
+        *'"method":"env/check"'*)
+            parent_secret_present=false
+            explicit_backend_present=false
+            path_present=false
+            home_present=false
+            tmpdir_present=false
+            cwd_preserved=false
+            [ "${MCP_GATEWAY_TEST_PARENT_SECRET+x}" = x ] && parent_secret_present=true
+            [ "${MCP_GATEWAY_TEST_EXPLICIT_BACKEND:-}" = configured-value ] && explicit_backend_present=true
+            [ -n "${PATH:-}" ] && path_present=true
+            [ -n "${HOME:-}" ] && home_present=true
+            [ -n "${TMPDIR:-}" ] && tmpdir_present=true
+            [ -f server.sh ] && cwd_preserved=true
+            printf '{"jsonrpc":"2.0","id":2,"result":{"parent_secret_present":%s,"explicit_backend_present":%s,"path_present":%s,"home_present":%s,"tmpdir_present":%s,"cwd_preserved":%s}}\n' \
+                "$parent_secret_present" "$explicit_backend_present" "$path_present" \
+                "$home_present" "$tmpdir_present" "$cwd_preserved"
+            ;;
+    esac
+done
+"#,
+        )
+        .expect("write stdio child server");
+
+        let transport = StdioTransport::new(
+            "sh server.sh",
+            HashMap::from([(
+                EXPLICIT_BACKEND_ENV.to_string(),
+                "configured-value".to_string(),
+            )]),
+            Some(workspace.path().to_string_lossy().into_owned()),
+            std::time::Duration::from_secs(5),
+            None,
+        );
+
+        transport.start().await.expect("start stdio child server");
+        let response = transport
+            .request("env/check", None)
+            .await
+            .expect("request child environment report");
+        transport.close().await.expect("close stdio child server");
+
+        let report = response.result.expect("environment report result");
+        assert_eq!(report["parent_secret_present"], false);
+        assert_eq!(report["explicit_backend_present"], true);
+        assert_eq!(report["path_present"], true);
+        assert_eq!(report["home_present"], true);
+        assert_eq!(report["tmpdir_present"], true);
+        assert_eq!(report["cwd_preserved"], true);
     }
 }

--- a/src/validator/rules_schema.rs
+++ b/src/validator/rules_schema.rs
@@ -468,7 +468,7 @@ mod tests {
 
         let result = rule.check(&tool).unwrap();
         assert!(!result.passed);
-        assert!(result.severity == Severity::Fail);
+        assert_eq!(result.severity, Severity::Fail);
     }
 
     // ── AX-008: Conflict Detection ──────────────────────────────
@@ -498,7 +498,7 @@ mod tests {
 
         let result = rule.check(&tool).unwrap();
         assert!(!result.passed);
-        assert!(result.severity == Severity::Warn);
+        assert_eq!(result.severity, Severity::Warn);
     }
 
     #[test]
@@ -572,7 +572,7 @@ mod tests {
 
         let result = rule.check(&tool).unwrap();
         assert!(!result.passed);
-        assert!(result.severity == Severity::Info);
+        assert_eq!(result.severity, Severity::Info);
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
 
         let result = rule.check(&tool).unwrap();
         assert!(!result.passed);
-        assert!(result.severity == Severity::Warn);
+        assert_eq!(result.severity, Severity::Warn);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Five commits: one new capability feature, two hygiene/portability fixes, and two backend correctness/security fixes recovered from local work.

### Feature
- **`feat(capability): declarative `path_selector` for REST capabilities`** — lets a REST capability choose one of several URL path templates from a caller-supplied string parameter. Fail-closed by design: only pre-declared keys in the `paths` map resolve; non-declared values return a config error and never become a raw URL fragment; non-strings are rejected before schema coercion. A safe, declarative alternative to executable request-transform snippets. Load-time validation (CAP-005/CAP-006) mirrors the runtime guard: rest-only, parameter present and string-typed in schema, default present in `paths`, no conflicting `endpoint`/`path`, slash-prefixed templates.

### Fixes
- **`fix(lint): use `assert_eq!` for severity checks`** — restores a green `cargo clippy --all-targets -- -D warnings` under Rust 1.97 (`manual_assert_eq` promoted to deny). Test-only, no behavior change.
- **`fix(capabilities): PATH-resolved command names`** — `trawl_extract`, `metacognition_verify`, and `desktop_event_bus` hardcoded absolute binary paths under one developer's home directory, which do not exist for other users of this public catalog. Now bare command names resolved via `PATH`, matching the convention used by every other capability.
- **`fix: preserve direct backend request ids`** — restores the caller's original JSON-RPC id on direct-backend responses so clients can correlate responses with their requests (the transport uses private internal ids for concurrent upstream calls).
- **`fix: isolate stdio backend environments`** — stdio subprocesses now receive only a minimal safe environment (PATH/HOME/TMPDIR plus OS essentials) plus values explicitly configured for that backend. Gateway-process secrets are no longer inherited implicitly by spawned MCP servers.

## Acceptance criteria
- [x] PR.PATHSEL.1 — a caller value matching a declared key selects that path template; a non-declared value fails closed without building a URL.
- [x] PR.PATHSEL.2 — a non-string selector value is rejected before schema coercion.
- [x] PR.PORT.1 — no capability YAML contains a machine-local absolute path.
- [x] PR.STDIO.1 — a parent-process secret is not present in a spawned stdio backend; explicitly configured backend env is present.
- [x] PR.RPC.1 — a direct-backend response carries the caller's original JSON-RPC id.

## Evidence (V = verified by running the command this session)
- V: `cargo fmt --check` — clean, exit 0
- V: `cargo clippy --all-targets -- -D warnings` — clean, 0 warnings, exit 0 (re-run after rebase against bumped deps)
- V: `cargo test` — 4004 passed, 0 failed, 0 failed suites (includes 16 path_selector tests, the stdio isolation scenario `backend_subprocess_receives_only_safe_and_explicit_environment`, and `backend_handler_preserves_callers_jsonrpc_id_on_success`)
- V: line-level review of every changed symbol via `difft` against parent commits; independent adversarial review of `path_selector` for SSRF/traversal/panic/validator-runtime consistency — no material defect found
- V: rebased onto current `origin/main` (Dependabot bumps #385–#390); test + clippy re-verified against the bumped dependencies
- I: no committed capability consumes `path_selector` yet — feature lands ahead of consumers (design intent, not a gap)

## Notes
- No committed capability consumes `path_selector` yet; the feature lands ahead of consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
