### PR TITLE
fix(failsafe): make max_attempts mean attempts, not retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`failsafe.retry.max_attempts` now means attempts, not retries.** It was
+  passed straight to `backon`, which counts retries, so every backend made
+  `max_attempts + 1` calls: a configured `3` produced four, and the shipped
+  default of `3` has always meant four.
+
+  The two user-facing statements of this setting already contradicted each
+  other — `examples/gateway-full.yaml` documented it as "Total attempts
+  (1 original + 2 retries)" while the struct doc said "Maximum retry attempts".
+  The code now matches the example and the name.
+
+  **Action required if you tuned around the old behaviour:** backends make one
+  fewer call per request than before. Raise `max_attempts` by one to keep the
+  previous number of calls. `max_attempts: 0` clamps to a single attempt rather
+  than none.
+
+
 ## [3.3.2] - 2026-07-15
 
 ### Fixed

--- a/gateway.example.yaml
+++ b/gateway.example.yaml
@@ -33,7 +33,7 @@ failsafe:
     reset_timeout: 30s
   retry:
     enabled: true
-    max_attempts: 3
+    max_attempts: 3               # Total attempts (1 original + 2 retries)
     initial_backoff: 0s
     max_backoff: 10s
     multiplier: 2.0

--- a/src/config/features/failsafe.rs
+++ b/src/config/features/failsafe.rs
@@ -76,7 +76,15 @@ impl Default for CircuitBreakerConfig {
 pub struct RetryConfig {
     /// Enable retries.
     pub enabled: bool,
-    /// Maximum retry attempts.
+    /// Maximum number of ATTEMPTS, counting the first one.
+    ///
+    /// `3` means three calls: the original plus two retries. This is what
+    /// `examples/gateway-full.yaml` has always documented and what the name
+    /// says; the implementation used to pass the value straight to `backon`,
+    /// which counts RETRIES, so a configured 3 produced four calls.
+    ///
+    /// `0` clamps to a single attempt rather than none — a backend that never
+    /// sends the request at all is not what a retry setting is asking for.
     pub max_attempts: u32,
     /// Initial backoff duration.
     #[serde(with = "crate::config::humantime_serde")]

--- a/src/failsafe/retry.rs
+++ b/src/failsafe/retry.rs
@@ -47,7 +47,16 @@ impl RetryPolicy {
             .with_min_delay(self.initial_backoff)
             .with_max_delay(self.max_backoff)
             .with_factor(self.multiplier as f32)
-            .with_max_times(self.max_attempts as usize)
+            // backon counts RETRIES, not attempts: `with_max_times(n)` runs one
+            // initial call plus n retries. Passing `max_attempts` straight
+            // through therefore gave `max_attempts + 1` calls, so an operator
+            // configuring `max_attempts: 3` silently got four. Subtract one so
+            // the setting means what its name says.
+            //
+            // `max_attempts: 0` is degenerate; it clamps to a single attempt
+            // rather than none, because a request that is never sent at all is
+            // never what the operator meant by a retry setting.
+            .with_max_times(self.max_attempts.saturating_sub(1) as usize)
     }
 }
 
@@ -89,4 +98,64 @@ fn is_retryable(error: &Error) -> bool {
         error,
         Error::Transport(_) | Error::BackendTimeout(_) | Error::Http(_) | Error::Io(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn policy(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy {
+            enabled: true,
+            max_attempts,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+            multiplier: 1.0,
+        }
+    }
+
+    /// Counts how many times the operation is actually invoked for a policy
+    /// that always fails with a retryable error.
+    async fn invocations_for(max_attempts: u32) -> usize {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::clone(&calls);
+        let result: Result<(), Error> = with_retry(&policy(max_attempts), "test", move || {
+            let seen = Arc::clone(&seen);
+            async move {
+                seen.fetch_add(1, Ordering::SeqCst);
+                Err(Error::Transport("always fails".to_string()))
+            }
+        })
+        .await;
+        assert!(result.is_err(), "fixture must exhaust every attempt");
+        calls.load(Ordering::SeqCst)
+    }
+
+    // `max_attempts` must mean attempts, not retries.
+    //
+    // backon's `with_max_times(n)` runs one initial call plus n retries, so
+    // passing the setting through unchanged gave `max_attempts + 1` calls: an
+    // operator asking for 3 got 4. That also silently inflated every duration
+    // derived from the setting.
+    #[tokio::test]
+    async fn max_attempts_is_the_total_number_of_calls() {
+        assert_eq!(invocations_for(1).await, 1, "1 attempt means no retries");
+        assert_eq!(invocations_for(2).await, 2);
+        assert_eq!(
+            invocations_for(3).await,
+            3,
+            "the shipped default: three attempts, not four"
+        );
+    }
+
+    // Degenerate config still sends the request once. Zero attempts would mean
+    // a configured backend that never talks to anything, which is never what a
+    // retry setting is asking for.
+    #[tokio::test]
+    async fn zero_attempts_still_sends_the_request_once() {
+        assert_eq!(invocations_for(0).await, 1);
+    }
 }


### PR DESCRIPTION
`backon` counts **retries**: `with_max_times(n)` runs one initial call plus n retries. `max_attempts` was passed straight through, so every backend made `max_attempts + 1` calls.

An operator configuring `max_attempts: 3` got four, and the shipped default of 3 has always meant 4.

Fixed by keeping the name and correcting the logic, because the name is the part that reaches users and "attempts" is what it should have meant. `max_attempts: 0` clamps to a single attempt rather than none — a backend that never sends the request at all is not what a retry setting is asking for.

## ⚠️ Behaviour change

Backends now make **one fewer call per request** than before. Deployments relying on the extra attempt should raise `max_attempts` by one.

## Evidence

`max_attempts_is_the_total_number_of_calls` counts actual invocations against an always-failing operation for 1, 2 and 3. Verified against the previous implementation: passing the setting through unchanged fails it at `1 attempt means no retries` (2 vs 1). `zero_attempts_still_sends_the_request_once` pins the degenerate case.

No existing test encoded the old behaviour — checked before changing it.

`cargo test --lib` 3449 passed / 0 failed; `cargo clippy --all-targets --all-features` clean.

## Why this is its own PR

Surfaced while checking a review finding on #392, where a duration derived from this setting inherited the off-by-one. Split out because the defect is in the retry layer, it changes operator-visible behaviour, and it deserves its own release note rather than being buried in a feature branch.

Second of a four-branch stack. Targets #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)