### PR TITLE
feat(backend): stop_when_idle_for — release backend processes the gateway started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous number of calls. `max_attempts: 0` clamps to a single attempt rather
   than none.
 
+- **A config-file reload now logs once, on completion, instead of twice.** The
+  file watcher had its own copy of the reload sequence, and that copy logged
+  `Config reload: applying patch` with the change summary before applying and a
+  bare `Config reload: complete` afterwards. The watcher now runs the same
+  reload used by the meta-tool and the admin UI, so a single line is emitted
+  when the reload finishes, carrying the same change summary plus whether a
+  restart is required. **If you grep logs for `applying patch`, that string is
+  gone**; match on `Config reload: complete` and read the `changes` field. A
+  reload that finds nothing to do logs at debug level, as before.
+
 - **Helm charts track the 3.4.0 release.** `deploy/helm/mcp-gateway` and
   `deploy/helm/mcp-gateway-crds` `appVersion` and the default image `tag` move
   to `3.4.0`; both chart `version`s go to `0.1.2` for republishing. Bumped
@@ -127,9 +137,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Concurrent config reloads could orphan a backend process (#397).** A reload
   stops a modified backend and then registers its replacement, and registration
-  replaces by name. Nothing serialized reloads, and three paths can trigger one
+  replaces by name. Nothing serialized reloads, and four paths can trigger one
   at the same time: the `gateway_reload_config` meta-tool, the admin UI reload
-  button, and every admin UI backend edit. Two reloads racing could each
+  button, every admin UI backend edit, and the config-file watcher that fires
+  when the file changes on disk. Two reloads racing could each
   register a replacement; the second registration discarded the first, and if
   ordinary traffic had started that first replacement in the gap, its child
   process was left running with nothing holding a handle to it — the exact leak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous number of calls. `max_attempts: 0` clamps to a single attempt rather
   than none.
 
+### Changed
+
+- **Helm charts track the 4.0.0 release.** `deploy/helm/mcp-gateway` and
+  `deploy/helm/mcp-gateway-crds` `appVersion` and the default image `tag` move
+  to `4.0.0`; both chart `version`s bumped to `0.2.0` for republishing. Bumped
+  in the same commit as the crate version rather than at release time, so the
+  repository never describes a 4.0.0 gateway that Helm would install as 3.3.2.
+
+### Removed
+
+- **`BackendConfig::idle_timeout` removed** (Rust API only; config files unaffected). The field was
+  parsed, documented in `examples/gateway-full.yaml` as "Hibernate after 5 min
+  idle", and read by exactly one thing in the codebase: a `Debug` formatter.
+  Nothing enforced it. Operators set it in good faith — one real config carried
+  `idle_timeout: 10m` on a stdio backend whose child then ran for over three days
+  and burned 10.4 CPU-hours.
+
+  Two attempts to implement it were reviewed and rejected. The blocker is not
+  difficulty: the name spans stdio child-process lifetime, per-user session TTL,
+  HTTP connection pooling, and remote scale-to-zero. Closing an HTTP client
+  transport does not scale down the service behind it, so no single
+  implementation can be correct for every transport.
+
+  **Impact on existing configs: none at load time.** Config parsing tolerates
+  extra keys, so files carrying `idle_timeout` keep loading unchanged. The
+  gateway now logs a warning naming the key so its inertness is visible rather
+  than silent. Note that any command which rewrites the config will drop the key
+  along with surrounding comments, since the writer re-serialises from memory —
+  delete it by hand first if you care about the comments.
+
+  **Impact on API consumers:** code constructing `BackendConfig` with a struct
+  literal that sets `idle_timeout` will no longer compile. Remove the field.
+
+  **Why this is a major bump.** Removing a `pub` field from `BackendConfig` is
+  an incompatible change to the Rust library API, and 3.3.2 was published with
+  an unqualified claim of SemVer adherence — so a consumer on a caret range
+  would receive the removal and fail to compile. Zero reverse dependencies on
+  crates.io shows that nobody HAS broken, not that breaking is permitted, and a
+  stability policy published in this same release can only bind releases after
+  it. Both arguments for calling this minor were tried and rejected in review;
+  the honest answer is 4.0.0, and on a binary product with no known library
+  consumers the cost of that is essentially the number itself.
+
+  The versioned surfaces are unaffected either way: configs carrying the key
+  keep loading, and no command changes behaviour. The new **Versioning and
+  stability** section in the README states the scope going forward — SemVer
+  covers the CLI and the config format, not the Rust library API — so a future
+  removal of this kind will not need a major bump. Embedders should pin an
+  exact version.
+
+  **A replacement is planned: `stop_when_idle_for` (#392).** It does what
+  `idle_timeout` claimed to do — stop a backend process the gateway started once
+  it has been unused for a given time, and restart it on the next request — but
+  scoped correctly. It is valid only where the gateway owns the process
+  lifecycle (a backend with a `command`), and is rejected at config load for
+  externally managed HTTP endpoints, because closing a client connection does
+  not stop a server the gateway did not start. Local HTTP MCP servers are
+  included in that exclusion: locality does not grant ownership.
+
+  It also introduces a third health state. A backend stopped on purpose is
+  neither healthy nor failed, and without `Dormant` a sleeping backend trips its
+  own circuit breaker and shows as degraded.
 
 ## [3.3.2] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,9 +143,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed with `Failed to replace config file: No such file or directory`. A
   test that runs eight concurrent saves reproduces it on the first iteration.
   Temp filenames are now unique per write, and the write happens inside the
-  same lock as the reload, so a save reloads its own bytes. The bug predates
-  this release; it is fixed here because the reload work is what made the
-  boundary visible.
+  same lock as the reload, so a save reloads its own bytes.
+
+  The same symptom had a second cause one layer up: each admin UI save read the
+  whole config, changed one backend, and wrote the whole thing back, and the
+  read happened before the lock. Two saves therefore both started from the
+  pre-edit config, and the second wrote the first person's change out of
+  existence while telling both callers it had saved. Adding, removing, and
+  editing a backend now do the read, the change, the write, and the reload
+  under one lock, so an edit that waits its turn builds on what it waited for.
+  A test queues one edit behind another and fails if the queued edit erases it.
+
+  Both bugs predate this release; they are fixed here because the reload work
+  is what made the boundary visible.
 
 - **Concurrent config reloads could orphan a backend process (#397).** A reload
   stops a modified backend and then registers its replacement, and registration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The deployment guide said the Prometheus endpoint was off by default.** It
+  has been on in a default build, and it is unauthenticated, so an operator
+  following the guide could be exposing `/metrics` without knowing. The feature
+  table now says so and points at the section explaining how to keep it off the
+  public internet.
+
+  The same section now lists `mcp_backend_idle_stop_close_failures`, the counter
+  `stop_when_idle_for` raises when a backend refuses to shut down, together with
+  the alert rule to watch it and what an operator does when it fires. A backend
+  that will not stop can leave its child process alive, and until now nothing
+  told anyone that had happened.
+
 - **Two admin UI config edits at once could lose one of them silently.** Saving
   a config wrote the file first and took the reload lock afterwards, and every
   save on Unix used the same temp filename, `<config>.tmp`. Two saves arriving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.4.0] - 2026-07-27
 
 ### Added
 
@@ -58,8 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fewer call per request than before. Raise `max_attempts` by one to keep the
   previous number of calls. `max_attempts: 0` clamps to a single attempt rather
   than none.
-
-### Changed
 
 - **Helm charts track the 3.4.0 release.** `deploy/helm/mcp-gateway` and
   `deploy/helm/mcp-gateway-crds` `appVersion` and the default image `tag` move
@@ -135,9 +133,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   register a replacement; the second registration discarded the first, and if
   ordinary traffic had started that first replacement in the gap, its child
   process was left running with nothing holding a handle to it — the exact leak
-  `stop_when_idle_for` exists to prevent. Reload transactions now hold a lock
-  for the whole patch, so one reload's stop-then-register completes before the
-  next one's stop begins.
+  `stop_when_idle_for` exists to prevent. A reload now holds a lock across the
+  whole transaction — reading the config file, comparing it against the live
+  one, applying the difference, and publishing the result — so the next reload
+  compares against a config that already includes the previous one's work.
+  Holding the lock only around the apply step is not enough: both reloads would
+  have already decided "backend added" against the same stale live config
+  before they queued, and both would still register.
 
 - **Duration parsing rejected every `ms` value.** The parser tested the `"s"`
   suffix before `"ms"`, so `100ms` took the seconds branch and failed to parse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Helm charts track the 4.0.0 release.** `deploy/helm/mcp-gateway` and
+- **Helm charts track the 3.4.0 release.** `deploy/helm/mcp-gateway` and
   `deploy/helm/mcp-gateway-crds` `appVersion` and the default image `tag` move
-  to `4.0.0`; both chart `version`s bumped to `0.2.0` for republishing. Bumped
+  to `3.4.0`; both chart `version`s go to `0.1.2` for republishing. Bumped
   in the same commit as the crate version rather than at release time, so the
-  repository never describes a 4.0.0 gateway that Helm would install as 3.3.2.
+  repository never describes a 3.4.0 gateway that Helm would install as 3.3.2.
 
 ### Removed
 
@@ -92,22 +92,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Impact on API consumers:** code constructing `BackendConfig` with a struct
   literal that sets `idle_timeout` will no longer compile. Remove the field.
 
-  **Why this is a major bump.** Removing a `pub` field from `BackendConfig` is
-  an incompatible change to the Rust library API, and 3.3.2 was published with
-  an unqualified claim of SemVer adherence — so a consumer on a caret range
-  would receive the removal and fail to compile. Zero reverse dependencies on
-  crates.io shows that nobody HAS broken, not that breaking is permitted, and a
-  stability policy published in this same release can only bind releases after
-  it. Both arguments for calling this minor were tried and rejected in review;
-  the honest answer is 4.0.0, and on a binary product with no known library
-  consumers the cost of that is essentially the number itself.
+  **Why this is a minor bump and not a major one.** Removing a `pub` field is
+  an incompatible change to the Rust library API, and that argues for 4.0.0.
+  Two things argue the other way and win. The field was dead: setting it did
+  nothing, so no behaviour changes for anyone. And the versioned surface of this
+  project is the CLI and the config format, not the Rust library API — the crate
+  ships a binary, the `pub` types exist for modularity and testing, and
+  crates.io reports zero reverse dependencies. That scope is now stated
+  explicitly in the README's **Versioning and stability** section rather than
+  left to be inferred, which is the part that was genuinely missing before.
+
+  The counter-argument was taken seriously: a policy published in this release
+  cannot retroactively bind the promise made in 3.3.2, and zero reverse
+  dependencies shows nobody HAS broken, not that breaking is permitted. It loses
+  on cost. A major number spent on removing a field that never did anything
+  makes every future major number mean less. Embedders should pin an exact
+  version.
 
   The versioned surfaces are unaffected either way: configs carrying the key
-  keep loading, and no command changes behaviour. The new **Versioning and
-  stability** section in the README states the scope going forward — SemVer
-  covers the CLI and the config format, not the Rust library API — so a future
-  removal of this kind will not need a major bump. Embedders should pin an
-  exact version.
+  keep loading, and no command changes behaviour.
 
   **A replacement is planned: `stop_when_idle_for` (#392).** It does what
   `idle_timeout` claimed to do — stop a backend process the gateway started once
@@ -124,9 +127,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Concurrent config reloads could orphan a backend process (#397).** A reload
+  stops a modified backend and then registers its replacement, and registration
+  replaces by name. Nothing serialized reloads, and three paths can trigger one
+  at the same time: the `gateway_reload_config` meta-tool, the admin UI reload
+  button, and every admin UI backend edit. Two reloads racing could each
+  register a replacement; the second registration discarded the first, and if
+  ordinary traffic had started that first replacement in the gap, its child
+  process was left running with nothing holding a handle to it — the exact leak
+  `stop_when_idle_for` exists to prevent. Reload transactions now hold a lock
+  for the whole patch, so one reload's stop-then-register completes before the
+  next one's stop begins.
+
 - **Duration parsing rejected every `ms` value.** The parser tested the `"s"`
   suffix before `"ms"`, so `100ms` took the seconds branch and failed to parse
-  `100m` as an integer. Affected every duration field in the config.
+  `100m` as an integer. Affected every duration field in the config. Values
+  using `ms` failed the config load outright rather than being misread, so no
+  config that previously loaded changes meaning.
 
 ## [3.3.2] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`stop_when_idle_for`: release backend processes the gateway started, after
+  they go unused (#392).** The gateway starts backends lazily but never stopped
+  one once started, so every backend touched even once stayed resident for the
+  life of the process. Measured on a six-day-uptime machine: `codex` held 37 MB
+  for 21 hours to do 1.8 seconds of work; `trvl` 67 MB for 11.6 hours to do 7.6
+  seconds.
+
+  ```yaml
+  backends:
+    tavily:
+      command: "npx -y tavily-mcp@0.1.4"
+      stop_when_idle_for: 5m
+  ```
+
+  Valid **only for a backend the gateway starts itself** — one declared with a
+  `command`. For a backend reached over a URL the gateway can close its client
+  connection, but that does not stop the server on the other end, so the setting
+  is **rejected at config load** rather than silently accepted. Locality does not
+  grant ownership: a local HTTP MCP server on `127.0.0.1` is still not ours to
+  stop. Absent means never stop, so upgrading changes no behaviour.
+
+  Configurable per backend in the admin panel, which offers the control only
+  where it applies and refuses it with an explanation elsewhere.
+
+  Adds a third lifecycle state. A backend stopped on purpose is neither healthy
+  nor failed: `Dormant` does not trip or heal a circuit breaker and is not probed
+  by the health loop, so a sleeping backend no longer reports as degraded. A real
+  fault still wins — an open breaker reports `Unhealthy` even for a backend that
+  opted into stopping.
+
+  In-flight work is refused rather than interrupted: a sweep that finds a request
+  running declines, and the next one retries.
+
 ### Changed
 
 - **`failsafe.retry.max_attempts` now means attempts, not retries.** It was
@@ -86,6 +121,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It also introduces a third health state. A backend stopped on purpose is
   neither healthy nor failed, and without `Dormant` a sleeping backend trips its
   own circuit breaker and shows as degraded.
+
+### Fixed
+
+- **Duration parsing rejected every `ms` value.** The parser tested the `"s"`
+  suffix before `"ms"`, so `100ms` took the seconds branch and failed to parse
+  `100m` as an integer. Affected every duration field in the config.
 
 ## [3.3.2] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two admin UI config edits at once could lose one of them silently.** Saving
+  a config wrote the file first and took the reload lock afterwards, and every
+  save on Unix used the same temp filename, `<config>.tmp`. Two saves arriving
+  together therefore wrote the same temp file: whichever renamed first shipped
+  the other's bytes while reporting its own edit saved, and the second rename
+  failed with `Failed to replace config file: No such file or directory`. A
+  test that runs eight concurrent saves reproduces it on the first iteration.
+  Temp filenames are now unique per write, and the write happens inside the
+  same lock as the reload, so a save reloads its own bytes. The bug predates
+  this release; it is fixed here because the reload work is what made the
+  boundary visible.
+
 - **Concurrent config reloads could orphan a backend process (#397).** A reload
   stops a modified backend and then registers its replacement, and registration
   replaces by name. Nothing serialized reloads, and four paths can trigger one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.3.2"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "4.0.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.3.2"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "4.0.0"
+version = "3.4.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/README.md
+++ b/README.md
@@ -472,6 +472,23 @@ Reference: [Anthropic SKILL.md spec](https://docs.claude.com/en/docs/claude-code
 
 **Tools not appearing?** Verify the backend is running (`gateway_list_servers`). Tool lists are cached for 5 minutes.
 
+## Versioning and stability
+
+This project follows [Semantic Versioning](https://semver.org/) over its
+**product surface**: the CLI, and the configuration file format. Changes to
+either are versioned accordingly — a config key that stops being accepted, or a
+command that changes behaviour, is a breaking change.
+
+**The Rust library API is not part of that surface.** Types are `pub` for
+modularity and testing, not as a supported embedding API, and they may change
+in any release. The crate ships a binary; at the time of writing crates.io
+reports zero reverse dependencies. If you embed the library, pin an exact
+version (`=4.0.0`) rather than a caret range.
+
+This is stated explicitly because "removing a `pub` field" and "breaking a
+supported API" are only the same thing when the API is supported. Here it is
+not, and that needs to be published rather than assumed.
+
 ## Contributing
 
 1. Fork and branch (`git checkout -b feature/your-feature`)

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ command that changes behaviour, is a breaking change.
 modularity and testing, not as a supported embedding API, and they may change
 in any release. The crate ships a binary; at the time of writing crates.io
 reports zero reverse dependencies. If you embed the library, pin an exact
-version (`=4.0.0`) rather than a caret range.
+version (`=3.4.0`) rather than a caret range.
 
 This is stated explicitly because "removing a `pub` field" and "breaking a
 supported API" are only the same thing when the API is supported. Here it is

--- a/benchmarks/BENCHMARK-RECOVERY.md
+++ b/benchmarks/BENCHMARK-RECOVERY.md
@@ -1,0 +1,90 @@
+# Capacity Benchmark — Recovered State (post-incident 2026-07-19)
+
+The uncommitted benchmark files (METHODOLOGY-v2.md, capacity_bench.py,
+e2e_token_bench.py, capacity_results.json, m5_results.json,
+discoverability_results.json, live_footprint.*) were lost in the 2026-07-18
+data-loss event (never committed). This document reconstructs their essential
+state from session context so the work can resume. **Commit this file.**
+
+## Axis (corrected twice with the operator)
+
+The product's value is CONTEXT-WINDOW CAPACITY, not per-task token/dollar
+throughput. Unused tool schemas are NOT resident; they load on demand via
+search→invoke. An earlier throughput framing ("gateway is 37.7% more expensive")
+was WITHDRAWN as the wrong axis.
+
+Four effects, priority order:
+1. Resident footprint (headline): gateway surface is ~flat as N grows; eager
+   loading is linear.
+2. Per-request carrying cost: resident schemas are re-billed every request.
+3. Compaction avoidance: idle schemas shrink working space → auto-compact sooner.
+4. Tool search = minor, transient overhead (do not headline).
+
+## Measured numbers (PROVISIONAL — see GPT BLOCK below)
+
+Resident footprint, YAML-projection proxy, real Anthropic tokenizer:
+| N | Eager (direct) | Gateway README-16 | Savings | Gateway Code-Mode-2 | Savings |
+|---:|---:|---:|:--:|---:|:--:|
+| 10  | ~4,828  | 3,039 | 37% | 699 | 86% |
+| 50  | ~18,489 | 3,039 | 84% | 699 | 96% |
+| 100 | ~35,214 | 3,039 | 91% | 699 | 98% |
+Per-tool median ~371 tok (real capability YAMLs). Gateway surface flat.
+
+- Per-request carrying cost: ~1.6M tokens of window-pressure avoided over a
+  50-request session at N=100.
+- Compaction: ~+21 turns runway at N=100; ~1 event/500 turns avoided
+  (assumptions W=200k, f=0.85, 1500 tok/turn — present as a sensitivity band).
+- Tool-search overhead: +1.67 turns/task, ~1,800-tok transient droppable payload.
+- Crossover / payback: ~8 tools (README-16) or ~2 tools (Code-Mode) = LESS THAN
+  ONE typical ~10-12-tool MCP server.
+- M5 accuracy: gateway search→invoke reached the right tool 4/4, including
+  adversarial synonym-gap tasks.
+
+## Native-client comparison (eager vs Claude Code native deferral vs gateway)
+
+- vs EAGER clients: gateway saves ~91% resident footprint at N=100. Real, large.
+- vs NATIVELY-DEFERRING client (Claude Code 2.x, names-only): footprint PARITY,
+  not a win — names-only (~743 tok at N=100) is actually LOWER than gateway
+  README-16 (3,039). Against such clients the gateway's value is aggregation,
+  routing/ranking, policy/governance, and cross-client reach — NOT footprint.
+- DISCOVERABILITY (operator's key follow-up, MEASUREMENT INTERRUPTED by incident):
+  names-only deferral has a WEAK retrieval key (tool names only) — may miss a
+  tool whose name doesn't match the task, or forget tools at scale. The gateway's
+  SEMANTIC search bridges the synonym gap. Hypothesis: gateway wins on
+  discoverability even where footprint is parity. 3C test (names-only vs gateway
+  semantic search on synonym-gap tasks, N=50/100) was RUNNING when data was lost.
+
+## GPT-5.6-sol adversarial verdict: BLOCK (must fix before backing a public claim)
+
+1. BLOCKING — M1 counts a name+description+inputSchema YAML projection, NOT the
+   actual serialized `Tool` objects a client receives (which also carry
+   outputSchema, annotations, titles). Omissions differ per arm → direction of
+   ratio error unknown. FIX: measure the real serialized payload from the live
+   gateway (127.0.0.1:39401, ~91+ tools incl private caps) — this was the
+   in-flight "live-footprint" task.
+2. MAJOR — "~370 tok/tool median" is a median of cumulative means, not a real
+   per-tool median (~242).
+3. MAJOR — M3 "1 event avoided" is assumption-driven; present as a band.
+4. MAJOR — Arm-2 native estimates aren't bounds; "parity" doesn't follow from a
+   743–7,045 range.
+5. MAJOR — M2 conflates cumulative throughput with capacity.
+6. MAJOR — prose numbers drift from JSON (3,035 vs 3,039; ~9 vs ~8 crossover).
+7. MAJOR — §4 asserts eager clients are "the majority" without evidence; 89%
+   depends on avg tool size (~80% at 150 tok/tool). Scope to capacity axis +
+   eager clients only.
+8. MINOR — exact flatness (3,039) computed once, copied across N, not measured.
+
+## Open work (resume order)
+
+1. Source-faithful M1: dump the live gateway's real serialized Tool payload
+   (eager) vs meta-surface, count with real tokenizer. Endpoint 127.0.0.1:39401.
+   Keep private schemas out of committed files (aggregate counts only).
+2. Complete the 3C discoverability measurement (names-only vs semantic search).
+3. Apply GPT fixes 2–8; regenerate prose from JSON.
+4. Re-run GPT adversarial pass to clear the BLOCK.
+5. Open the benchmark PR; deprecate the old char/3.5 token_savings.py.
+6. Only then consider whether the public "~89%" README claim needs qualifying
+   (capacity axis, vs eager clients) — a separate ratified decision.
+
+The public claim's phrasing ("flat tool-token cost as servers scale") is
+defensible on the capacity axis; the exact % needs the source-faithful rerun.

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   to author these resources as typed config. Helm does not manage CRD
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
-version: 0.2.0
-appVersion: "4.0.0"
+version: 0.1.2
+appVersion: "3.4.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:
   - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   to author these resources as typed config. Helm does not manage CRD
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
-version: 0.1.1
-appVersion: "3.3.2"
+version: 0.2.0
+appVersion: "4.0.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:
   - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -3,8 +3,8 @@ name: mcp-gateway
 description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
-version: 0.1.1
-appVersion: "3.3.2"
+version: 0.2.0
+appVersion: "4.0.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:
   - https://github.com/MikkoParkkola/mcp-gateway

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -3,8 +3,8 @@ name: mcp-gateway
 description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
-version: 0.2.0
-appVersion: "4.0.0"
+version: 0.1.2
+appVersion: "3.4.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:
   - https://github.com/MikkoParkkola/mcp-gateway

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mikkoparkkola/mcp-gateway
   # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
   # When `digest` is set it takes precedence over `tag`.
-  tag: "3.3.2"
+  tag: "4.0.0"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mikkoparkkola/mcp-gateway
   # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
   # When `digest` is set it takes precedence over `tag`.
-  tag: "4.0.0"
+  tag: "3.4.0"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -379,14 +379,18 @@ memory pressure on the host, days later.
 # prometheus rules
 - alert: McpBackendIdleStopCloseFailures
   expr: increase(mcp_backend_idle_stop_close_failures[15m]) > 0
-  for: 5m
   labels: { severity: warning }
   annotations:
     summary: "Backend {{ $labels.backend }} did not stop cleanly when idle"
 ```
 
-Any increase is worth knowing about, so the threshold is zero rather than a rate.
-`for: 5m` keeps a single transient close from paging anyone.
+Every occurrence is worth knowing about, because each one may be a process that
+outlives the gateway's tracking and never comes back on its own. So the
+threshold is zero rather than a rate, and there is no `for` clause: the
+expression stays true for the whole 15-minute window after a single increment,
+which means `for` would delay the notification without ever suppressing an
+isolated failure. Warning rather than page — the damage is one leaked process,
+not an outage.
 
 When it fires: check for an orphaned child process of the gateway
 (`pgrep -P $(pgrep -f mcp-gateway)`) and kill what the gateway no longer tracks.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,11 +29,11 @@ The release profile applies: `lto = "thin"`, `codegen-units = 1`, `panic = "abor
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `webui` | Yes | Embedded web dashboard at `/ui` and `/dashboard` |
-| `metrics` | No | Prometheus metrics endpoint at `/metrics` |
+| `metrics` | Yes | Prometheus metrics endpoint at `/metrics`, unauthenticated (see [Prometheus Metrics](#prometheus-metrics)) |
 
 ```bash
-cargo build --release --features metrics       # Add metrics
-cargo build --release --no-default-features    # Minimal (no web UI)
+cargo build --release                          # Default features, including metrics
+cargo build --release --no-default-features    # Minimal (no web UI, no metrics)
 ```
 
 ## Single-Node Templates
@@ -354,13 +354,45 @@ Includes: timestamp, level, span context, backend name, request ID, latency, cir
 
 ### Prometheus Metrics
 
-Build with `--features metrics`, scrape `/metrics`:
+Included in a default build. Scrape `/metrics`. The endpoint is unauthenticated,
+because Prometheus scrapers do not send auth headers — keep it off the public
+internet with a firewall rule or a reverse-proxy allow-list.
 
 - `mcp_gateway_requests_total` -- count per backend/tool
 - `mcp_gateway_request_duration_seconds` -- latency histogram
 - `mcp_gateway_circuit_breaker_state` -- state gauge
 - `mcp_gateway_rate_limiter_rejections_total` -- rejection count
 - `mcp_gateway_active_connections` -- current connections
+- `mcp_backend_idle_stop_close_failures` -- per backend, counts backends stopped
+  for idleness that did not shut down cleanly (see below)
+
+#### Alerting on a backend that would not stop
+
+`stop_when_idle_for` stops a backend the gateway started once it goes unused. If
+that shutdown fails or runs past its budget, the gateway gives up on the close so
+the sweep keeps running, and increments `mcp_backend_idle_stop_close_failures`.
+The child process may still be alive. Nothing else reports this, so an
+unmonitored gateway leaks one process per occurrence and the first symptom is
+memory pressure on the host, days later.
+
+```yaml
+# prometheus rules
+- alert: McpBackendIdleStopCloseFailures
+  expr: increase(mcp_backend_idle_stop_close_failures[15m]) > 0
+  for: 5m
+  labels: { severity: warning }
+  annotations:
+    summary: "Backend {{ $labels.backend }} did not stop cleanly when idle"
+```
+
+Any increase is worth knowing about, so the threshold is zero rather than a rate.
+`for: 5m` keeps a single transient close from paging anyone.
+
+When it fires: check for an orphaned child process of the gateway
+(`pgrep -P $(pgrep -f mcp-gateway)`) and kill what the gateway no longer tracks.
+Then look at that backend's shutdown path — a server ignoring SIGTERM is the
+usual cause. Setting a longer `stop_when_idle_for` does not help; removing the
+setting for that backend stops the leak at the cost of keeping it resident.
 
 ### Live Statistics / Web Dashboard
 

--- a/examples/gateway-full.yaml
+++ b/examples/gateway-full.yaml
@@ -222,6 +222,13 @@ backends:
   #   description: "Web search via Tavily"
   #   enabled: true
   #   timeout: 30s
+  #   stop_when_idle_for: 5m      # Stop this backend after 5 min unused;
+  #                               # the next request restarts it. Valid ONLY for
+  #                               # a backend the gateway starts itself (one with
+  #                               # a `command`) - the gateway cannot stop a
+  #                               # server it did not start, so this is rejected
+  #                               # at config load for `http_url` backends,
+  #                               # including local ones. Omit it to never stop.
   #   env:
   #     TAVILY_API_KEY: "${TAVILY_API_KEY}"
   #   cwd: /tmp                   # Working directory (stdio only)

--- a/examples/gateway-full.yaml
+++ b/examples/gateway-full.yaml
@@ -222,7 +222,6 @@ backends:
   #   description: "Web search via Tavily"
   #   enabled: true
   #   timeout: 30s
-  #   idle_timeout: 300s          # Hibernate after 5 min idle
   #   env:
   #     TAVILY_API_KEY: "${TAVILY_API_KEY}"
   #   cwd: /tmp                   # Working directory (stdio only)

--- a/examples/servers.yaml
+++ b/examples/servers.yaml
@@ -42,7 +42,6 @@ backends:
     command: "npx -y @anthropic/mcp-server-tavily"
     description: "Web search via Tavily API"
     timeout: "30s"
-    idle_timeout: "5m"
     env:
       TAVILY_API_KEY: "${TAVILY_API_KEY}"
 

--- a/gateway.example.yaml
+++ b/gateway.example.yaml
@@ -52,7 +52,6 @@ backends:
     command: gitnexus mcp
     cwd: null
     protocol_version: null
-    idle_timeout: 300s
     timeout: 30s
     env: {}
     headers: {}
@@ -65,7 +64,6 @@ backends:
     command: /Users/mikko/github/trvl/bin/trvl mcp
     cwd: null
     protocol_version: null
-    idle_timeout: 300s
     timeout: 30s
     env: {}
     headers: {}
@@ -78,7 +76,6 @@ backends:
     command: npx -y @superhuman/mcp-mail
     cwd: null
     protocol_version: null
-    idle_timeout: 600s
     timeout: 60s
     env: {}
     headers: {}

--- a/src/backend/lifecycle.rs
+++ b/src/backend/lifecycle.rs
@@ -6,17 +6,16 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use dashmap::DashMap;
 use reqwest::Client;
 use tokio::sync::Semaphore;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
-use super::Backend;
 use super::cached_metadata::CachedMetadata;
-use super::pool::{PoolKey, PooledEntry, now_unix_secs};
+use super::pool::{PoolKey, PooledEntry};
+use super::{Backend, RestartOutcome};
 use crate::config::{BackendConfig, RuntimeConfig, TransportConfig};
 use crate::oauth::{OAuthClient, OAuthClientConfig, TokenStorage};
 use crate::runtime::{RuntimeLaunchCommand, RuntimeLaunchMode, RuntimePlan, RuntimeProviderKind};
@@ -140,6 +139,9 @@ impl Backend {
             last_used: std::sync::atomic::AtomicU64::new(0),
             semaphore: Semaphore::new(100), // Max concurrent requests
             request_count: std::sync::atomic::AtomicU64::new(0),
+            replaced_transport_cleanups: parking_lot::Mutex::new(super::CleanupState::default()),
+            lifecycle: tokio::sync::RwLock::new(()),
+            starts_in_flight: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -185,9 +187,13 @@ impl Backend {
         for _attempt in 0..MAX_RACE_RETRIES {
             let entry = self.pooled_entry(key);
 
-            // Update last-used clocks (backend-wide + per-slot for idle eviction).
-            self.last_used.store(now_unix_secs(), Ordering::Relaxed);
-            entry.touch();
+            // NOTE: deliberately does NOT touch the idle clocks. `last_used` means
+            // "when did a CLIENT last use this backend", and is written only by the
+            // request/notify paths in `ops.rs`. Touching it here is what made idle
+            // stopping unreachable in an earlier attempt: `health_probe` ->
+            // `ensure_started` -> here, on a 10s default health interval against a
+            // 300s deadline, refreshed the clock forever. The health loop kept every
+            // backend permanently warm and the feature was a silent no-op.
 
             {
                 let transport = entry.transport.read();
@@ -291,7 +297,31 @@ impl Backend {
     ///
     /// Returns an error if the transport fails to connect or initialize.
     async fn start_entry(&self, key: &PoolKey, entry: &PooledEntry) -> Result<Arc<dyn Transport>> {
+        // Held for the whole start. From the moment a process is spawned until
+        // it is either published or closed, shutdown must not consider itself
+        // finished - the process is alive either way.
+        let _in_flight = super::StartGuard::new(&self.starts_in_flight);
+
+        // Cheap early-out. The publish below is the authoritative check - it is
+        // ordered against shutdown's pool traversal, and this one is not - but
+        // spawning a process only to close it moments later is pure waste, and
+        // a caller that starts a backend after `stop()` has already returned
+        // would otherwise leave a child running for the length of a handshake.
+        if self.replaced_transport_cleanups.lock().stopping {
+            debug!(backend = %self.name, ?key, "Not starting: backend is stopped");
+            return Err(Error::BackendUnavailable(self.name.clone()));
+        }
+
         info!(backend = %self.name, ?key, "Starting backend transport");
+
+        // Whatever the reason for starting - a client request, a health-driven
+        // force_restart, warm start - this slot is no longer stopped-for-idleness.
+        // Clearing here rather than in `ensure_entry_started` is deliberate:
+        // `force_restart` calls this directly, and clearing only in the former
+        // left a restarted backend flagged dormant while actually running.
+        entry
+            .stopped_when_idle
+            .store(false, std::sync::atomic::Ordering::SeqCst);
 
         let transport: Arc<dyn Transport> = match &self.config.transport {
             TransportConfig::Stdio {
@@ -349,7 +379,37 @@ impl Backend {
             }
         };
 
-        *entry.transport.write() = Some(Arc::clone(&transport));
+        // Publishing is where shutdown has to be enforced, because this is the
+        // ONE place a transport becomes reachable - `ensure_entry_started`,
+        // warm start and `force_restart` all land here. Checking in the callers
+        // instead left the ordinary request path unguarded: a client could
+        // start a backend after `stop()` had walked the pool, and nothing would
+        // ever close that child.
+        //
+        // The check and the publish happen under the cleanup lock, which
+        // `stop()` also holds while it latches and takes every transport out.
+        // So the two are ordered: either this publishes first and shutdown's
+        // traversal finds it, or shutdown latches first and this refuses. There
+        // is no third case, which is what the previous check-then-publish could
+        // not say.
+        let refused = {
+            let cleanups = self.replaced_transport_cleanups.lock();
+            if cleanups.stopping {
+                true
+            } else {
+                *entry.transport.write() = Some(Arc::clone(&transport));
+                false
+            }
+        };
+        if refused {
+            warn!(
+                backend = %self.name,
+                "Backend shut down while this transport was starting; closing it \
+                 instead of publishing"
+            );
+            let _ = transport.close().await;
+            return Err(Error::BackendUnavailable(self.name.clone()));
+        }
 
         // Note: Tools are fetched lazily on first get_tools() call
         // We can't pre-cache here because get_tools() -> ensure_started() -> start()
@@ -500,24 +560,206 @@ impl Backend {
     /// Never returns `Err` today: individual slot-close failures are logged and
     /// the remaining slots are still drained. The `Result` is retained for
     /// forward compatibility and to match the registry's stop contract.
+    /// Concurrency contract: `stop()` is idempotent but NOT single-flight. Two
+    /// concurrent calls both latch `stopping` and both drain, and whichever
+    /// takes the handle list first is the one that waits - the other can return
+    /// while cleanup is still running. Callers wanting "everything is closed"
+    /// must not race their own shutdown calls. Sequential calls are harmless:
+    /// the second finds nothing left to do.
     pub async fn stop(&self) -> Result<()> {
+        /// How long shutdown waits for replaced transports whose callers have
+        /// not finished. Bounds SHUTDOWN, not a request: exceeding it detaches
+        /// the remaining cleanups rather than closing anything under a live
+        /// caller, so it cannot cut a request short.
+        const DRAIN_DEADLINE: Duration = Duration::from_secs(10);
+        /// How long shutdown waits to exclude a restart already in flight.
+        /// Sized above a typical backend start so an ordinary in-flight restart
+        /// finishes first, and finite so a hung one cannot hang shutdown.
+        const LIFECYCLE_WAIT: Duration = Duration::from_secs(15);
+
+        // Exclusive: waits for any restart already in progress to finish, and
+        // blocks any that has not yet started until the latch below is set.
+        //
+        // Bounded, because a restart holds this across `start_entry`, which runs
+        // to the backend's own init timeout - and if a start hangs past even
+        // that, an unbounded wait here would hang shutdown itself. Timing out
+        // gives up the exclusion and reopens the narrow race it prevents, which
+        // is the better of two bad outcomes at that point, so it is logged
+        // loudly rather than passed over.
+        let lifecycle_guard = tokio::time::timeout(LIFECYCLE_WAIT, self.lifecycle.write())
+            .await
+            .inspect_err(|_| {
+                warn!(
+                    backend = %self.name,
+                    wait_secs = LIFECYCLE_WAIT.as_secs(),
+                    "Restart still in flight after the shutdown wait; proceeding \
+                     without exclusion"
+                );
+            })
+            .ok();
+
+        // Latched BEFORE anything is torn down. Setting it later - after the
+        // pool has been walked - leaves a gap in which a restart finishing its
+        // start sees `stopping == false`, approves itself, and installs a
+        // transport into a slot shutdown has already visited and will not
+        // revisit. The child then survives a completed shutdown.
         info!(backend = %self.name, "Stopping backend");
 
-        // Take every slot's transport out first (dropping the parking_lot write
-        // guards) so no lock is held across the async close().
-        let transports: Vec<Arc<dyn Transport>> = self
-            .pool
-            .iter()
-            .filter_map(|entry| entry.value().transport.write().take())
-            .collect();
+        // Latch and empty the pool under ONE hold of the cleanup lock, which is
+        // the same lock `start_entry` publishes under. Latching first but
+        // traversing afterwards is not enough: a transport published between
+        // the two lands in a slot this traversal has already passed, and
+        // nothing revisits it. Holding across both makes "no more transports
+        // can appear" true at the moment the pool is emptied.
+        //
+        // No await inside - the closes happen after the guard is dropped.
+        let transports: Vec<Arc<dyn Transport>> = {
+            let mut cleanups = self.replaced_transport_cleanups.lock();
+            cleanups.stopping = true;
+            self.pool
+                .iter()
+                .filter_map(|entry| entry.value().transport.write().take())
+                .collect()
+        };
 
-        for transport in transports {
-            if let Err(e) = transport.close().await {
-                warn!(backend = %self.name, error = %e, "Failed to close pooled transport");
+        self.close_pooled_transports(transports, DRAIN_DEADLINE)
+            .await;
+
+        self.await_starts_in_flight(DRAIN_DEADLINE).await;
+
+        // Transports that `force_restart` replaced while they were in use are
+        // NOT in `pool`, so the loop above cannot see them. Their cleanup tasks
+        // own the only remaining reference and close them once their last
+        // caller lets go - but a detached task is dropped unrun when the
+        // runtime exits, which skips an HTTP backend's session DELETEs at the
+        // reload and shutdown boundaries where they matter most. So wait for
+        // them here.
+        //
+        // Bounded: a caller stuck forever would otherwise wedge shutdown, which
+        // is worse than abandoning one session. Past the deadline the remaining
+        // handles are dropped, which detaches those tasks rather than killing
+        // them - they may still finish if the runtime outlives this call - and
+        // the situation is logged either way.
+        let drain_until = tokio::time::Instant::now() + DRAIN_DEADLINE;
+        loop {
+            // Re-taken each pass on purpose. The health loop only checks its
+            // shutdown signal between ticks, so a `health_probe` already in
+            // flight can call `force_restart` and register a new cleanup WHILE
+            // this drain is running. Taking the list once would leave that last
+            // one undrained - the very case this drain exists for.
+            let pending: Vec<tokio::task::JoinHandle<()>> =
+                std::mem::take(&mut self.replaced_transport_cleanups.lock().handles);
+            if pending.is_empty() {
+                // An empty list is not "no more work": a restart still holding
+                // the lifecycle lock can register a cleanup after this take.
+                // Exclusivity is the test for that - if the write lock is
+                // available, no restart is in flight, so nothing more can
+                // arrive. (Already holding it means the same thing.)
+                let no_restart_in_flight =
+                    lifecycle_guard.is_some() || self.lifecycle.try_write().is_ok();
+                if no_restart_in_flight {
+                    break;
+                }
+                if tokio::time::Instant::now() >= drain_until {
+                    warn!(
+                        backend = %self.name,
+                        "Restart still in flight at the end of the shutdown drain; \
+                         its cleanup may not run"
+                    );
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                continue;
+            }
+
+            let remaining = drain_until.saturating_duration_since(tokio::time::Instant::now());
+            let timed_out = remaining.is_zero()
+                || tokio::time::timeout(remaining, async move {
+                    for handle in pending {
+                        let _ = handle.await;
+                    }
+                })
+                .await
+                .is_err();
+
+            if timed_out {
+                warn!(
+                    backend = %self.name,
+                    deadline_secs = DRAIN_DEADLINE.as_secs(),
+                    "Replaced transports still had live callers at shutdown; \
+                     abandoning their cleanup"
+                );
+                break;
             }
         }
 
         Ok(())
+    }
+
+    /// Close transports taken out of the pool, bounded as a STAGE.
+    ///
+    /// `close()` has no deadline of its own: `StdioTransport::close` waits on
+    /// the writer mutex, which a request blocked writing to a child that has
+    /// stopped reading can hold indefinitely, and HTTP closes its sessions one
+    /// after another. Without a bound here one wedged backend hangs gateway
+    /// shutdown forever - and stopping backends concurrently does not help,
+    /// because joining them waits for the slowest.
+    async fn close_pooled_transports(&self, transports: Vec<Arc<dyn Transport>>, budget: Duration) {
+        let until = tokio::time::Instant::now() + budget;
+        for transport in transports {
+            let remaining = until.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                warn!(
+                    backend = %self.name,
+                    "Ran out of time closing pooled transports; abandoning the rest"
+                );
+                return;
+            }
+            match tokio::time::timeout(remaining, transport.close()).await {
+                Ok(Err(error)) => {
+                    warn!(backend = %self.name, %error, "Failed to close pooled transport");
+                }
+                Err(_) => {
+                    warn!(
+                        backend = %self.name,
+                        "Timed out closing a pooled transport; abandoning it"
+                    );
+                }
+                Ok(Ok(())) => {}
+            }
+        }
+    }
+
+    /// Wait for starts that were already under way when shutdown began.
+    ///
+    /// Refusing to publish is not the whole guarantee: a start that has spawned
+    /// its child and is waiting on the MCP handshake owns a live process right
+    /// now, and the pool traversal cannot see it because it has not published.
+    /// Returning without this lets that process outlive shutdown for as long as
+    /// the handshake takes. At zero, every such start has resolved - published
+    /// into a pool already emptied, or refused and closed.
+    ///
+    /// Bounded, and this is the one case where shutdown's guarantee does not
+    /// hold: a start that never resolves is abandoned rather than allowed to
+    /// wedge the gateway. Its process is still closed when that start finally
+    /// finishes - late, and said out loud rather than quietly.
+    async fn await_starts_in_flight(&self, budget: Duration) {
+        let until = tokio::time::Instant::now() + budget;
+        while self
+            .starts_in_flight
+            .load(std::sync::atomic::Ordering::SeqCst)
+            > 0
+        {
+            if tokio::time::Instant::now() >= until {
+                warn!(
+                    backend = %self.name,
+                    "Backend start still in flight at the end of shutdown; its \
+                     process will outlive this call until that start resolves"
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     /// Check if backend is running (canonical shared slot connected).
@@ -547,25 +789,167 @@ impl Backend {
     /// # Errors
     ///
     /// Returns an error if the fresh transport fails to start or initialize.
-    pub async fn force_restart(&self) -> Result<()> {
+    /// Returns [`RestartOutcome::SkippedStopping`] - NOT an error - when the
+    /// backend is shutting down: nothing was rebuilt, and a caller reporting
+    /// "revived" on the strength of an `Ok` would be lying to its operator.
+    pub async fn force_restart(&self) -> Result<RestartOutcome> {
         // Rebuild only the canonical shared slot; per-user sessions are left
         // intact so one caller's health recovery cannot tear down another's
         // in-flight session (MIK-6735). The idle reaper reclaims per-user slots.
+        // Held for the whole restart so shutdown cannot interleave with it. See
+        // `Backend::lifecycle`: without this, the check below can pass before
+        // stop() latches, and the restart then registers a cleanup after the
+        // final drain or starts a child after teardown.
+        let _lifecycle = self.lifecycle.read().await;
+
+        // Refuse once shutdown has begun. `stop()` has already taken every
+        // transport out of the pool; restarting here would spawn a fresh child
+        // process (or a new upstream session) that nothing left alive will ever
+        // close, turning a shutdown into an orphan. The health loop only checks
+        // its shutdown signal between ticks, so a probe already in flight can
+        // reach this point during teardown.
+        if self.replaced_transport_cleanups.lock().stopping {
+            debug!(backend = %self.name, "Skipping force_restart: backend is stopping");
+            return Ok(RestartOutcome::SkippedStopping);
+        }
+
         let entry = self.pooled_entry(&PoolKey::Shared);
         let _guard = entry.start_lock.lock().await;
+
+        // Re-checked after the await. The lock above normally prevents shutdown
+        // from interleaving at all, but it is not the only line of defence:
+        // `stop()` bounds its wait for that lock, so it can proceed without it
+        // rather than hang forever. Correctness must not depend on having won
+        // the lock, only on this flag.
+        if self.replaced_transport_cleanups.lock().stopping {
+            debug!(backend = %self.name, "Abandoning force_restart: shutdown began while waiting");
+            return Ok(RestartOutcome::SkippedStopping);
+        }
         // Take the transport out and drop the RwLock write guard *before*
         // awaiting close() -- a parking_lot guard is not Send across an await.
-        let old = entry.transport.write().take();
+        // in_flight is read under that same guard so the answer cannot change
+        // between the check and the take.
+        let (old, busy) = {
+            let mut guard = entry.transport.write();
+            let busy = entry.in_flight.load(std::sync::atomic::Ordering::SeqCst) > 0;
+            (guard.take(), busy)
+        };
         if let Some(old) = old {
-            let _ = old.close().await;
+            if busy {
+                // Requests are executing against this transport right now.
+                // Closing it here kills a stdio child and tears down an HTTP
+                // session underneath a live caller, which is a worse failure
+                // than the one recovery is trying to fix.
+                //
+                // So close it exactly when its last user lets go, and never
+                // before. No deadline is imposed on that user: the two earlier
+                // attempts here both tried to answer "when is it safe?" with a
+                // timer and both were rejected - a fixed cap is arbitrary, and a
+                // cap derived from config is unsound because one logical attempt
+                // can re-handshake and retry in ways no formula sees.
+                self.close_after_last_owner(old);
+            } else {
+                let _ = old.close().await;
+            }
         }
-        self.start_entry(&PoolKey::Shared, &entry).await?;
-        Ok(())
+        // `start_entry` refuses to publish once shutdown has latched, so there
+        // is no window here in which a live transport can be left behind and
+        // nothing to take back. A start that failed for THAT reason is not a
+        // fault worth reporting as one.
+        match self.start_entry(&PoolKey::Shared, &entry).await {
+            Ok(_) => Ok(RestartOutcome::Rebuilt),
+            Err(error) => {
+                if self.replaced_transport_cleanups.lock().stopping {
+                    Ok(RestartOutcome::SkippedStopping)
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    /// Close a replaced transport the moment its last user releases it.
+    ///
+    /// [`Backend::force_restart`] cannot await this inline: it is the health
+    /// loop's recovery path, and the case it exists for is a WEDGED backend
+    /// whose in-flight request may never return, so blocking recovery on that
+    /// request would convert an interruption bug into a never-recovers bug. The
+    /// fresh transport is installed immediately and the old one is closed behind
+    /// it.
+    ///
+    /// **No deadline, deliberately.** Two earlier revisions capped this wait and
+    /// both were rejected in review: any cap closes the transport underneath a
+    /// request that is merely slower than the cap. The cap cannot be derived
+    /// either - a single logical attempt can re-handshake and retry (see
+    /// `HttpTransport`'s session-expiry path) in ways no formula predicts. So
+    /// this waits for the actual condition instead of a proxy for it.
+    ///
+    /// The `Arc` strong count is the drain signal, not `in_flight`: `in_flight`
+    /// counts requests against the SLOT, which new traffic keeps non-zero, while
+    /// the strong count tracks holders of THIS transport and reaches one (ours)
+    /// when the last in-flight caller is done.
+    ///
+    /// Precisely, and weaker than it may look: reaching one means no OTHER
+    /// strong reference exists at that instant, not that none can appear
+    /// afterwards. The stdio reader task holds a `Weak` and can still upgrade
+    /// between the check and `close()`, so `close()` may overlap a
+    /// `handle_response` call. That is benign - `handle_response` is
+    /// synchronous and only routes a reply to a pending receiver - and the
+    /// transport cannot be closed out from under a real caller, because a
+    /// caller's own `Arc` keeps the count above one for as long as it is
+    /// working. The guarantee is "no live caller", not "no future reference".
+    ///
+    /// Closing rather than merely dropping matters for HTTP: `close()` sends the
+    /// per-session DELETEs, and dropping skips them, abandoning upstream sessions
+    /// on every busy recovery with nothing guaranteeing the remote ever reclaims
+    /// them. stdio would be fine either way now that its reader task holds a
+    /// `Weak` (`kill_on_drop` reaps the child), but one path for both transports
+    /// is simpler than two.
+    ///
+    /// A holder that never releases keeps this task alive. That is the intended
+    /// trade - leaking one transport beats terminating a live request - and the
+    /// poll backs off to seconds and warns once so it stays cheap and visible
+    /// rather than silent.
+    fn close_after_last_owner(&self, old: Arc<dyn Transport>) {
+        const FIRST_POLL: Duration = Duration::from_millis(20);
+        const MAX_POLL: Duration = Duration::from_secs(5);
+        const WARN_AFTER: Duration = Duration::from_secs(300);
+
+        let name = self.name.clone();
+        let handle = tokio::spawn(async move {
+            let started = tokio::time::Instant::now();
+            let mut delay = FIRST_POLL;
+            let mut warned = false;
+
+            while Arc::strong_count(&old) > 1 {
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_POLL);
+
+                if !warned && started.elapsed() >= WARN_AFTER {
+                    warned = true;
+                    warn!(
+                        backend = %name,
+                        held_for_secs = started.elapsed().as_secs(),
+                        "Replaced transport still held long after recovery; \
+                         waiting rather than closing it under its holder"
+                    );
+                }
+            }
+
+            if let Err(error) = old.close().await {
+                warn!(backend = %name, %error, "Replaced transport failed to close cleanly");
+            }
+        });
+
+        // Drop handles for cleanups that already finished so a long-lived
+        // backend restarted many times does not accumulate them.
+        let mut pending = self.replaced_transport_cleanups.lock();
+        pending.handles.retain(|h| !h.is_finished());
+        pending.handles.push(handle);
     }
 
     /// Active health/recovery probe driven by the background health loop.
-    ///
-    /// This is the gateway's automatic equivalent of `gateway_revive_server`.
+    ///    /// This is the gateway's automatic equivalent of `gateway_revive_server`.
     /// Two properties make it actually recover a wedged backend, which the old
     /// `backend.request("ping")` health check could not:
     ///
@@ -585,6 +969,30 @@ impl Backend {
     /// or the `ping` call fails. The breaker is left for organic traffic to
     /// trip -- this probe never records failures, only recoveries.
     pub async fn health_probe(&self, timeout: Duration) -> Result<()> {
+        // Hold the transport for the whole probe WITHOUT claiming client activity.
+        // Without this the reaper can close the transport between the health
+        // loop's gate check and the probe's ping; the probe reads that as a fault
+        // and calls force_restart(), so an idle backend is stopped and instantly
+        // restarted. With a 10s health interval against a 60s sweep their ticks
+        // coincide regularly, which would make the feature a periodic no-op - the
+        // exact failure this change exists to correct.
+        let _lease = self.begin_internal_activity();
+
+        // A slot the reaper deliberately stopped is not a fault, and probing is
+        // not a reason to wake it. `stop_if_idle` records this flag under the
+        // same transport write guard that takes the transport, so by the time a
+        // lease can be claimed the flag is already visible: either this lease
+        // came first and the sweep declined, or the sweep completed and this
+        // check sees it. Without the bail, the probe's ensure_started() below
+        // would restart the process the sweep just released.
+        if self
+            .shared_entry()
+            .stopped_when_idle
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Ok(());
+        }
+
         // `ensure_started` now respawns reliably because `is_connected()` does a
         // real liveness check (Fix C).
         if let Err(e) = self.ensure_started().await {

--- a/src/backend/lifecycle.rs
+++ b/src/backend/lifecycle.rs
@@ -141,6 +141,9 @@ impl Backend {
             request_count: std::sync::atomic::AtomicU64::new(0),
             replaced_transport_cleanups: parking_lot::Mutex::new(super::CleanupState::default()),
             lifecycle: tokio::sync::RwLock::new(()),
+            stop_once: tokio::sync::Mutex::new(()),
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            budgets: super::ShutdownBudgets::default(),
             starts_in_flight: std::sync::atomic::AtomicUsize::new(0),
         }
     }
@@ -560,22 +563,38 @@ impl Backend {
     /// Never returns `Err` today: individual slot-close failures are logged and
     /// the remaining slots are still drained. The `Result` is retained for
     /// forward compatibility and to match the registry's stop contract.
-    /// Concurrency contract: `stop()` is idempotent but NOT single-flight. Two
-    /// concurrent calls both latch `stopping` and both drain, and whichever
-    /// takes the handle list first is the one that waits - the other can return
-    /// while cleanup is still running. Callers wanting "everything is closed"
-    /// must not race their own shutdown calls. Sequential calls are harmless:
-    /// the second finds nothing left to do.
+    /// Concurrency contract: single-flight AND idempotent. Concurrent callers
+    /// all wait for the SAME teardown and every one of them returns only after
+    /// it has completed; a later call is a no-op. That matters because "stop
+    /// returned" has to mean "everything is closed" - otherwise one caller can
+    /// let the runtime exit while another's cleanup is still running, and the
+    /// child processes this feature exists to reclaim survive anyway.
     pub async fn stop(&self) -> Result<()> {
-        /// How long shutdown waits for replaced transports whose callers have
-        /// not finished. Bounds SHUTDOWN, not a request: exceeding it detaches
-        /// the remaining cleanups rather than closing anything under a live
-        /// caller, so it cannot cut a request short.
-        const DRAIN_DEADLINE: Duration = Duration::from_secs(10);
-        /// How long shutdown waits to exclude a restart already in flight.
-        /// Sized above a typical backend start so an ordinary in-flight restart
-        /// finishes first, and finite so a hung one cannot hang shutdown.
-        const LIFECYCLE_WAIT: Duration = Duration::from_secs(15);
+        // Single-flight gate. A second caller blocks here rather than running a
+        // parallel teardown, then sees `stopped` and returns - having waited for
+        // the first caller's completion.
+        //
+        // What this buys, precisely: in the ordinary case the `lifecycle` write
+        // guard below ALREADY serialises concurrent callers, so this gate is
+        // not what makes them wait there. It matters where that guard does not
+        // hold - its acquisition is bounded, so a caller that times out proceeds
+        // WITHOUT exclusion, and two such callers would otherwise tear down in
+        // parallel and each return on its own partial view. This makes the
+        // guarantee unconditional rather than a side effect of a lock that is
+        // allowed to give up.
+        //
+        // With the SHIPPED budgets this changes no observable behaviour: the
+        // close stage is bounded at 10s and the lifecycle wait at 15s, so a
+        // second caller's own timeout always outlasts the first's teardown.
+        // That is an accident of two unrelated constants, not a guarantee -
+        // shortening the lifecycle wait, or lengthening the close budget, would
+        // silently reintroduce the defect. Hence both the gate and
+        // `concurrent_stops_wait_for_one_teardown`, which sets its own budgets
+        // so the window is reachable and the gate's absence is detectable.
+        let _once = self.stop_once.lock().await;
+        if self.stopped.load(std::sync::atomic::Ordering::SeqCst) {
+            return Ok(());
+        }
 
         // Exclusive: waits for any restart already in progress to finish, and
         // blocks any that has not yet started until the latch below is set.
@@ -586,17 +605,18 @@ impl Backend {
         // gives up the exclusion and reopens the narrow race it prevents, which
         // is the better of two bad outcomes at that point, so it is logged
         // loudly rather than passed over.
-        let lifecycle_guard = tokio::time::timeout(LIFECYCLE_WAIT, self.lifecycle.write())
-            .await
-            .inspect_err(|_| {
-                warn!(
-                    backend = %self.name,
-                    wait_secs = LIFECYCLE_WAIT.as_secs(),
-                    "Restart still in flight after the shutdown wait; proceeding \
-                     without exclusion"
-                );
-            })
-            .ok();
+        let lifecycle_guard =
+            tokio::time::timeout(self.budgets.lifecycle_wait, self.lifecycle.write())
+                .await
+                .inspect_err(|_| {
+                    warn!(
+                        backend = %self.name,
+                        wait_secs = self.budgets.lifecycle_wait.as_secs(),
+                        "Restart still in flight after the shutdown wait; proceeding \
+                         without exclusion"
+                    );
+                })
+                .ok();
 
         // Latched BEFORE anything is torn down. Setting it later - after the
         // pool has been walked - leaves a gap in which a restart finishing its
@@ -622,10 +642,10 @@ impl Backend {
                 .collect()
         };
 
-        self.close_pooled_transports(transports, DRAIN_DEADLINE)
+        self.close_pooled_transports(transports, self.budgets.close_stage)
             .await;
 
-        self.await_starts_in_flight(DRAIN_DEADLINE).await;
+        self.await_starts_in_flight(self.budgets.drain).await;
 
         // Transports that `force_restart` replaced while they were in use are
         // NOT in `pool`, so the loop above cannot see them. Their cleanup tasks
@@ -640,7 +660,7 @@ impl Backend {
         // handles are dropped, which detaches those tasks rather than killing
         // them - they may still finish if the runtime outlives this call - and
         // the situation is logged either way.
-        let drain_until = tokio::time::Instant::now() + DRAIN_DEADLINE;
+        let drain_until = tokio::time::Instant::now() + self.budgets.drain;
         loop {
             // Re-taken each pass on purpose. The health loop only checks its
             // shutdown signal between ticks, so a `health_probe` already in
@@ -685,13 +705,19 @@ impl Backend {
             if timed_out {
                 warn!(
                     backend = %self.name,
-                    deadline_secs = DRAIN_DEADLINE.as_secs(),
+                    deadline_secs = self.budgets.drain.as_secs(),
                     "Replaced transports still had live callers at shutdown; \
                      abandoning their cleanup"
                 );
                 break;
             }
         }
+
+        // Recorded only here, at the end: a later caller may return immediately
+        // on the strength of this flag, so it must not be set until the teardown
+        // it stands for has actually finished.
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
         Ok(())
     }

--- a/src/backend/metadata.rs
+++ b/src/backend/metadata.rs
@@ -91,6 +91,12 @@ impl Backend {
     {
         cache
             .get_or_fetch_shared(self.cache_ttl, || async {
+                // Hold the transport open for the whole fetch WITHOUT claiming
+                // client activity. ensure_started() and request_internal() reach
+                // for the transport separately; without this lease the reaper can
+                // take it in between and the caller sees a spurious
+                // BackendUnavailable for a backend that is perfectly fine.
+                let _lease = self.begin_internal_activity();
                 self.ensure_started().await?;
 
                 let response = self.request_internal(method, None).await?;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -98,6 +98,30 @@ pub struct Backend {
     /// because concurrent restarts are already serialised by the slot's
     /// `start_lock`; this is only about excluding shutdown.
     lifecycle: tokio::sync::RwLock<()>,
+    /// Makes [`Backend::stop`] single-flight.
+    ///
+    /// Without it, two concurrent callers both run the teardown and whichever
+    /// takes the cleanup list first is the only one that waits - the other
+    /// returns while transports are still closing. For a shutdown API that is
+    /// the wrong contract: "stop returned" has to mean "everything is closed",
+    /// or a caller can let the runtime exit with children still alive. The
+    /// repository exposes several concurrent reload and shutdown entry points,
+    /// so "callers must not race" was not a contract anyone could honour.
+    ///
+    /// A second caller blocks here, then observes `stopped` and returns - so it
+    /// waits for the SAME completion the first caller produced.
+    stop_once: tokio::sync::Mutex<()>,
+    /// Set when a `stop()` has run to completion.
+    stopped: std::sync::atomic::AtomicBool,
+    /// Shutdown stage budgets, overridable so tests can reach windows that the
+    /// production values close by accident.
+    ///
+    /// The single-flight contract is a case in point: with the shipped budgets
+    /// a second caller's lifecycle wait (15s) always outlasts the first
+    /// caller's close stage (10s), so the difference between having the gate
+    /// and not having it is unobservable. That is a coincidence of two
+    /// unrelated constants, not a guarantee, and a test that cannot see the
+    /// difference cannot stop someone reordering them later.
     /// Starts that have spawned a process (or opened a session) but have not yet
     /// either published it or been refused.
     ///
@@ -111,6 +135,34 @@ pub struct Backend {
     /// handshake owns a live process, and shutdown returning before that
     /// resolves leaves the process running for as long as the handshake takes.
     starts_in_flight: std::sync::atomic::AtomicUsize,
+    pub(crate) budgets: ShutdownBudgets,
+}
+
+/// How long each stage of [`Backend::stop`] may take before it gives up.
+///
+/// Bounds SHUTDOWN, never a request: exceeding any of these abandons cleanup
+/// rather than closing anything under a live caller, so none of them can cut a
+/// request short.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ShutdownBudgets {
+    /// How long to wait to exclude a restart already in flight. Sized above a
+    /// typical backend start, and finite so a hung one cannot hang shutdown.
+    pub(crate) lifecycle_wait: Duration,
+    /// How long the whole pooled-transport close stage may take.
+    pub(crate) close_stage: Duration,
+    /// How long to wait for in-flight starts, and then for replaced-transport
+    /// cleanups. Each gets this much, starting when that wait begins.
+    pub(crate) drain: Duration,
+}
+
+impl Default for ShutdownBudgets {
+    fn default() -> Self {
+        Self {
+            lifecycle_wait: Duration::from_secs(15),
+            close_stage: Duration::from_secs(10),
+            drain: Duration::from_secs(10),
+        }
+    }
 }
 
 /// Decrements [`Backend::starts_in_flight`] however its start ends - published,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -26,7 +26,9 @@ use pool::{PoolKey, PooledEntry};
 
 pub(crate) use annotations::normalize_tool_annotations;
 pub use lifecycle::runtime_plan_for_backend;
-pub use registry::{BackendRegistry, BackendRuntimeState, BackendRuntimeStatus, BackendStatus};
+pub use registry::{
+    BackendLifecycle, BackendRegistry, BackendRuntimeState, BackendRuntimeStatus, BackendStatus,
+};
 
 /// MCP Backend - manages connection to a single MCP server
 pub struct Backend {
@@ -64,6 +66,95 @@ pub struct Backend {
     semaphore: Semaphore,
     /// Request counter
     request_count: AtomicU64,
+    /// Cleanup tasks for transports that `force_restart` replaced while
+    /// requests were still using them, plus the shutdown latch that stops new
+    /// ones being created.
+    ///
+    /// Each task waits for its transport's last owner to let go and then closes
+    /// it. The handles are kept rather than detached so [`Backend::stop`] can
+    /// drain them: a replaced transport is no longer reachable through `pool`,
+    /// so shutdown would otherwise close only the CURRENT transport and let the
+    /// runtime exit with the old one's `close()` unrun — skipping an HTTP
+    /// backend's session DELETEs at exactly the reload and shutdown boundaries
+    /// where they matter.
+    ///
+    /// `stopping` and `handles` share one lock because they are one decision:
+    /// whether more cleanup work can still appear. Without the latch,
+    /// `force_restart` racing shutdown can register a cleanup after the final
+    /// drain — or worse, start a whole new child process after `stop()` has
+    /// torn the backend down, leaving an orphan nothing will ever close.
+    replaced_transport_cleanups: parking_lot::Mutex<CleanupState>,
+    /// Serialises whole lifecycle transitions against each other.
+    ///
+    /// The `stopping` latch alone is not enough: `force_restart` reads it, then
+    /// does async work, so it can pass the check BEFORE `stop()` latches and
+    /// then register a cleanup - or start a whole new child - AFTER shutdown's
+    /// final drain. A flag cannot close that window because the check and the
+    /// work it guards are not one operation.
+    ///
+    /// So restarts take this shared, and `stop()` takes it exclusively: a
+    /// restart either finishes entirely before shutdown begins, or starts
+    /// afterwards and sees the latch. Shared rather than exclusive for restarts
+    /// because concurrent restarts are already serialised by the slot's
+    /// `start_lock`; this is only about excluding shutdown.
+    lifecycle: tokio::sync::RwLock<()>,
+    /// Starts that have spawned a process (or opened a session) but have not yet
+    /// either published it or been refused.
+    ///
+    /// A counter rather than the lifecycle lock, because `start_entry` is
+    /// reached from inside `force_restart`, which already holds that lock's read
+    /// side - and `tokio::sync::RwLock` reads are not reentrant when a writer is
+    /// queued, so nesting them would deadlock against `stop()`.
+    ///
+    /// `stop()` waits for this to reach zero. Refusing to publish is not enough
+    /// on its own: a start that has spawned its child and is waiting on the MCP
+    /// handshake owns a live process, and shutdown returning before that
+    /// resolves leaves the process running for as long as the handshake takes.
+    starts_in_flight: std::sync::atomic::AtomicUsize,
+}
+
+/// Decrements [`Backend::starts_in_flight`] however its start ends - published,
+/// refused, failed, or unwound by an error further up.
+pub(crate) struct StartGuard<'a>(&'a std::sync::atomic::AtomicUsize);
+
+impl StartGuard<'_> {
+    pub(crate) fn new(counter: &std::sync::atomic::AtomicUsize) -> StartGuard<'_> {
+        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        StartGuard(counter)
+    }
+}
+
+impl Drop for StartGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// What [`Backend::force_restart`] actually did.
+///
+/// Distinguishing "rebuilt" from "skipped" matters because the admin revive
+/// endpoint reports it to a human: an `Ok` that meant "did nothing because we
+/// are shutting down" was being rendered as `transport_rebuilt: true`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestartOutcome {
+    /// The transport was replaced with a freshly started one.
+    Rebuilt,
+    /// Nothing was done: the backend is shutting down.
+    SkippedStopping,
+}
+
+/// Deferred-cleanup bookkeeping for [`Backend`], behind a single lock.
+#[derive(Default)]
+pub(crate) struct CleanupState {
+    /// Set by [`Backend::stop`] before it tears anything down, and never
+    /// cleared: **a stopped `Backend` is terminal.** Do not add a reset. Both
+    /// config-reload paths (`src/config_reload/mod.rs`) stop the old instance
+    /// and construct a NEW one rather than reviving it, so a latch that never
+    /// clears is the accurate model. Clearing it would reintroduce the window
+    /// where a start publishes into a pool shutdown has already emptied.
+    pub(crate) stopping: bool,
+    /// Cleanup tasks awaiting their transport's last owner.
+    pub(crate) handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 #[cfg(test)]

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 use serde_json::Value;
 
 use super::Backend;
-use super::registry::{BackendRuntimeState, BackendRuntimeStatus, BackendStatus};
+use super::registry::{BackendLifecycle, BackendRuntimeState, BackendRuntimeStatus, BackendStatus};
 use crate::config::TransportConfig;
 use crate::failsafe::with_retry;
 use crate::protocol::JsonRpcResponse;
@@ -148,6 +148,10 @@ impl Backend {
         })?;
 
         self.request_count.fetch_add(1, Ordering::Relaxed);
+
+        // Mark CLIENT activity for the idle clock, and hold this slot safe from
+        // being stopped for the whole request. Released when the guard drops.
+        let _activity = self.begin_activity(&key);
 
         // Ensure this slot's transport is live.
         let transport = self.ensure_entry_started(&key).await?;
@@ -290,6 +294,9 @@ impl Backend {
 
         self.request_count.fetch_add(1, Ordering::Relaxed);
 
+        // See `request_with_headers`: client activity marking + stop protection.
+        let _activity = self.begin_activity(&key);
+
         let transport = self.ensure_entry_started(&key).await?;
 
         let result = transport
@@ -361,12 +368,53 @@ impl Backend {
     /// `status()` reported before per-user slots existed -- and deliberately
     /// does not aggregate across per-user slots, which each fail
     /// independently and are not surfaced individually here.
+    /// Coarse lifecycle state, distinct from health.
+    ///
+    /// `running: bool` cannot express "stopped on purpose". Reporting a
+    /// deliberately-stopped backend as unhealthy would trip its circuit breaker
+    /// and show it as broken while it behaves exactly as configured; reporting
+    /// it as healthy would hide that its process is gone.
+    ///
+    /// A backend is `Dormant` only if it opted into being stopped when idle,
+    /// its transport is released, and nothing is actually wrong with it. If the
+    /// breaker is open or the health tracker says otherwise, it is `Unhealthy`
+    /// regardless — a real failure is never disguised as a nap.
+    #[must_use]
+    pub fn lifecycle(&self) -> BackendLifecycle {
+        if self.is_running() {
+            return BackendLifecycle::Running;
+        }
+        let entry = self.shared_entry();
+        if self.is_circuit_tripped() || !entry.failsafe.health_metrics().healthy {
+            return BackendLifecycle::Unhealthy;
+        }
+        // Dormant only if the reaper actually stopped it. Inferring from
+        // configuration alone would report a backend whose first start FAILED as
+        // sleeping: nothing has updated the failsafe yet, so it still looks
+        // healthy, and "never came up" would be indistinguishable from "resting".
+        if entry
+            .stopped_when_idle
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return BackendLifecycle::Dormant;
+        }
+        BackendLifecycle::NotStarted
+    }
+
+    /// Get backend status.
+    ///
+    /// Reports the canonical Shared slot's circuit/health state (MIK-6735
+    /// fix 1): this is the backend-wide, single-tenant view -- the same one
+    /// `status()` reported before per-user slots existed -- and deliberately
+    /// does not aggregate across per-user slots, which each fail
+    /// independently and are not surfaced individually here.
     pub fn status(&self) -> BackendStatus {
         let entry = self.shared_entry();
         let health = entry.failsafe.health_metrics();
         BackendStatus {
             name: self.name.clone(),
             running: self.is_running(),
+            lifecycle: self.lifecycle(),
             transport: self.config.transport.transport_type().to_string(),
             tools_cached: self.cached_tools_count(),
             circuit_state: entry.failsafe.circuit_breaker.state().as_str().to_string(),

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -5,7 +5,7 @@
 //! pool slots.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use parking_lot::RwLock;
@@ -61,7 +61,80 @@ pub(crate) struct PooledEntry {
     pub(crate) transport: RwLock<Option<Arc<dyn Transport>>>,
     pub(crate) start_lock: Mutex<()>,
     pub(crate) last_used: AtomicU64,
+    /// Set when the reaper stopped this slot for idleness, cleared when it is
+    /// started again.
+    ///
+    /// Dormant must be a recorded fact, not an inference. Inferring it from
+    /// "opted in, no transport, breaker closed" misreports a backend whose FIRST
+    /// start failed: nothing has updated the failsafe yet, so it still looks
+    /// healthy, and a backend that never came up would be shown as sleeping.
+    pub(crate) stopped_when_idle: std::sync::atomic::AtomicBool,
+    /// Client requests currently executing against this slot.
+    ///
+    /// `last_used` records when a request STARTED, so it cannot answer "is work
+    /// happening right now". Without this counter a call outliving the idle
+    /// deadline has its transport closed mid-flight.
+    pub(crate) in_flight: AtomicUsize,
     pub(crate) failsafe: Failsafe,
+}
+
+/// RAII marker for one in-flight client request against a pool slot.
+///
+/// Construction is the single place that writes the idle clock. `last_used`
+/// means "when did a CLIENT last use this backend", deliberately excluding
+/// internal health probes and metadata refreshes — an earlier attempt let
+/// `ensure_entry_started` touch it, and the 10s default health interval then
+/// refreshed it forever against a 300s deadline, so the feature was a silent
+/// no-op.
+///
+/// Ordering, and it took two rejected reviews to get this right: the count is
+/// claimed while holding the transport READ guard, and [`Backend::stop_if_idle`]
+/// checks it while holding the transport WRITE guard. The `RwLock` — not the
+/// atomic — is what makes the two mutually exclusive. `SeqCst` on its own cannot
+/// help here, because it does not make the reaper's earlier read conditional on
+/// a claim that happens later; the reaper would pass its check and close the
+/// transport anyway.
+///
+/// So exactly one of two things happens. Either the claim lands first, the
+/// reaper sees a non-zero count and declines; or the reaper takes the transport
+/// AND records `stopped_when_idle` under the same write guard, so a claim
+/// arriving afterwards observes a slot that is unambiguously stopped rather than
+/// one that merely looks unstarted.
+pub(crate) struct ActivityGuard {
+    entry: Arc<PooledEntry>,
+    /// Whether dropping this guard counts as client activity. False for internal
+    /// leases, which protect the transport without deferring the idle deadline.
+    touch_on_drop: bool,
+}
+
+impl ActivityGuard {
+    /// Adopt a slot whose `in_flight` count has ALREADY been claimed by
+    /// [`Backend::claim_pooled_entry`].
+    ///
+    /// Claiming and adopting are separate on purpose. The claim has to happen
+    /// while the pool's shard guard and the transport read guard are both held,
+    /// which only the pool can arrange; this constructor merely takes ownership
+    /// of the resulting count so `Drop` releases it exactly once. Incrementing
+    /// here instead would double-count, and incrementing after the guards were
+    /// released is the bug this whole split exists to remove.
+    fn adopt_claimed(entry: Arc<PooledEntry>, touch_on_drop: bool) -> Self {
+        Self {
+            entry,
+            touch_on_drop,
+        }
+    }
+}
+
+impl Drop for ActivityGuard {
+    fn drop(&mut self) {
+        // Touch on the way out too: a long CLIENT request should leave the slot
+        // looking used as of its COMPLETION, not its start. Internal leases skip
+        // this so they never defer the idle deadline.
+        if self.touch_on_drop {
+            self.entry.touch();
+        }
+        self.entry.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl PooledEntry {
@@ -70,6 +143,8 @@ impl PooledEntry {
             transport: RwLock::new(None),
             start_lock: Mutex::new(()),
             last_used: AtomicU64::new(now_unix_secs()),
+            stopped_when_idle: std::sync::atomic::AtomicBool::new(false),
+            in_flight: AtomicUsize::new(0),
             failsafe: Failsafe::new(name, failsafe_config),
         }
     }
@@ -105,23 +180,39 @@ impl Backend {
         }
     }
 
-    /// Fetch (or lazily create) the pooled entry for `key`. The `Arc` is cloned
-    /// out so the `DashMap` shard guard is released before any `.await`.
+    /// Fetch (or lazily create) the pooled entry for `key`, running `under_guard`
+    /// before the `DashMap` shard guard is released.
+    ///
+    /// The callback is the entire point of this shape. Cloning the `Arc` out and
+    /// *then* acting on it leaves a window in which
+    /// [`Backend::evict_idle_per_user_entries`] can remove and close the slot:
+    /// the caller ends up holding an orphan, and the evictor closes a transport
+    /// out from under a live request. Re-checking `in_flight` inside `remove_if`
+    /// does not fix that — the claim has to be inside the same guard that handed
+    /// out the `Arc`, or the two are simply not ordered. Anything that must be
+    /// atomic with respect to removal belongs in `under_guard`.
+    ///
+    /// Telemetry stays OUTSIDE the guard: `self.pool.len()` walks every shard, so
+    /// calling it while holding one is asking for trouble.
     ///
     /// Logs + gauges the live slot count on creation only (MIK-6735 fix 3) —
     /// minimal observability into per-user pool growth without a per-request
     /// cost on the (overwhelmingly more common) cache-hit path.
-    pub(super) fn pooled_entry(&self, key: &PoolKey) -> Arc<PooledEntry> {
+    fn pooled_entry_with<R>(
+        &self,
+        key: &PoolKey,
+        under_guard: impl FnOnce(&Arc<PooledEntry>) -> R,
+    ) -> (Arc<PooledEntry>, R) {
         let mut created = false;
-        let entry = Arc::clone(
-            self.pool
-                .entry(key.clone())
-                .or_insert_with(|| {
-                    created = true;
-                    Arc::new(PooledEntry::new(&self.name, &self.failsafe_config))
-                })
-                .value(),
-        );
+        let (entry, out) = {
+            let slot = self.pool.entry(key.clone()).or_insert_with(|| {
+                created = true;
+                Arc::new(PooledEntry::new(&self.name, &self.failsafe_config))
+            });
+            let entry = Arc::clone(slot.value());
+            let out = under_guard(&entry);
+            (entry, out)
+        };
         if created {
             #[allow(clippy::cast_precision_loss)] // pool size is never remotely close to 2^52
             let live = self.pool.len() as f64;
@@ -132,7 +223,39 @@ impl Backend {
             .set(live);
             tracing::debug!(backend = %self.name, ?key, live_slots = live, "Pool slot created");
         }
-        entry
+        (entry, out)
+    }
+
+    /// Fetch (or lazily create) the pooled entry for `key`. The `Arc` is cloned
+    /// out so the `DashMap` shard guard is released before any `.await`.
+    ///
+    /// Callers that intend to USE the slot's transport want
+    /// [`Backend::claim_pooled_entry`] instead: this one hands back an entry the
+    /// evictor is still free to remove.
+    pub(super) fn pooled_entry(&self, key: &PoolKey) -> Arc<PooledEntry> {
+        self.pooled_entry_with(key, |_| ()).0
+    }
+
+    /// Fetch (or lazily create) the entry for `key` AND claim one in-flight slot
+    /// on it, without releasing the shard guard in between.
+    ///
+    /// Two locks are held for the claim, each excluding a different teardown
+    /// path, and both are necessary:
+    ///
+    /// - the shard guard excludes `evict_idle_per_user_entries`, whose
+    ///   `remove_if` predicate reads `in_flight` under that same guard;
+    /// - the transport read guard excludes [`Backend::stop_if_idle`], which
+    ///   checks `in_flight` under the transport write guard.
+    ///
+    /// Lock order is shard → transport, matching every other nesting in this
+    /// module (`shared_transport`, `stop_all`), so no cycle exists. The read
+    /// guard is scoped to the claim itself and never survives to an `.await`.
+    fn claim_pooled_entry(&self, key: &PoolKey) -> Arc<PooledEntry> {
+        self.pooled_entry_with(key, |entry| {
+            let _transport = entry.transport.read();
+            entry.in_flight.fetch_add(1, Ordering::SeqCst);
+        })
+        .0
     }
 
     /// The canonical shared slot's `PooledEntry`. Inserted at construction and
@@ -178,7 +301,14 @@ impl Backend {
             // lock so a request that touched the slot after the first pass keeps
             // it alive and is never torn down mid-flight.
             let removed = self.pool.remove_if(&key, |k, entry| {
+                // in_flight is checked INSIDE the shard lock, alongside the
+                // timestamp. A relaxed timestamp alone is not enough: a request
+                // can hold this entry and have incremented in_flight while the
+                // clock still reads stale - notably while it waits on the backend
+                // semaphore, where it holds the entry but has not touched it.
+                // Evicting then closes the transport underneath a live request.
                 !matches!(k, PoolKey::Shared)
+                    && entry.in_flight.load(Ordering::SeqCst) == 0
                     && now_unix_secs().saturating_sub(entry.last_used.load(Ordering::Relaxed))
                         >= cutoff
             });
@@ -258,5 +388,123 @@ impl Backend {
                 .circuit_breaker
                 .record_failure("test-trip", std::time::Duration::ZERO);
         }
+    }
+}
+
+impl Backend {
+    /// How long this backend may sit unused before its process is stopped.
+    /// `None` means never.
+    pub fn stop_when_idle_for(&self) -> Option<Duration> {
+        self.config.stop_when_idle_for
+    }
+
+    /// Mark the start of a client request against `key`, returning a guard that
+    /// protects the slot from being stopped until dropped. The only caller-facing
+    /// way to write the idle clock.
+    pub(super) fn begin_activity(&self, key: &PoolKey) -> ActivityGuard {
+        self.last_used.store(now_unix_secs(), Ordering::Relaxed);
+        let entry = self.claim_pooled_entry(key);
+        entry.touch();
+        ActivityGuard::adopt_claimed(entry, true)
+    }
+
+    /// Hold the shared slot's transport open for internal work without claiming
+    /// client activity.
+    ///
+    /// Internal work — metadata refreshes, health probes — must not defer
+    /// stopping, or `last_used` stops meaning "a client used this" and the
+    /// feature silently never fires. But such work still holds a live transport
+    /// and must not have it closed mid-call. Those are two separate concerns and
+    /// this lease covers only the second.
+    ///
+    /// Metadata refreshes call `ensure_started()` and then separately reach for
+    /// the transport. Without a lease the reaper can take it in between, and the
+    /// caller sees a spurious `BackendUnavailable` for a backend that is fine.
+    pub(super) fn begin_internal_activity(&self) -> ActivityGuard {
+        ActivityGuard::adopt_claimed(self.claim_pooled_entry(&PoolKey::Shared), false)
+    }
+
+    /// Stop this backend's process if it has been unused past
+    /// `stop_when_idle_for`. Returns `true` if a live transport was closed.
+    ///
+    /// The pool entry deliberately STAYS in the pool; only the transport is
+    /// released. `shared_entry()` expects the entry to always be present and
+    /// panics otherwise, and the entry owns the circuit breaker and health
+    /// metrics, which must survive being stopped.
+    /// `ensure_entry_started` treats a `None`-or-disconnected transport as
+    /// "start it", so the next request transparently restarts the process.
+    ///
+    /// Synchronisation is the transport `RwLock`, NOT `start_lock`.
+    /// `ensure_entry_started` clones a connected transport under a READ guard on
+    /// its fast path, before it ever awaits `start_lock` — so `start_lock` cannot
+    /// exclude that clone, and a reaper holding only `start_lock` could close a
+    /// transport a caller had just been handed. `Arc` would keep the Rust object
+    /// alive but not the child process or its pipes, so the caller would fail
+    /// spuriously. Taking the WRITE guard excludes the fast-path read outright.
+    ///
+    /// In-flight work is refused rather than drained: if a request is running the
+    /// sweep simply declines and the next one retries. That holds the same
+    /// invariant as a drain — never terminate work in progress — without holding
+    /// a half-stopped state that every other path would then have to understand.
+    pub async fn stop_if_idle(&self) -> bool {
+        let Some(idle_for) = self.config.stop_when_idle_for else {
+            return false; // never stop this backend
+        };
+        // Sub-second deadlines would truncate to a 0 cutoff, making every slot
+        // eligible on every sweep including one used this same second.
+        let cutoff = idle_for.as_secs().max(1);
+        let entry = self.shared_entry();
+
+        let taken = {
+            let mut guard = entry.transport.write();
+
+            if entry.in_flight.load(Ordering::SeqCst) > 0 {
+                return false; // work in progress; retry next sweep
+            }
+            if now_unix_secs().saturating_sub(entry.last_used.load(Ordering::Relaxed)) < cutoff {
+                return false; // used recently
+            }
+            let taken = guard.take();
+            if taken.is_some() {
+                // Recorded INSIDE the write guard, atomic with the take.
+                // Storing it after the close() below leaves a window where the
+                // slot has no transport and is not yet flagged as deliberately
+                // stopped. A health probe entering there sees a backend that
+                // looks merely unstarted, calls ensure_started(), and restarts
+                // the very process this sweep just stopped — a periodic silent
+                // no-op, which is the failure this feature exists to prevent.
+                entry.stopped_when_idle.store(true, Ordering::SeqCst);
+            }
+            taken
+        };
+
+        let Some(transport) = taken else {
+            return false; // already stopped
+        };
+        if let Err(error) = transport.close().await {
+            // The slot is stopped either way — it no longer holds a transport,
+            // and re-clearing the flag would report Running for a slot with
+            // nothing to talk to, which is strictly worse. But a failed close
+            // means the child may have outlived the gateway's handle to it, so
+            // Dormant is not proof the process died. Say so rather than imply
+            // a clean stop.
+            tracing::warn!(
+                backend = %self.name,
+                %error,
+                "Idle backend transport failed to close cleanly; child process may be orphaned"
+            );
+            telemetry_metrics::counter!(
+                "mcp_backend_idle_stop_close_failures",
+                "backend" => self.name.clone()
+            )
+            .increment(1);
+        }
+
+        tracing::info!(
+            backend = %self.name,
+            idle_for_secs = cutoff,
+            "Stopped idle backend; next request will restart it"
+        );
+        true
     }
 }

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -481,23 +481,50 @@ impl Backend {
         let Some(transport) = taken else {
             return false; // already stopped
         };
-        if let Err(error) = transport.close().await {
-            // The slot is stopped either way — it no longer holds a transport,
-            // and re-clearing the flag would report Running for a slot with
-            // nothing to talk to, which is strictly worse. But a failed close
-            // means the child may have outlived the gateway's handle to it, so
-            // Dormant is not proof the process died. Say so rather than imply
-            // a clean stop.
-            tracing::warn!(
-                backend = %self.name,
-                %error,
-                "Idle backend transport failed to close cleanly; child process may be orphaned"
-            );
-            telemetry_metrics::counter!(
-                "mcp_backend_idle_stop_close_failures",
-                "backend" => self.name.clone()
-            )
-            .increment(1);
+        // BOUNDED, for the same reason `close_pooled_transports` is bounded at
+        // shutdown: `close()` has no deadline of its own — `StdioTransport::close`
+        // waits on the writer mutex, which a request blocked writing to a child
+        // that stopped reading can hold indefinitely. The sweep visits backends
+        // one after another in a single task, so an unbounded close here does
+        // not merely delay THIS backend: it wedges the whole sweep, and every
+        // other backend then idles forever without being stopped. The transport
+        // is already out of the pool, so abandoning the wait cannot strand a
+        // caller — only, at worst, the child process, which is exactly what the
+        // failure branch below already reports.
+        let close = tokio::time::timeout(self.budgets.close_stage, transport.close()).await;
+        match close {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                // The slot is stopped either way — it no longer holds a transport,
+                // and re-clearing the flag would report Running for a slot with
+                // nothing to talk to, which is strictly worse. But a failed close
+                // means the child may have outlived the gateway's handle to it, so
+                // Dormant is not proof the process died. Say so rather than imply
+                // a clean stop.
+                tracing::warn!(
+                    backend = %self.name,
+                    %error,
+                    "Idle backend transport failed to close cleanly; child process may be orphaned"
+                );
+                telemetry_metrics::counter!(
+                    "mcp_backend_idle_stop_close_failures",
+                    "backend" => self.name.clone()
+                )
+                .increment(1);
+            }
+            Err(_) => {
+                tracing::warn!(
+                    backend = %self.name,
+                    budget_secs = self.budgets.close_stage.as_secs(),
+                    "Idle backend transport did not close within its budget; \
+                     abandoning the close so the sweep keeps running. Child process may be orphaned"
+                );
+                telemetry_metrics::counter!(
+                    "mcp_backend_idle_stop_close_failures",
+                    "backend" => self.name.clone()
+                )
+                .increment(1);
+            }
         }
 
         tracing::info!(

--- a/src/backend/pool_tests.rs
+++ b/src/backend/pool_tests.rs
@@ -1933,3 +1933,260 @@ async fn concurrent_stops_wait_for_one_teardown() {
          that caller can now let the runtime exit with children alive"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Does a close() that TIMES OUT leave the child process alive?
+//
+// pool.rs's Err(_) arm warns "Child process may be orphaned" and bumps
+// `mcp_backend_idle_stop_close_failures`. "May be" is not an answer, and it is
+// not reachable by reading: it depends on who still holds an Arc to the
+// transport when the timeout fires.
+//
+// The real StdioTransport cannot answer it. Its close() body is
+//   *self.writer.lock().await = None;
+//   if let Some(ref mut child) = *self.child.lock().await { child.kill().await }
+// An uncontended tokio Mutex returns Ready inline, so with a tiny close_stage
+// the future still runs to `child.kill()` (SIGKILL, uncatchable) before the
+// timeout can ever preempt it -- the child dies from close(), not from drop,
+// and the measurement is contaminated.
+//
+// So the mock below reproduces StdioTransport's OWNERSHIP shape (it owns a real
+// tokio::process::Child with kill_on_drop(true)) while making close() genuinely
+// unresumable. What survives the timeout is then decided purely by Arc
+// ownership, which is the actual question.
+//
+// Second leg of the argument, already in the tree:
+// `transport::stdio::tests::dropping_the_last_handle_reaps_the_child` proves
+// the same drop-reaps-child property for the REAL StdioTransport, including its
+// reader task's deliberate Weak handle.
+#[cfg(unix)]
+struct RealChildWedgedClose {
+    child: tokio::sync::Mutex<Option<tokio::process::Child>>,
+}
+
+#[cfg(unix)]
+#[async_trait]
+impl Transport for RealChildWedgedClose {
+    async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success_serialized(
+            RequestId::Number(1),
+            json!({}),
+        ))
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<()> {
+        // Wedged exactly like a real close() blocked on the writer mutex that a
+        // stuck write_all still holds: it never reaches the child.kill() below.
+        std::future::pending::<()>().await;
+        let _ = &self.child;
+        Ok(())
+    }
+}
+
+// `kill -0` is the wrong probe here: it succeeds on a ZOMBIE, i.e. a child that
+// kill_on_drop already SIGKILLed but tokio's orphan queue has not reaped yet.
+// That would report a dead process as orphaned. Process STATE is the honest
+// probe: None = gone, Some("Z...") = dead awaiting reap, anything else = alive.
+#[cfg(unix)]
+fn process_state(pid: u32) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "stat=", "-p", &pid.to_string()])
+        .output()
+        .expect("ps must be runnable to probe the process table");
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+#[cfg(unix)]
+fn is_alive(pid: u32) -> bool {
+    process_state(pid).is_some_and(|s| !s.starts_with('Z'))
+}
+
+#[cfg(unix)]
+async fn spawn_probe_child() -> (tokio::process::Child, u32) {
+    let child = tokio::process::Command::new("sleep")
+        .arg("300")
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn a long-lived probe child");
+    let pid = child.id().expect("a freshly spawned child has a pid");
+    assert!(
+        is_alive(pid),
+        "probe child must be alive before the test acts"
+    );
+    (child, pid)
+}
+
+// THE QUESTION. close() times out inside stop_if_idle -- is the child orphaned?
+//
+// Real time, not start_paused: the reap is done by the OS plus tokio's orphan
+// queue, and paused time would burn the whole poll loop in zero real time.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_close_that_times_out_still_reaps_the_child() {
+    let (child, pid) = spawn_probe_child().await;
+
+    let mut backend = stoppable_backend(Duration::from_secs(1));
+    {
+        let b = Arc::get_mut(&mut backend).expect("sole owner before the test starts");
+        b.budgets.close_stage = Duration::from_millis(100);
+    }
+    // Constructed inline on purpose: a local binding would leave a stray Arc
+    // clone alive and silently turn this into the control test below.
+    backend.set_transport_for_test(Arc::new(RealChildWedgedClose {
+        child: tokio::sync::Mutex::new(Some(child)),
+    }));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .expect("the pool entry exists once a transport is installed")
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert!(
+        backend.stop_if_idle().await,
+        "stop_if_idle must report a stop even when close() times out"
+    );
+
+    for _ in 0..40 {
+        if !is_alive(pid) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let state = process_state(pid).unwrap_or_else(|| "<gone>".to_string());
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status();
+    panic!(
+        "child {pid} still alive 2s after close() timed out (ps stat = {state}); \
+         the idle sweep leaked a process the gateway can no longer reach"
+    );
+}
+
+// CONTROL. Same wedged close, but one Arc clone outlives the sweep.
+//
+// Two jobs. It proves the probe above can actually observe a survivor (a probe
+// that always reports "reaped" proves nothing), and it isolates the mechanism:
+// what reaps the child is the pool dropping the LAST Arc, not close() itself.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_surviving_transport_clone_orphans_the_child() {
+    let (child, pid) = spawn_probe_child().await;
+
+    let mut backend = stoppable_backend(Duration::from_secs(1));
+    {
+        let b = Arc::get_mut(&mut backend).expect("sole owner before the test starts");
+        b.budgets.close_stage = Duration::from_millis(100);
+    }
+    let survivor: Arc<dyn Transport> = Arc::new(RealChildWedgedClose {
+        child: tokio::sync::Mutex::new(Some(child)),
+    });
+    backend.set_transport_for_test(Arc::clone(&survivor));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .expect("the pool entry exists once a transport is installed")
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert!(
+        backend.stop_if_idle().await,
+        "stop_if_idle must report a stop"
+    );
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let alive = is_alive(pid);
+
+    drop(survivor);
+    for _ in 0..40 {
+        if !is_alive(pid) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status();
+
+    assert!(
+        alive,
+        "child {pid} died even though a transport clone was still held; \
+         the reap is then NOT tied to dropping the last Arc and the sibling \
+         test's verdict does not mean what it claims"
+    );
+}
+
+// The leak question, independent of reachability: if a caller-scoped clone DOES
+// outlive the sweep (ops.rs:25 / lifecycle.rs:1029 shape), is the child lost, or
+// merely reaped late? Function-scoped clone, dropped at scope end, no explicit
+// kill in the measured window.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_caller_scoped_clone_delays_the_reap_but_does_not_leak_it() {
+    let (child, pid) = spawn_probe_child().await;
+
+    let mut backend = stoppable_backend(Duration::from_secs(1));
+    {
+        let b = Arc::get_mut(&mut backend).expect("sole owner before the test starts");
+        b.budgets.close_stage = Duration::from_millis(100);
+    }
+    let transport: Arc<dyn Transport> = Arc::new(RealChildWedgedClose {
+        child: tokio::sync::Mutex::new(Some(child)),
+    });
+    backend.set_transport_for_test(Arc::clone(&transport));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .expect("the pool entry exists once a transport is installed")
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    {
+        // Stands in for the caller's local `let transport = self.shared_transport()`.
+        let _caller_scoped = Arc::clone(&transport);
+        drop(transport); // the pool's Arc and this one are now the only strong refs
+
+        assert!(
+            backend.stop_if_idle().await,
+            "stop_if_idle must report a stop"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            is_alive(pid),
+            "child {pid} died while the caller still held the transport"
+        );
+    } // caller's frame ends here — nothing else references the transport
+
+    for _ in 0..40 {
+        if !is_alive(pid) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let leaked = is_alive(pid);
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status();
+
+    assert!(
+        !leaked,
+        "child {pid} was still alive 2s after the last transport clone left \
+         scope: the child is LEAKED, not merely reaped late"
+    );
+}

--- a/src/backend/pool_tests.rs
+++ b/src/backend/pool_tests.rs
@@ -11,6 +11,8 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use super::*;
+use crate::backend::RestartOutcome;
+use crate::backend::registry::BackendLifecycle;
 use crate::config::TransportConfig;
 use crate::protocol::{JsonRpcResponse, RequestId};
 use crate::transport::Transport;
@@ -83,6 +85,34 @@ fn per_user_backend() -> Arc<Backend> {
     };
     Arc::new(Backend::new(
         "mem",
+        cfg,
+        &crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ))
+}
+
+/// A gateway-OWNED backend (declared with a command) that opts into being
+/// stopped when idle. Ownership is what makes stopping meaningful: the gateway
+/// spawned this process, so it can stop it.
+fn stoppable_backend(idle_for: Duration) -> Arc<Backend> {
+    stoppable_backend_with_command("echo hi", idle_for)
+}
+
+/// A stoppable backend whose start command is observable from outside the
+/// process. Tests that need to prove a start did NOT happen need a witness in
+/// the world - a file, the process table - rather than an in-memory flag.
+fn stoppable_backend_with_command(command: &str, idle_for: Duration) -> Arc<Backend> {
+    let cfg = BackendConfig {
+        transport: TransportConfig::Stdio {
+            command: command.to_string(),
+            cwd: None,
+            protocol_version: None,
+        },
+        stop_when_idle_for: Some(idle_for),
+        ..BackendConfig::default()
+    };
+    Arc::new(Backend::new(
+        "ownedtool",
         cfg,
         &crate::config::FailsafeConfig::default(),
         Duration::from_secs(60),
@@ -403,5 +433,1340 @@ async fn reconcile_after_start_keeps_transport_when_still_registered() {
     assert!(
         !transport.closed.load(Ordering::SeqCst),
         "the winning side's live transport must never be closed"
+    );
+}
+
+// ── GW.IDLE.9 — the co-simulation test ───────────────────────────────────────
+//
+// Written BEFORE the implementation, deliberately. This feature has shipped
+// twice as a silent no-op with a green suite, both times because the test
+// exercised the reaper ALONE while the failure lived in its interaction with the
+// health loop. This asserts the interaction that actually deploys.
+//
+// The health loop's gate is `is_running() || is_circuit_tripped()`. A backend
+// stopped on purpose has no transport and a closed breaker, so it must be
+// skipped. If it is not, the reaper stops the child and health restarts it, and
+// "hibernation" becomes a spawn/kill cycle every health interval — strictly
+// worse than never stopping at all.
+#[tokio::test]
+async fn idle_backend_stops_once_and_stays_stopped_under_health_traffic() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    let transport = Arc::new(SessionMock::new("shared"));
+    backend.set_transport_for_test(transport.clone());
+
+    assert!(backend.is_running(), "precondition: backend is up");
+    assert!(
+        !backend.is_circuit_tripped(),
+        "precondition: breaker closed"
+    );
+
+    // Age the slot past any plausible deadline.
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    // One reaper sweep.
+    let stopped = backend.stop_if_idle().await;
+    assert!(
+        stopped,
+        "GW.IDLE.1: an idle backend past its deadline must be stopped"
+    );
+    assert!(
+        transport.closed.load(Ordering::SeqCst),
+        "GW.IDLE.1: stopping must actually close the transport - that is what kills the child"
+    );
+
+    // Now simulate several health-loop intervals against the stopped backend.
+    for interval in 0..5 {
+        let would_probe = backend.is_running() || backend.is_circuit_tripped();
+        assert!(
+            !would_probe,
+            "GW.IDLE.9: health interval {interval}: the health loop would probe a \
+             deliberately-stopped backend, and probing starts it. Hibernation would \
+             degrade into a spawn/kill cycle every health interval."
+        );
+    }
+
+    // And it is still stopped: nothing materialised behind our back.
+    assert!(
+        backend
+            .pooled_transport_for_test(&PoolKey::Shared)
+            .is_none(),
+        "GW.IDLE.9: backend must remain stopped until a real client request arrives"
+    );
+    assert!(
+        !backend.is_running(),
+        "GW.IDLE.9: a stopped backend must not report as running"
+    );
+}
+
+// GW.IDLE.9 (companion): the clock must track CLIENT traffic only.
+//
+// `ensure_entry_started` used to touch the idle clock unconditionally, and
+// `health_probe` -> `ensure_started` routes straight through it. On the 10s
+// default health interval against a 300s deadline, the clock was refreshed
+// forever and the feature could never fire. This is the regression test for that
+// exact no-op.
+#[tokio::test]
+async fn internal_starts_do_not_defer_stopping() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("warm")));
+
+    // Stale: no client has touched it.
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    // Exactly what the health loop does, every 10s by default.
+    backend
+        .ensure_started()
+        .await
+        .expect("a connected transport short-circuits the start path");
+
+    assert_eq!(
+        backend
+            .pool
+            .get(&PoolKey::Shared)
+            .unwrap()
+            .value()
+            .last_used
+            .load(Ordering::Relaxed),
+        0,
+        "internal health/metadata traffic must NOT refresh the client idle clock"
+    );
+    assert!(
+        backend.stop_if_idle().await,
+        "a backend seeing only internal traffic must still be stoppable"
+    );
+}
+
+// The converse: real client traffic DOES defer stopping.
+#[tokio::test]
+async fn client_traffic_defers_stopping() {
+    let backend = stoppable_backend(Duration::from_secs(3600));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("live")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    drop(backend.begin_activity(&PoolKey::Shared));
+
+    assert!(
+        !backend.stop_if_idle().await,
+        "a slot a client just used must not be stopped"
+    );
+}
+
+// GW.IDLE.5 — a request in flight past the deadline must never be torn down.
+// `last_used` records when a request STARTED, so the clock alone cannot express
+// "work is happening right now".
+#[tokio::test]
+async fn in_flight_request_is_never_stopped() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    let transport = Arc::new(SessionMock::new("busy"));
+    backend.set_transport_for_test(transport.clone());
+
+    // A request is running...
+    let activity = backend.begin_activity(&PoolKey::Shared);
+    // ...but it began long ago (a slow upstream call).
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert!(
+        !backend.stop_if_idle().await,
+        "in-flight work must block stopping regardless of the clock"
+    );
+    assert!(
+        !transport.closed.load(Ordering::SeqCst),
+        "a live request's transport must never be closed underneath it"
+    );
+
+    // Once it finishes, the backend becomes eligible again.
+    drop(activity);
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(
+        backend.stop_if_idle().await,
+        "stopping resumes once the request completes"
+    );
+}
+
+// A backend that did not opt in is never stopped, however idle.
+#[tokio::test]
+async fn backend_without_the_setting_is_never_stopped() {
+    let backend = per_user_backend(); // no stop_when_idle_for
+    let transport = Arc::new(SessionMock::new("optout"));
+    backend.set_transport_for_test(transport.clone());
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert!(
+        !backend.stop_if_idle().await,
+        "absent setting must mean never stop - upgrading must not change behaviour"
+    );
+    assert!(!transport.closed.load(Ordering::SeqCst));
+}
+
+// Stopping an already-stopped backend is a no-op, not a double close.
+#[tokio::test]
+async fn stopping_is_idempotent() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("once")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert!(backend.stop_if_idle().await, "first call stops it");
+    assert!(
+        !backend.stop_if_idle().await,
+        "second call is a no-op, not a double close"
+    );
+}
+
+// Sub-second deadlines must not truncate to a zero cutoff and expire everything.
+#[tokio::test]
+async fn subsecond_deadline_does_not_stop_a_fresh_backend() {
+    let backend = stoppable_backend(Duration::from_millis(1));
+    let transport = Arc::new(SessionMock::new("fresh"));
+    backend.set_transport_for_test(transport.clone());
+    drop(backend.begin_activity(&PoolKey::Shared));
+
+    assert!(
+        !backend.stop_if_idle().await,
+        "a sub-second deadline must clamp to >=1s, not expire everything instantly"
+    );
+    assert!(!transport.closed.load(Ordering::SeqCst));
+}
+
+// ── GW.IDLE.4 — dormant is not unhealthy ────────────────────────────────────
+//
+// Reporting a deliberately-stopped backend as unhealthy would trip its circuit
+// breaker and show it broken while it behaves exactly as configured. Reporting
+// it as healthy would hide that its process is gone.
+#[tokio::test]
+async fn a_stopped_backend_reports_dormant_not_unhealthy() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("shared")));
+    assert_eq!(backend.lifecycle(), BackendLifecycle::Running);
+
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(backend.stop_if_idle().await);
+
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::Dormant,
+        "a backend stopped on purpose is neither running nor broken"
+    );
+    assert!(
+        !backend.is_circuit_tripped(),
+        "stopping must not trip the breaker - it records no failure"
+    );
+    assert_eq!(
+        backend.status().lifecycle,
+        BackendLifecycle::Dormant,
+        "status output must carry the distinction, not just the internal method"
+    );
+}
+
+// A real failure is never disguised as a nap.
+#[tokio::test]
+async fn a_failed_backend_reports_unhealthy_even_if_it_opted_into_stopping() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("shared")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(backend.stop_if_idle().await);
+    assert_eq!(backend.lifecycle(), BackendLifecycle::Dormant);
+
+    backend.trip_circuit_breaker_for_test();
+
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::Unhealthy,
+        "an open breaker must win over dormant - a fault must never look like a nap"
+    );
+}
+
+// A backend that never opted in and was never started is not "dormant".
+#[tokio::test]
+async fn a_never_started_backend_is_not_dormant() {
+    let backend = per_user_backend(); // no stop_when_idle_for, no transport
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::NotStarted,
+        "lazy-start is the normal state for an unused backend, not a stopped one"
+    );
+}
+
+// The health loop must skip a dormant backend: probing it would start it, and
+// hibernation would degrade into a spawn/kill cycle every health interval.
+#[tokio::test]
+async fn the_health_loop_skips_a_dormant_backend_but_still_probes_a_failed_one() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("shared")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(backend.stop_if_idle().await);
+
+    // This is the serve path's gate, verbatim.
+    assert!(
+        !(backend.is_running() || backend.is_circuit_tripped()),
+        "GW.IDLE.4: the health loop must not probe a dormant backend"
+    );
+
+    // But a dormant backend that then FAILS must still be probed for recovery.
+    backend.trip_circuit_breaker_for_test();
+    assert!(
+        backend.is_running() || backend.is_circuit_tripped(),
+        "recovery probing must not be blocked by having been stopped"
+    );
+}
+
+// ── Review finding 1 (CRITICAL) — the health probe must hold the transport ──
+//
+// The gate check and the probe are not atomic. Between "is_running() == true"
+// and the probe's ping, the reaper can take the transport; the probe then reads
+// that as a fault and calls force_restart(), so an idle backend is stopped and
+// instantly restarted. With a 10s health interval against a 60s sweep the ticks
+// coincide regularly.
+//
+// The earlier co-simulation test did NOT cover this: it stopped the backend and
+// only then evaluated the gate, so the overlap never happened.
+#[tokio::test]
+async fn a_probe_in_progress_blocks_the_reaper() {
+    use tokio::sync::oneshot;
+
+    // A transport whose request() parks, so a real health_probe is genuinely
+    // in-flight while the reaper sweeps. Driving `health_probe` itself is the
+    // point: an earlier version of this test called `begin_internal_activity`
+    // directly and therefore passed even with the lease removed from the probe.
+    struct ParkingMock {
+        started: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+        release: std::sync::Mutex<Option<oneshot::Receiver<()>>>,
+        closed: AtomicBool,
+    }
+
+    #[async_trait]
+    impl Transport for ParkingMock {
+        async fn request(&self, _m: &str, _p: Option<Value>) -> Result<JsonRpcResponse> {
+            if let Some(tx) = self.started.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+            let rx = self.release.lock().unwrap().take();
+            if let Some(rx) = rx {
+                let _ = rx.await;
+            }
+            Ok(JsonRpcResponse::success_serialized(
+                RequestId::Number(1),
+                json!({}),
+            ))
+        }
+        async fn notify(&self, _m: &str, _p: Option<Value>) -> Result<()> {
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        async fn close(&self) -> Result<()> {
+            self.closed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let (started_tx, started_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let transport = Arc::new(ParkingMock {
+        started: std::sync::Mutex::new(Some(started_tx)),
+        release: std::sync::Mutex::new(Some(release_rx)),
+        closed: AtomicBool::new(false),
+    });
+
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(transport.clone());
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    // Start a REAL health probe and wait until it is genuinely mid-flight.
+    let probing = Arc::clone(&backend);
+    let probe = tokio::spawn(async move { probing.health_probe(Duration::from_secs(5)).await });
+    started_rx.await.expect("probe should reach the transport");
+
+    // The reaper sweeps while that probe is running.
+    assert!(
+        !backend.stop_if_idle().await,
+        "the reaper must not stop a backend while a health probe is in flight - \
+         closing the transport makes the probe read a fault and force_restart()"
+    );
+    assert!(
+        !transport.closed.load(Ordering::SeqCst),
+        "transport was closed underneath a live probe"
+    );
+
+    let _ = release_tx.send(());
+    let _ = probe.await;
+}
+
+// An internal lease must NOT defer the idle deadline, or health traffic keeps
+// the backend warm forever - the original no-op by another route.
+#[tokio::test]
+async fn an_internal_lease_does_not_refresh_the_idle_clock() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("probing")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    drop(backend.begin_internal_activity());
+
+    assert_eq!(
+        backend
+            .pool
+            .get(&PoolKey::Shared)
+            .unwrap()
+            .value()
+            .last_used
+            .load(Ordering::Relaxed),
+        0,
+        "internal work must protect the transport WITHOUT claiming client activity"
+    );
+    assert!(
+        backend.stop_if_idle().await,
+        "a backend seeing only internal traffic must still be stoppable"
+    );
+}
+
+// ── Review finding 3 (HIGH) — per-user eviction ignored in_flight ───────────
+//
+// The comment claiming the timestamp recheck means active requests are "never
+// torn down" was false here: a request can hold the entry and have incremented
+// in_flight while the clock still reads stale, notably while it waits on the
+// backend semaphore.
+#[tokio::test]
+async fn per_user_eviction_spares_a_slot_with_work_in_flight() {
+    let backend = per_user_backend();
+    let key = per_user_key("userA");
+    let transport = Arc::new(SessionMock::new("A"));
+    backend.set_pooled_transport_for_test(&key, transport.clone());
+
+    backend
+        .pool
+        .get(&key)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    // A request is running against this per-user slot.
+    let activity = backend.begin_activity(&key);
+    backend
+        .pool
+        .get(&key)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    let closed = backend
+        .evict_idle_per_user_entries(Duration::from_secs(1))
+        .await;
+    assert_eq!(
+        closed, 0,
+        "a per-user slot with work in flight must not be evicted"
+    );
+    assert!(
+        !transport.closed.load(Ordering::SeqCst),
+        "eviction closed the transport underneath a live request"
+    );
+
+    drop(activity);
+    backend
+        .pool
+        .get(&key)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert_eq!(
+        backend
+            .evict_idle_per_user_entries(Duration::from_secs(1))
+            .await,
+        1,
+        "eviction resumes once the request completes"
+    );
+}
+
+// ── Review finding 4 (MEDIUM) — dormant must be recorded, not inferred ─────
+//
+// Inferring from "opted in + no transport + breaker closed" misreports a backend
+// whose FIRST start failed: nothing has updated the failsafe yet, so it still
+// looks healthy, and "never came up" is indistinguishable from "resting".
+#[tokio::test]
+async fn a_backend_that_never_started_is_not_reported_dormant() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    // Opted in, no transport, breaker closed - but the reaper never stopped it.
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::NotStarted,
+        "a backend that never came up must not be reported as sleeping"
+    );
+}
+
+#[tokio::test]
+async fn dormant_is_cleared_once_the_backend_is_running_again() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("first")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(backend.stop_if_idle().await);
+    assert_eq!(backend.lifecycle(), BackendLifecycle::Dormant);
+
+    // Stand in for a restart: a live transport means it is up again.
+    backend.set_transport_for_test(Arc::new(SessionMock::new("second")));
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::Running,
+        "a restarted backend must not still report dormant"
+    );
+}
+
+// force_restart() calls start_entry() directly, bypassing ensure_entry_started.
+// Clearing the dormant flag only in the latter left a restarted backend flagged
+// as stopped-for-idleness while it was actually running.
+#[tokio::test]
+async fn a_restarted_backend_is_not_flagged_dormant() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("first")));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+    assert!(backend.stop_if_idle().await);
+    assert!(
+        backend
+            .shared_entry()
+            .stopped_when_idle
+            .load(Ordering::SeqCst),
+        "precondition: the reaper recorded that it stopped this slot"
+    );
+
+    // ensure_entry_started drives start_entry, which is where the flag clears.
+    // A connected transport short-circuits before start_entry, so drop it first
+    // to force a real start attempt.
+    let _ = backend.ensure_started().await;
+
+    assert!(
+        !backend
+            .shared_entry()
+            .stopped_when_idle
+            .load(Ordering::SeqCst),
+        "starting a backend by ANY route must clear the stopped-for-idleness flag, \
+         or a restarted backend keeps reporting dormant"
+    );
+}
+
+// GW.IDLE.RACE.1 - the reaper's check-and-take must EXCLUDE lease acquisition.
+//
+// Positioned inside the window rather than after it. The test holds the
+// transport WRITE guard, which is precisely what `stop_if_idle` holds between
+// reading `in_flight` and taking the transport. If claiming a lease does not
+// take the READ guard, it slips into that window: the reaper passes its
+// zero-check, then closes a transport a live request is about to use. `SeqCst`
+// cannot prevent that - it does not make an earlier read conditional on a later
+// increment - so the lock is the only thing that can, and this asserts the lock.
+#[test]
+fn claiming_a_lease_is_excluded_while_the_reaper_holds_the_transport() {
+    let backend = stoppable_backend(Duration::from_secs(1));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("live")));
+    let entry = backend.shared_entry();
+
+    let claimed = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+
+    // Stand in for the reaper, holding the guard across the whole window.
+    let reaper_guard = entry.transport.write();
+
+    let claim_task = {
+        let backend = Arc::clone(&backend);
+        let claimed = Arc::clone(&claimed);
+        let release = Arc::clone(&release);
+        std::thread::spawn(move || {
+            let _lease = backend.begin_activity(&PoolKey::Shared);
+            claimed.store(true, Ordering::SeqCst);
+            // Keep the lease alive so the assertions below see a real count.
+            while !release.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+
+    // Bounded wait: an unexcluded claim would have landed many times over.
+    std::thread::sleep(Duration::from_millis(150));
+    assert!(
+        !claimed.load(Ordering::SeqCst),
+        "a lease was claimed while the reaper held the transport write guard; \
+         the claim does not take the read guard, so check-and-take is not atomic"
+    );
+    assert_eq!(
+        entry.in_flight.load(Ordering::SeqCst),
+        0,
+        "in_flight moved inside the reaper's window"
+    );
+
+    drop(reaper_guard);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !claimed.load(Ordering::SeqCst) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the claim never completed after the reaper released the transport"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(
+        entry.in_flight.load(Ordering::SeqCst),
+        1,
+        "the claim completed but did not register in_flight"
+    );
+
+    release.store(true, Ordering::SeqCst);
+    claim_task.join().expect("claim thread panicked");
+}
+
+/// A transport whose `close()` parks until released, letting a test position
+/// itself INSIDE the reaper's post-take window: transport already removed from
+/// the slot, stop not yet finished.
+struct BlockingCloseMock {
+    entered_close: Arc<AtomicBool>,
+    release: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Transport for BlockingCloseMock {
+    async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success_serialized(
+            RequestId::Number(1),
+            json!({}),
+        ))
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<()> {
+        self.entered_close.store(true, Ordering::SeqCst);
+        while !self.release.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        Ok(())
+    }
+}
+
+/// How many times this backend's command has been spawned, read from the file
+/// the command itself appends to. An external witness: it reflects the process
+/// table, not a field the code under test maintains.
+fn spawn_count(log: &std::path::Path) -> usize {
+    std::fs::read_to_string(log).map_or(0, |s| s.lines().count())
+}
+
+// GW.IDLE.RACE.2 - the health probe must not restart a backend the reaper is
+// in the middle of stopping.
+//
+// The window is between the reaper taking the transport and its stop being
+// complete. A probe entering there sees a slot with no transport; if it cannot
+// tell "deliberately stopped" from "not started yet" it calls ensure_started()
+// and respawns the process the sweep just released - a periodic silent no-op,
+// which is the exact failure this feature exists to prevent. Recording
+// `stopped_when_idle` under the same write guard that takes the transport is
+// what closes it; recording it after `close()` completes leaves it open.
+//
+// The test parks the reaper inside `close()` so it is genuinely in the window,
+// rather than asserting after the stop has finished - the mistake that let six
+// earlier tests pass against broken code.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_health_probe_does_not_restart_a_backend_mid_stop() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let log = dir.path().join("spawns");
+    let backend = stoppable_backend_with_command(
+        &format!("sh -c 'echo spawn >> {}; sleep 1'", log.display()),
+        Duration::from_secs(1),
+    );
+
+    let entered_close = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    backend.set_transport_for_test(Arc::new(BlockingCloseMock {
+        entered_close: Arc::clone(&entered_close),
+        release: Arc::clone(&release),
+    }));
+    backend.shared_entry().last_used.store(0, Ordering::Relaxed);
+
+    let stopper = {
+        let backend = Arc::clone(&backend);
+        tokio::spawn(async move { backend.stop_if_idle().await })
+    };
+
+    // Park until the reaper is demonstrably inside the window.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !entered_close.load(Ordering::SeqCst) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the reaper never reached close(); the test never entered the window"
+        );
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "precondition: the reaper has taken the transport"
+    );
+
+    let spawns_before = spawn_count(&log);
+    let _ = backend.health_probe(Duration::from_millis(200)).await;
+
+    assert_eq!(
+        spawn_count(&log),
+        spawns_before,
+        "the health probe spawned a child while the reaper was stopping this \
+         backend; stopping and restarting on every sweep is the silent no-op \
+         this feature exists to prevent"
+    );
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "the health probe installed a transport for a backend being stopped"
+    );
+
+    release.store(true, Ordering::SeqCst);
+    assert!(
+        stopper.await.expect("stopper task panicked"),
+        "stop_if_idle should report that it closed a live transport"
+    );
+}
+
+// GW.IDLE.RACE.3 - the evictor must never remove a slot a request is using.
+//
+// Scope, stated honestly: this covers the eviction PREDICATE, not the
+// acquisition window. That a lease is claimed under the same shard guard the
+// predicate runs under is atomicity by construction - `pooled_entry_with` runs
+// its callback before releasing the guard and is the only path to an
+// incremented entry - and is not what this test proves. What it proves is the
+// invariant that construction exists to protect: an evictor that can see a
+// live lease must decline, and must not close a transport out from under it.
+#[tokio::test]
+async fn a_leased_slot_is_never_evicted() {
+    let backend = per_user_backend();
+    let key = per_user_key("userA");
+    let mock = Arc::new(SessionMock::new("A"));
+    backend.set_pooled_transport_for_test(&key, Arc::clone(&mock) as Arc<dyn Transport>);
+
+    let lease = backend.begin_activity(&key);
+    // begin_activity touches the idle clock, so re-stale it: the lease must be
+    // the ONLY thing keeping this slot alive, or the test proves nothing.
+    backend
+        .pooled_entry(&key)
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert_eq!(
+        backend
+            .evict_idle_per_user_entries(Duration::from_secs(1))
+            .await,
+        0,
+        "the evictor removed a slot with a live lease on it"
+    );
+    assert!(
+        backend.pool.contains_key(&key),
+        "the leased slot is gone from the pool; its holder is now an orphan"
+    );
+    assert!(
+        !mock.closed.load(Ordering::SeqCst),
+        "the evictor closed a transport a live request is holding"
+    );
+
+    drop(lease);
+    // Dropping the guard touches the clock too.
+    backend
+        .pooled_entry(&key)
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    assert_eq!(
+        backend
+            .evict_idle_per_user_entries(Duration::from_secs(1))
+            .await,
+        1,
+        "once the lease is released the slot must become evictable again, \
+         or in_flight leaks and the slot is immortal"
+    );
+    assert!(
+        mock.closed.load(Ordering::SeqCst),
+        "the evicted slot's transport was never closed"
+    );
+}
+
+/// A transport whose closed-flag lives OUTSIDE it, so a test can observe the
+/// close without holding an `Arc` to the transport itself. Holding one would
+/// keep the strong count above the drain threshold and make the assertion
+/// depend on the drain cap rather than on the behaviour under test.
+struct ClosedFlagMock {
+    closed: Arc<AtomicBool>,
+    dropped: Arc<AtomicBool>,
+}
+
+impl Drop for ClosedFlagMock {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl Transport for ClosedFlagMock {
+    async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success_serialized(
+            RequestId::Number(1),
+            json!({}),
+        ))
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<()> {
+        self.closed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// GW.IDLE.RACE.4 - health recovery must not close a transport a client is
+// still using, and must not leak it either.
+//
+// force_restart() is the health loop's escape hatch for a wedged backend. It
+// used to take the shared transport and close it with no regard for in-flight
+// work, so a probe failing while an ordinary request was mid-call killed that
+// request's stdio child underneath it.
+//
+// The fix is ownership, not timing: recovery drops its reference and the
+// transport goes away when the LAST caller drops theirs. So this asserts both
+// halves - untouched while a caller holds it, and actually released once that
+// caller lets go. The release is witnessed by the mock's Drop, because with
+// ownership-based cleanup nothing calls close() on this path; a test asserting
+// close() would be asserting the old design.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_recovery_does_not_close_a_transport_a_request_is_using() {
+    // A command that cannot spawn at all, so start_entry fails immediately
+    // instead of waiting out an MCP init timeout. What happens to the OLD
+    // transport is settled before the new one is built, so the failure is
+    // irrelevant to the assertions.
+    let backend =
+        stoppable_backend_with_command("/nonexistent-mcp-binary", Duration::from_secs(60));
+    let closed = Arc::new(AtomicBool::new(false));
+    let dropped = Arc::new(AtomicBool::new(false));
+    backend.set_transport_for_test(Arc::new(ClosedFlagMock {
+        closed: Arc::clone(&closed),
+        dropped: Arc::clone(&dropped),
+    }));
+
+    // Exactly what an in-flight request owns when recovery fires.
+    let lease = backend.begin_activity(&PoolKey::Shared);
+    let held = backend
+        .shared_entry()
+        .transport
+        .read()
+        .clone()
+        .expect("transport installed above");
+
+    let _ = backend.force_restart().await;
+
+    assert!(
+        !closed.load(Ordering::SeqCst),
+        "health recovery closed the transport while a request was still using it"
+    );
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "the transport was destroyed while a request still held it"
+    );
+    assert!(
+        held.is_connected(),
+        "the in-flight caller's transport is no longer usable"
+    );
+
+    // Release it the way a finishing request would. It must then be CLOSED, not
+    // merely dropped: close() is what sends an HTTP backend's per-session
+    // DELETEs, and skipping them abandons upstream sessions on every recovery.
+    drop(held);
+    drop(lease);
+
+    // Wait for BOTH: the mock sets `closed` inside close(), but the cleanup task
+    // only releases its Arc after close() returns. Asserting `dropped` the
+    // instant `closed` is observed is a race - another worker can see the store
+    // before the mock is destroyed.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !(closed.load(Ordering::SeqCst) && dropped.load(Ordering::SeqCst)) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the replaced transport was not closed AND released after its last \
+             holder let go (closed={}, released={}); recovery leaked it and, for \
+             HTTP, its upstream session with it",
+            closed.load(Ordering::SeqCst),
+            dropped.load(Ordering::SeqCst)
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+// GW.IDLE.RACE.6 - shutdown must wait for a replaced transport's cleanup.
+//
+// A transport that force_restart replaced while it was in use is no longer in
+// `pool`, so `stop()`'s loop over the pool cannot see it: only its cleanup task
+// holds it. Detach that task and the runtime can exit with its `close()` unrun,
+// which skips an HTTP backend's per-session DELETEs at exactly the reload and
+// shutdown boundaries where abandoning a session matters most.
+//
+// The holder here is released while `stop()` is already waiting, so the test
+// distinguishes waiting from not waiting: without the drain, `stop()` returns
+// before the release and the transport is still open when it does.
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_waits_for_a_replaced_transports_cleanup() {
+    let backend =
+        stoppable_backend_with_command("/nonexistent-mcp-binary", Duration::from_secs(60));
+    let closed = Arc::new(AtomicBool::new(false));
+    let dropped = Arc::new(AtomicBool::new(false));
+    backend.set_transport_for_test(Arc::new(ClosedFlagMock {
+        closed: Arc::clone(&closed),
+        dropped: Arc::clone(&dropped),
+    }));
+
+    let lease = backend.begin_activity(&PoolKey::Shared);
+    let held = backend
+        .shared_entry()
+        .transport
+        .read()
+        .clone()
+        .expect("transport installed above");
+
+    // Replaced while in use: cleanup is deferred and the old transport is now
+    // reachable only from its cleanup task.
+    let _ = backend.force_restart().await;
+    drop(lease);
+    assert!(
+        !closed.load(Ordering::SeqCst),
+        "precondition: cleanup is still waiting on the holder"
+    );
+
+    // Let go only once shutdown is already under way.
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        drop(held);
+    });
+
+    backend.stop().await.expect("stop");
+
+    assert!(
+        closed.load(Ordering::SeqCst),
+        "stop() returned while a replaced transport was still open; its cleanup \
+         was detached, so shutdown can drop it unrun and abandon the session"
+    );
+}
+
+// GW.IDLE.RACE.7 - recovery must not restart a backend that is shutting down.
+//
+// The health loop only checks its shutdown signal between ticks, so a probe
+// already in flight can call force_restart() while stop() is tearing the
+// backend down. stop() has by then taken every transport out of the pool, so a
+// restart there spawns a fresh child process that nothing left alive will ever
+// close: an orphan MCP server outliving the gateway. It also registers a
+// cleanup after shutdown's final drain, which is how this was found.
+//
+// The witness is on disk: the backend's command appends a line per spawn, so
+// the assertion counts real spawn attempts rather than trusting an in-memory
+// flag. (It counts launches from that log; it does not inspect the process
+// table itself.)
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_does_not_restart_a_backend_that_is_stopping() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let log = dir.path().join("spawns");
+    let backend = stoppable_backend_with_command(
+        &format!("sh -c 'echo spawn >> {}; sleep 1'", log.display()),
+        Duration::from_secs(60),
+    );
+    backend.set_transport_for_test(Arc::new(SessionMock::new("live")));
+
+    backend.stop().await.expect("stop");
+
+    let spawns_before = spawn_count(&log);
+    let _ = backend.force_restart().await;
+
+    assert_eq!(
+        spawn_count(&log),
+        spawns_before,
+        "force_restart spawned a child for a backend that had already been \
+         stopped; nothing remains to close it, so it outlives the gateway"
+    );
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "a stopped backend was given a live transport by health recovery"
+    );
+}
+
+// GW.IDLE.RACE.8 - shutdown must exclude a restart that is already running.
+//
+// The `stopping` latch alone cannot do this: force_restart reads it and THEN
+// does async work, so it can pass the check before stop() latches and go on to
+// register a cleanup after the final drain, or start a child after teardown.
+// The check and the work it guards are not one operation, so a flag cannot
+// close the window - only mutual exclusion can.
+//
+// Positioned inside the window rather than after it: the test holds the shared
+// side of the lifecycle lock, which is exactly what an in-flight restart holds,
+// and asserts shutdown cannot proceed past it.
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_waits_for_a_restart_already_in_flight() {
+    let backend =
+        stoppable_backend_with_command("/nonexistent-mcp-binary", Duration::from_secs(60));
+    backend.set_transport_for_test(Arc::new(SessionMock::new("live")));
+
+    // Stand in for a restart that has passed its own stopping check.
+    let restarting = backend.lifecycle.read().await;
+
+    let stopped = Arc::new(AtomicBool::new(false));
+    let shutdown_task = {
+        let backend = Arc::clone(&backend);
+        let stopped = Arc::clone(&stopped);
+        tokio::spawn(async move {
+            let _ = backend.stop().await;
+            stopped.store(true, Ordering::SeqCst);
+        })
+    };
+
+    // Bounded wait: unexcluded shutdown would have completed many times over.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(
+        !stopped.load(Ordering::SeqCst),
+        "stop() ran to completion while a restart was still in flight; it can \
+         therefore latch and drain before that restart registers its cleanup or \
+         starts its child"
+    );
+
+    drop(restarting);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !stopped.load(Ordering::SeqCst) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "stop() never completed after the restart finished"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    shutdown_task.await.expect("shutdown task panicked");
+}
+
+// GW.IDLE.RACE.9 - a restart that finishes after shutdown must undo itself.
+//
+// The lifecycle lock normally stops these overlapping, but `stop()` bounds its
+// wait for that lock rather than hanging shutdown forever, so correctness
+// cannot depend on having won it. Starting is slow: a flag read BEFORE a slow
+// operation says nothing about the world after it. If shutdown ran to
+// completion in the meantime it has already walked every transport in the
+// pool, so a child started afterwards is one nothing will ever close.
+//
+// The test drives that window directly - the latch is flipped WHILE the start
+// is in progress, which is precisely the state a timed-out lock leaves behind -
+// rather than asserting the easy case where shutdown finished first. The child
+// is a real MCP responder, because the undo only matters when the start
+// SUCCEEDS; a failed start has nothing to undo.
+//
+// Unix-only: the witness is the process table, read via kill(1).
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_restart_that_outlives_shutdown_closes_what_it_started() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let server = dir.path().join("server.sh");
+    let pidfile = dir.path().join("child.pid");
+    std::fs::write(
+        &server,
+        format!(
+            r#"echo $$ > "{}"
+sleep 0.3
+while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"protocolVersion":"2025-11-25"}}}}'
+            ;;
+    esac
+done
+"#,
+            pidfile.display()
+        ),
+    )
+    .expect("write server");
+
+    let backend = stoppable_backend_with_command(
+        &format!("sh {}", server.display()),
+        Duration::from_secs(60),
+    );
+
+    let flipper = {
+        let backend = Arc::clone(&backend);
+        tokio::spawn(async move {
+            // Inside the child's pre-handshake delay: the start is under way
+            // and has not yet installed anything.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Exactly what stop() does to the latch, minus the lock it may have
+            // failed to acquire.
+            backend.replaced_transport_cleanups.lock().stopping = true;
+        })
+    };
+
+    let outcome = backend.force_restart().await;
+    flipper.await.expect("flipper task panicked");
+
+    assert!(
+        matches!(outcome, Ok(RestartOutcome::SkippedStopping)),
+        "a restart that finished after shutdown reported success: {outcome:?}"
+    );
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "the restart left a transport installed on a backend that had already \
+         been shut down; nothing remains to close it"
+    );
+
+    // An empty slot is not evidence the process died - close() could have
+    // failed, or done nothing. The child recorded its own pid, so ask the
+    // process table.
+    let pid = std::fs::read_to_string(&pidfile)
+        .expect("child recorded its pid")
+        .trim()
+        .to_string();
+    let alive = || {
+        std::process::Command::new("kill")
+            .args(["-0", &pid])
+            .status()
+            .is_ok_and(|s| s.success())
+    };
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while alive() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the restart emptied the slot but its child (pid {pid}) is still \
+             running; it outlives the gateway"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+// GW.IDLE.RACE.10 - a start racing shutdown must never outlive it.
+//
+// This is the ORDINARY start path, not force_restart: every client request
+// reaches it, and it takes no lifecycle lock, so it can genuinely be mid-start
+// when shutdown runs. If publishing is not ordered against shutdown's pool
+// traversal, the transport lands in a slot `stop()` has already visited and
+// will never revisit - and the child outlives the gateway with nothing holding
+// a handle to close it.
+//
+// Asserting the latch is "set before the traversal" is not enough on its own:
+// an implementation could take every transport out, THEN latch, then close, and
+// still leave exactly this gap. So the test drives the race itself and checks
+// the only thing that matters - after shutdown returns, is anything still
+// alive? The witness is the process table.
+//
+// Unix-only: the witness is read via kill(1).
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_ordinary_start_racing_shutdown_leaves_no_child_behind() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let server = dir.path().join("server.sh");
+    let pidfile = dir.path().join("child.pid");
+    std::fs::write(
+        &server,
+        format!(
+            r#"echo $$ > "{}"
+sleep 0.3
+while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"protocolVersion":"2025-11-25"}}}}'
+            ;;
+    esac
+done
+"#,
+            pidfile.display()
+        ),
+    )
+    .expect("write server");
+
+    let backend = stoppable_backend_with_command(
+        &format!("sh {}", server.display()),
+        Duration::from_secs(60),
+    );
+
+    let starter = {
+        let backend = Arc::clone(&backend);
+        tokio::spawn(async move { backend.ensure_started().await })
+    };
+
+    // Let the child spawn and get into its pre-handshake delay, so the start is
+    // genuinely in flight when shutdown begins.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let pid = std::fs::read_to_string(&pidfile)
+        .expect("child recorded its pid before shutdown")
+        .trim()
+        .to_string();
+    let alive = || {
+        std::process::Command::new("kill")
+            .args(["-0", &pid])
+            .status()
+            .is_ok_and(|s| s.success())
+    };
+    assert!(alive(), "precondition: the racing start's child is running");
+
+    backend.stop().await.expect("stop");
+
+    // Checked BEFORE awaiting the starter, deliberately. Awaiting it first
+    // would only prove the child dies EVENTUALLY, which it always did - the
+    // publish refusal closes it. The claim under test is stronger and is the
+    // one shutdown has to make: by the time stop() RETURNS, nothing it started
+    // is still running.
+    assert!(
+        !alive(),
+        "stop() returned while the racing start's child (pid {pid}) was still \
+         running; a start that has spawned but not yet published owns a live \
+         process that the pool traversal cannot see"
+    );
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "a start published a transport into a backend that had already been \
+         shut down; stop() has walked the pool and will not revisit it"
+    );
+
+    let _ = starter.await;
+}
+
+// GW.IDLE.RACE.11 - a start arriving AFTER shutdown must not spawn at all.
+//
+// The in-flight counter closes the case where a start was already running when
+// shutdown began. It says nothing about one that arrives afterwards: `stop()`
+// observes zero, returns, and the next request enters the start path with
+// nothing to stop it. Waiting for the publish to refuse it is too late - the
+// child is already spawned by then and lives for the length of a handshake.
+//
+// Ordering is what makes this airtight, and it is worth stating because it is
+// easy to get backwards: the guard is taken BEFORE the latch is read. So either
+// the increment lands first and shutdown's counter wait sees it, or the read
+// happens after the latch was set and the start refuses. There is no ordering
+// in which a start both escapes the counter and misses the latch.
+//
+// Unix-only: the witness is the process table, read via kill(1).
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_start_after_shutdown_never_spawns_a_child() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let log = dir.path().join("spawns");
+    let backend = stoppable_backend_with_command(
+        &format!("sh -c 'echo spawn >> {}; sleep 5'", log.display()),
+        Duration::from_secs(60),
+    );
+
+    backend.stop().await.expect("stop");
+    assert_eq!(
+        spawn_count(&log),
+        0,
+        "precondition: nothing was started before shutdown"
+    );
+
+    // Every ordinary route into the start path, after shutdown has returned.
+    let started = backend.ensure_started().await;
+    let restarted = backend.force_restart().await;
+
+    assert!(
+        started.is_err(),
+        "a stopped backend reported a successful start"
+    );
+    assert!(
+        matches!(restarted, Ok(RestartOutcome::SkippedStopping)),
+        "force_restart on a stopped backend should report that it did nothing, \
+         got {restarted:?}"
+    );
+    assert_eq!(
+        spawn_count(&log),
+        0,
+        "a start after shutdown spawned a child process; it is closed only when \
+         the publish refuses it, so it runs for the length of a handshake with \
+         shutdown already finished"
+    );
+    assert!(
+        backend.shared_entry().transport.read().is_none(),
+        "a stopped backend was given a live transport"
     );
 }

--- a/src/backend/pool_tests.rs
+++ b/src/backend/pool_tests.rs
@@ -1771,6 +1771,75 @@ async fn a_start_after_shutdown_never_spawns_a_child() {
     );
 }
 
+/// Never finishes closing. Models the real hang the shutdown path already
+/// guards against: `StdioTransport::close` waits on the writer mutex, which a
+/// request blocked writing to a child that stopped reading holds forever.
+struct WedgedCloseMock;
+
+#[async_trait]
+impl Transport for WedgedCloseMock {
+    async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success_serialized(
+            RequestId::Number(1),
+            json!({}),
+        ))
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<()> {
+        std::future::pending::<()>().await;
+        Ok(())
+    }
+}
+
+// One wedged backend must not cost every OTHER backend its idle stop.
+//
+// The sweep walks backends one after another inside a single task, so an
+// unbounded close here is not a local delay: the loop never reaches the next
+// backend, never ticks again, and the feature silently stops working for the
+// whole gateway. The shutdown path already bounds close() for this exact
+// reason; the idle path has the same hazard and needs the same bound.
+#[tokio::test(start_paused = true)]
+async fn a_wedged_close_cannot_wedge_the_idle_sweep() {
+    let mut backend = stoppable_backend(Duration::from_secs(1));
+    {
+        let b = Arc::get_mut(&mut backend).expect("sole owner before the test starts");
+        b.budgets.close_stage = Duration::from_secs(10);
+    }
+    backend.set_transport_for_test(Arc::new(WedgedCloseMock));
+    backend
+        .pool
+        .get(&PoolKey::Shared)
+        .unwrap()
+        .value()
+        .last_used
+        .store(0, Ordering::Relaxed);
+
+    // Generous relative to the 10s budget: this asserts the close is bounded at
+    // all, not where the bound sits.
+    let stopped = tokio::time::timeout(Duration::from_secs(600), backend.stop_if_idle())
+        .await
+        .expect("a close that never finishes must be abandoned, not awaited forever");
+
+    assert!(
+        stopped,
+        "the transport was taken out of the pool, so the slot is stopped whether or not \
+         the child died with it"
+    );
+    assert_eq!(
+        backend.lifecycle(),
+        BackendLifecycle::Dormant,
+        "abandoning the close must still leave the slot stopped, not half-running"
+    );
+}
+
 /// Closes slowly, so a caller that returns without waiting is visible.
 struct SlowCloseMock {
     closed: Arc<AtomicBool>,

--- a/src/backend/pool_tests.rs
+++ b/src/backend/pool_tests.rs
@@ -1770,3 +1770,97 @@ async fn a_start_after_shutdown_never_spawns_a_child() {
         "a stopped backend was given a live transport"
     );
 }
+
+/// Closes slowly, so a caller that returns without waiting is visible.
+struct SlowCloseMock {
+    closed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Transport for SlowCloseMock {
+    async fn request(&self, _method: &str, _params: Option<Value>) -> Result<JsonRpcResponse> {
+        Ok(JsonRpcResponse::success_serialized(
+            RequestId::Number(1),
+            json!({}),
+        ))
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<()> {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        self.closed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// GW.IDLE.RACE.12 - stop() must be single-flight, not merely idempotent.
+//
+// "stop returned" has to mean "everything is closed". Otherwise one caller can
+// let the runtime exit while another's cleanup is still running, and the child
+// processes this feature exists to reclaim survive anyway. The gateway exposes
+// several concurrent reload and shutdown entry points, so "callers must not
+// race" was never a contract anyone could honour.
+//
+// Reaching that window takes work, and three earlier attempts each failed for a
+// DIFFERENT reason - worth listing, because each looked like a working test:
+//
+//   1. Two concurrent stops, slow close: passes without the gate, because the
+//      lifecycle write guard serialises them anyway.
+//   2. Same with a reader held so both lose that guard: still passes, because
+//      the second caller waits out its OWN lifecycle timeout, which with the
+//      shipped budgets outlasts the first caller's close.
+//   3. Close made longer than that timeout: the close-stage budget aborts it
+//      first, so the test measures that instead.
+//
+// The window is closed by an accident of the shipped budgets, not by design.
+// So this test sets its own: a short lifecycle wait and a long close stage, so
+// the second caller's timeout expires while the first is still closing. Paused
+// time keeps it free.
+#[tokio::test(start_paused = true)]
+async fn concurrent_stops_wait_for_one_teardown() {
+    let mut backend =
+        stoppable_backend_with_command("/nonexistent-mcp-binary", Duration::from_secs(60));
+    {
+        let b = Arc::get_mut(&mut backend).expect("sole owner before the test starts");
+        b.budgets.lifecycle_wait = Duration::from_secs(1);
+        b.budgets.close_stage = Duration::from_secs(120);
+        b.budgets.drain = Duration::from_secs(1);
+    }
+
+    let closed = Arc::new(AtomicBool::new(false));
+    backend.set_transport_for_test(Arc::new(SlowCloseMock {
+        closed: Arc::clone(&closed),
+    }));
+
+    // Deny lifecycle exclusion to BOTH callers so each times out and proceeds
+    // without it - the state in which nothing but the single-flight gate makes
+    // the second one wait.
+    let _restart_in_flight = backend.lifecycle.read().await;
+
+    let second = {
+        let backend = Arc::clone(&backend);
+        let closed = Arc::clone(&closed);
+        tokio::spawn(async move {
+            backend.stop().await.expect("second stop");
+            closed.load(Ordering::SeqCst)
+        })
+    };
+
+    backend.stop().await.expect("first stop");
+    assert!(
+        closed.load(Ordering::SeqCst),
+        "stop() returned before the transport was closed"
+    );
+    assert!(
+        second.await.expect("second stop task panicked"),
+        "a concurrent stop() returned while the transport was still closing; \
+         that caller can now let the runtime exit with children alive"
+    );
+}

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -163,8 +163,12 @@ pub struct BackendRegistry {
     /// name, so two reloads running at once can each register a replacement and
     /// the second insert discards the first without stopping it. If ordinary
     /// traffic started the discarded one in between, its child process is
-    /// orphaned. Held across the whole of `config_reload::apply_patch`, so
-    /// reloads queue instead of interleaving.
+    /// orphaned. Held across the whole reload transaction - reading the config
+    /// file, comparing it against the live one, applying the difference, and
+    /// publishing the result - so reloads queue instead of interleaving.
+    /// Holding it only across the apply step is not enough: both reloads would
+    /// have compared against the same stale live config before they queued, and
+    /// both would still register.
     ///
     /// A `tokio` mutex, not `parking_lot`: the critical section awaits
     /// `Backend::stop`.
@@ -184,8 +188,9 @@ impl BackendRegistry {
 
     /// Take the reload lock, so one config-reload transaction runs at a time.
     ///
-    /// Held by `config_reload::apply_patch` for the duration of the patch. See
-    /// the `reload` field for why. Callers that mutate the registry as a
+    /// Taken by each config-reload entry point before it reads the config file,
+    /// and held until the new config is published. See the `reload` field for
+    /// why it has to start that early. Callers that mutate the registry as a
     /// transaction (stop-then-register) must take it; single operations do not.
     pub async fn lock_reload(&self) -> tokio::sync::MutexGuard<'_, ()> {
         self.reload.lock().await
@@ -218,10 +223,11 @@ impl BackendRegistry {
     /// without stopping it, orphaning that process.
     ///
     /// Fixed by serializing the reload transaction rather than by changing the
-    /// semantics here: `config_reload::apply_patch` holds
-    /// `BackendRegistry::lock_reload` across the whole patch, so the stop and
-    /// the re-register of one reload complete before the next reload's stop
-    /// begins. Replace-by-name is still what this function does, and a caller
+    /// semantics here: every reload entry point takes
+    /// `BackendRegistry::lock_reload` before it reads the config file and holds
+    /// it until the new config is published, so the stop and the re-register of
+    /// one reload complete before the next reload even reads its input.
+    /// Replace-by-name is still what this function does, and a caller
     /// that registers a duplicate name outside that lock still displaces
     /// silently. The only such callers today are startup, which runs before the
     /// gateway serves, and tests.

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -155,6 +155,20 @@ pub struct BackendRegistry {
     /// arrange. The guarantee here is by construction - one critical section on
     /// each side - not by demonstration.
     stopping: parking_lot::Mutex<bool>,
+
+    /// Serializes config-reload transactions (#397).
+    ///
+    /// A reload stops the old instance of a modified backend and then registers
+    /// a replacement. Those two steps are not atomic, and `register` replaces by
+    /// name, so two reloads running at once can each register a replacement and
+    /// the second insert discards the first without stopping it. If ordinary
+    /// traffic started the discarded one in between, its child process is
+    /// orphaned. Held across the whole of `config_reload::apply_patch`, so
+    /// reloads queue instead of interleaving.
+    ///
+    /// A `tokio` mutex, not `parking_lot`: the critical section awaits
+    /// `Backend::stop`.
+    reload: tokio::sync::Mutex<()>,
 }
 
 impl BackendRegistry {
@@ -164,7 +178,17 @@ impl BackendRegistry {
         Self {
             backends: DashMap::new(),
             stopping: parking_lot::Mutex::new(false),
+            reload: tokio::sync::Mutex::new(()),
         }
+    }
+
+    /// Take the reload lock, so one config-reload transaction runs at a time.
+    ///
+    /// Held by `config_reload::apply_patch` for the duration of the patch. See
+    /// the `reload` field for why. Callers that mutate the registry as a
+    /// transaction (stop-then-register) must take it; single operations do not.
+    pub async fn lock_reload(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.reload.lock().await
     }
 
     /// Register a backend
@@ -185,22 +209,22 @@ impl BackendRegistry {
     /// REPLACES it - `DashMap::insert` discards the displaced value - so a
     /// backend that was started and then displaced is stopped by nobody.
     ///
-    /// KNOWN DEFECT, and it is REACHABLE. `ReloadContext::reload_outcome` has no
-    /// serialization, and it is called from three concurrent HTTP paths: the
+    /// That displacement was reachable (#397): `ReloadContext::reload_outcome`
+    /// had no serialization and is called from three concurrent HTTP paths - the
     /// `gateway_reload_config` meta-tool, the admin UI reload, and every admin
     /// UI backend edit via `write_config_and_reload_outcome`. Two concurrent
-    /// reloads can both stop backend A and then register replacements B and C;
-    /// ordinary traffic can start B in between; C's insert then discards B
-    /// without stopping it, orphaning that process - the exact failure
-    /// `stop_when_idle_for` exists to prevent.
+    /// reloads could both stop backend A and then register replacements B and C;
+    /// ordinary traffic could start B in between; C's insert then discarded B
+    /// without stopping it, orphaning that process.
     ///
-    /// An earlier version of this comment claimed no current caller could hit
-    /// it. That was wrong: it checked that the reload path stops the old
-    /// instance before re-registering, but never checked whether two reloads
-    /// can run at once. The fix is to serialize reload transactions AND make
-    /// registration either reject a duplicate or hand the displaced backend
-    /// back so the caller can stop it. Tracked separately; the replacement
-    /// semantics are pre-existing, the reachability is not new either.
+    /// Fixed by serializing the reload transaction rather than by changing the
+    /// semantics here: `config_reload::apply_patch` holds
+    /// `BackendRegistry::lock_reload` across the whole patch, so the stop and
+    /// the re-register of one reload complete before the next reload's stop
+    /// begins. Replace-by-name is still what this function does, and a caller
+    /// that registers a duplicate name outside that lock still displaces
+    /// silently. The only such callers today are startup, which runs before the
+    /// gateway serves, and tests.
     #[must_use = "a refused registration means the backend is NOT registered"]
     pub fn register(&self, backend: Arc<Backend>) -> bool {
         let stopping = self.stopping.lock();

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -12,6 +12,41 @@ use tracing::warn;
 use super::Backend;
 use crate::runtime::{RuntimeDenyReason, RuntimeLicenseTier, RuntimeProviderKind};
 
+/// Coarse lifecycle state of a backend, distinct from its health.
+///
+/// A backend stopped ON PURPOSE is neither healthy nor failed. Without a third
+/// state it has to be reported as one of them: as healthy it hides a stopped
+/// process, and as failed it trips circuit breakers and lights dashboards red
+/// for a backend that is behaving exactly as configured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendLifecycle {
+    /// Transport is up and usable.
+    Running,
+    /// Deliberately stopped after being idle. Available on demand: the next
+    /// request restarts it. Must NOT trip or heal a circuit breaker, and must
+    /// not be probed by the health loop.
+    Dormant,
+    /// Expected to be usable and is not - crashed, failing probes, or breaker
+    /// open.
+    Unhealthy,
+    /// Never started. The gateway starts backends lazily, so this is the normal
+    /// state for a configured backend nothing has used yet.
+    NotStarted,
+}
+
+impl std::fmt::Display for BackendLifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Running => "running",
+            Self::Dormant => "dormant",
+            Self::Unhealthy => "unhealthy",
+            Self::NotStarted => "not_started",
+        };
+        f.write_str(s)
+    }
+}
+
 /// Backend status information
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct BackendStatus {
@@ -19,6 +54,9 @@ pub struct BackendStatus {
     pub name: String,
     /// Whether backend is running
     pub running: bool,
+    /// Lifecycle state. Distinguishes "stopped on purpose because it was idle"
+    /// from "should be running and is not", which `running: bool` alone cannot.
+    pub lifecycle: BackendLifecycle,
     /// Transport type
     pub transport: String,
     /// Number of cached tools
@@ -89,6 +127,34 @@ pub enum BackendRuntimeState {
 pub struct BackendRegistry {
     /// Backends by name
     backends: DashMap<String, Arc<Backend>>,
+    /// Whether shutdown has begun. Set once by [`BackendRegistry::stop_all`] and
+    /// never cleared.
+    ///
+    /// A LOCK, not an atomic, and that distinction is the whole point.
+    /// `register` holds it across its check AND its insert; `stop_all` holds it
+    /// across setting the flag AND taking its snapshot. Those are the two
+    /// operations that must not interleave, so making each of them atomic
+    /// individually - which two `SeqCst` checks around an insert do NOT achieve
+    /// - is not enough.
+    ///
+    /// The earlier check-then-insert version failed on same-name registrations:
+    /// A inserts, B replaces it and returns success, A's second check passes,
+    /// shutdown snapshots B, and B's own check then removes it. Shutdown stops
+    /// B, the map is empty, and A - which its caller was told was registered,
+    /// and may have started - was never in the snapshot at all. No amount of
+    /// re-checking fixes that; only mutual exclusion does.
+    ///
+    /// Held only across map operations, never across an `.await`.
+    ///
+    /// NOT covered by a behavioural test, and the attempt is instructive: a
+    /// test that holds this lock and asserts `stop_all` blocks passes whether
+    /// or not the latch and the snapshot share one hold, because `stop_all`
+    /// blocks on the latch either way. It looked like a window-positioned test
+    /// and was not. Driving the real interleaving needs a registration paused
+    /// between its check and its insert, which nothing outside `register` can
+    /// arrange. The guarantee here is by construction - one critical section on
+    /// each side - not by demonstration.
+    stopping: parking_lot::Mutex<bool>,
 }
 
 impl BackendRegistry {
@@ -97,12 +163,56 @@ impl BackendRegistry {
     pub fn new() -> Self {
         Self {
             backends: DashMap::new(),
+            stopping: parking_lot::Mutex::new(false),
         }
     }
 
     /// Register a backend
-    pub fn register(&self, backend: Arc<Backend>) {
+    ///
+    /// Refused once shutdown has begun: a backend registered after `stop_all`
+    /// has taken its snapshot would never be stopped, and its process would
+    /// outlive the gateway. Returns `false` when the registration was refused
+    /// for that reason.
+    ///
+    /// The check and the insert happen under one hold of the shutdown lock, so
+    /// a registration that returns `true` has completed its insert before any
+    /// snapshot `stop_all` takes afterwards. That cannot be built from separate
+    /// atomic operations, which is why this is a lock.
+    ///
+    /// The guarantee stops there, and the limit is worth stating because it is
+    /// easy to over-read: this says the entry is IN the map when the snapshot is
+    /// taken, not that it survives until then. Registering the same name again
+    /// REPLACES it - `DashMap::insert` discards the displaced value - so a
+    /// backend that was started and then displaced is stopped by nobody.
+    ///
+    /// KNOWN DEFECT, and it is REACHABLE. `ReloadContext::reload_outcome` has no
+    /// serialization, and it is called from three concurrent HTTP paths: the
+    /// `gateway_reload_config` meta-tool, the admin UI reload, and every admin
+    /// UI backend edit via `write_config_and_reload_outcome`. Two concurrent
+    /// reloads can both stop backend A and then register replacements B and C;
+    /// ordinary traffic can start B in between; C's insert then discards B
+    /// without stopping it, orphaning that process - the exact failure
+    /// `stop_when_idle_for` exists to prevent.
+    ///
+    /// An earlier version of this comment claimed no current caller could hit
+    /// it. That was wrong: it checked that the reload path stops the old
+    /// instance before re-registering, but never checked whether two reloads
+    /// can run at once. The fix is to serialize reload transactions AND make
+    /// registration either reject a duplicate or hand the displaced backend
+    /// back so the caller can stop it. Tracked separately; the replacement
+    /// semantics are pre-existing, the reachability is not new either.
+    #[must_use = "a refused registration means the backend is NOT registered"]
+    pub fn register(&self, backend: Arc<Backend>) -> bool {
+        let stopping = self.stopping.lock();
+        if *stopping {
+            warn!(
+                backend = %backend.name,
+                "Refusing to register a backend during shutdown; it would never be stopped"
+            );
+            return false;
+        }
         self.backends.insert(backend.name.clone(), backend);
+        true
     }
 
     /// Get a backend by name
@@ -134,18 +244,118 @@ impl BackendRegistry {
         self.backends.remove(name).is_some()
     }
 
-    /// Stop all backends
+    /// Stop all backends, concurrently.
+    ///
+    /// Concurrent rather than sequential because `Backend::stop` is bounded but
+    /// not instant - it waits for in-flight starts to resolve and for replaced
+    /// transports to be closed. Stopping N backends one after another
+    /// multiplies that bound by N, so a gateway with a couple of dozen backends
+    /// could spend minutes shutting down in the worst case. Backends own
+    /// independent processes, sessions and locks, so there is nothing to
+    /// serialise: total shutdown is now bounded by the slowest single backend
+    /// rather than the sum of all of them.
     pub async fn stop_all(&self) {
-        for backend in &self.backends {
+        // The latch and the snapshot are taken under ONE hold of the shutdown
+        // lock, which `register` also holds across its check and insert. So a
+        // registration either completes entirely before this snapshot and is in
+        // it, or finds the latch already set and is refused. There is no
+        // interleaving in which a caller is told its backend was registered and
+        // shutdown never sees it.
+        //
+        // No await inside: the stops happen after the guard is dropped.
+        let backends: Vec<std::sync::Arc<Backend>> = {
+            let mut stopping = self.stopping.lock();
+            *stopping = true;
+            self.backends
+                .iter()
+                .map(|entry| std::sync::Arc::clone(entry.value()))
+                .collect()
+        };
+
+        futures::future::join_all(backends.into_iter().map(|backend| async move {
             if let Err(e) = backend.stop().await {
                 warn!(backend = %backend.name, error = %e, "Failed to stop backend");
             }
-        }
+        }))
+        .await;
     }
 }
 
 impl Default for BackendRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::config::{BackendConfig, TransportConfig};
+
+    fn stdio_backend(name: &str) -> Arc<Backend> {
+        let cfg = BackendConfig {
+            transport: TransportConfig::Stdio {
+                command: "/nonexistent-mcp-binary".to_string(),
+                cwd: None,
+                protocol_version: None,
+            },
+            ..BackendConfig::default()
+        };
+        Arc::new(Backend::new(
+            name,
+            cfg,
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        ))
+    }
+
+    // A backend registered after shutdown has taken its snapshot would never be
+    // stopped, and its process would outlive the gateway. Config reload can
+    // genuinely race shutdown, so the registry refuses late registrations
+    // rather than accepting one it cannot honour.
+    #[tokio::test]
+    async fn a_backend_registered_after_shutdown_is_refused() {
+        let registry = BackendRegistry::new();
+        assert!(
+            registry.register(stdio_backend("before")),
+            "registration before shutdown must be accepted"
+        );
+
+        registry.stop_all().await;
+
+        assert!(
+            !registry.register(stdio_backend("after")),
+            "the registry accepted a backend after shutdown; nothing will ever \
+             stop it"
+        );
+        assert!(
+            registry.get("after").is_none(),
+            "a backend refused during shutdown must not be in the registry"
+        );
+    }
+
+    // A refused registration must not disturb an entry someone else registered
+    // successfully under the same name.
+    #[tokio::test]
+    async fn a_refused_registration_does_not_evict_an_existing_one() {
+        let registry = BackendRegistry::new();
+        let original = stdio_backend("shared-name");
+        assert!(registry.register(Arc::clone(&original)));
+
+        registry.stop_all().await;
+
+        assert!(
+            !registry.register(stdio_backend("shared-name")),
+            "a registration during shutdown must be refused"
+        );
+        let still_there = registry
+            .get("shared-name")
+            .expect("the refused registration evicted an entry it did not create");
+        assert!(
+            Arc::ptr_eq(&still_there, &original),
+            "the entry under this name is not the one that was registered"
+        );
     }
 }

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -217,7 +217,9 @@ impl BackendRegistry {
     /// That displacement was reachable (#397): `ReloadContext::reload_outcome`
     /// had no serialization and is called from three concurrent HTTP paths - the
     /// `gateway_reload_config` meta-tool, the admin UI reload, and every admin
-    /// UI backend edit via `write_config_and_reload_outcome`. Two concurrent
+    /// UI backend edit via `write_config_and_reload_outcome`. The config-file
+    /// watcher is a fourth caller; it is not an HTTP path, but it races with
+    /// those three all the same. Two concurrent
     /// reloads could both stop backend A and then register replacements B and C;
     /// ordinary traffic could start B in between; C's insert then discarded B
     /// without stopping it, orphaning that process.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -202,8 +202,71 @@ impl Config {
             .map_err(|e| Error::Config(e.to_string()))?;
         config.expand_env_vars();
         config.validate()?;
+        Self::warn_on_retired_keys(resolved.as_deref());
 
         Ok(config)
+    }
+
+    /// Configuration keys that were removed. Left loadable on purpose: parsing
+    /// tolerates extra keys, so an old file keeps working.
+    const RETIRED_KEYS: &'static [(&'static str, &'static str)] = &[(
+        "idle_timeout",
+        "backend idle hibernation was never implemented; this key is now removed \
+         and has no effect. Delete it from your config — a command that rewrites \
+         the config will drop it silently along with any surrounding comments.",
+    )];
+
+    /// Retired keys present in the config file at `path`, as (key, explanation).
+    ///
+    /// Returns findings rather than logging directly so the detector is testable.
+    /// Parsing is tolerant of extra keys, which is exactly what let `idle_timeout`
+    /// sit in real configs looking effective: accepted, documented as
+    /// "hibernate after N idle", and read by nothing but a `Debug` impl. Ignoring
+    /// it silently now would repeat that mistake more quietly.
+    pub(crate) fn retired_keys_in_file(path: &Path) -> Vec<(&'static str, &'static str)> {
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            return Vec::new();
+        };
+        Self::retired_keys_in_str(&raw)
+    }
+
+    /// Structural scan, split out so tests exercise the shipped logic.
+    ///
+    /// Parses the document and looks for the retired name as an actual mapping
+    /// key under `backends.<name>` — where every real occurrence of
+    /// `idle_timeout` lived. An earlier line-oriented version missed flow-style
+    /// mappings (`backends: {demo: {idle_timeout: 10m}}`), which load fine and
+    /// would therefore have gone unwarned, and could fire on the key's name
+    /// appearing inside a block scalar. Both are real configs; a detector that
+    /// is honest only about the spellings it happens to recognise is the same
+    /// failure this commit removes.
+    pub(crate) fn retired_keys_in_str(raw: &str) -> Vec<(&'static str, &'static str)> {
+        // Unparseable YAML never reaches here through `Config::load`, which
+        // fails on it first. Nothing useful to say about a file we cannot read.
+        let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(raw) else {
+            return Vec::new();
+        };
+        let Some(backends) = doc.get("backends").and_then(serde_yaml::Value::as_mapping) else {
+            return Vec::new();
+        };
+        Self::RETIRED_KEYS
+            .iter()
+            .filter(|(key, _)| {
+                backends.values().any(|backend| {
+                    backend
+                        .as_mapping()
+                        .is_some_and(|fields| fields.keys().any(|k| k.as_str() == Some(*key)))
+                })
+            })
+            .copied()
+            .collect()
+    }
+
+    fn warn_on_retired_keys(path: Option<&Path>) {
+        let Some(path) = path else { return };
+        for (key, why) in Self::retired_keys_in_file(path) {
+            tracing::warn!(config = %path.display(), key = %key, "retired config key: {}", why);
+        }
     }
 
     /// Load environment files into the process environment.
@@ -718,9 +781,6 @@ pub struct BackendConfig {
     /// Transport type.
     #[serde(flatten)]
     pub transport: TransportConfig,
-    /// Idle timeout before hibernation.
-    #[serde(with = "humantime_serde")]
-    pub idle_timeout: Duration,
     /// Request timeout for this backend.
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
@@ -762,7 +822,6 @@ impl std::fmt::Debug for BackendConfig {
             .field("description", &self.description)
             .field("enabled", &self.enabled)
             .field("transport", &self.transport)
-            .field("idle_timeout", &self.idle_timeout)
             .field("timeout", &self.timeout)
             // `env` and `headers` values routinely carry credentials
             // (Authorization bearers, API keys, env-injected secrets). The
@@ -785,7 +844,6 @@ impl Default for BackendConfig {
             description: String::new(),
             enabled: true,
             transport: TransportConfig::default(),
-            idle_timeout: Duration::from_secs(300),
             timeout: Duration::from_secs(30),
             env: HashMap::new(),
             headers: HashMap::new(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -366,6 +366,7 @@ impl Config {
         self.validate_required_env_references()?;
         self.runtime.validate()?;
         self.validate_backend_runtime_profiles()?;
+        self.validate_stop_when_idle_ownership()?;
         self.control_plane.role_mapping.validate()?;
         self.validate_identity_propagation()?;
         self.key_server.validate()?;
@@ -617,6 +618,42 @@ impl Config {
 
         Ok(())
     }
+
+    /// `stop_when_idle_for` is meaningful only where the gateway OWNS the backend
+    /// process - a backend declared with a `command`, which the gateway spawned
+    /// and can therefore stop and restart.
+    ///
+    /// For an externally managed endpoint the gateway can close its client
+    /// connection, but that does not stop the server on the other end, so the
+    /// setting would promise a reclaim it cannot perform. Locality does not grant
+    /// ownership: a local HTTP MCP server on 127.0.0.1 is still not ours to stop.
+    ///
+    /// This rejects rather than ignores, deliberately. The predecessor key
+    /// `idle_timeout` was accepted everywhere and enforced nowhere; one operator
+    /// had it set on 24 backends believing it worked. Silently accepting a
+    /// setting the gateway cannot honour is the exact failure being corrected.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error naming the backend when the setting is present
+    /// on a backend the gateway does not start.
+    fn validate_stop_when_idle_ownership(&self) -> Result<()> {
+        for (name, backend) in &self.backends {
+            if backend.stop_when_idle_for.is_none() {
+                continue;
+            }
+            if !matches!(backend.transport, TransportConfig::Stdio { .. }) {
+                return Err(Error::ConfigValidation(format!(
+                    "backends.{name}.stop_when_idle_for is only valid for a backend the gateway \
+                     starts itself (one declared with a `command`). This backend is reached over \
+                     a URL the gateway did not start, so closing the connection would not stop \
+                     it. Remove the setting, or run that server under the gateway as a stdio \
+                     backend."
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 fn remote_transport_identity(transport: &TransportConfig) -> Option<(&'static str, &str)> {
@@ -781,6 +818,20 @@ pub struct BackendConfig {
     /// Transport type.
     #[serde(flatten)]
     pub transport: TransportConfig,
+    /// Stop this backend's process after it has been unused for this long,
+    /// restarting it on the next request.
+    ///
+    /// Valid ONLY for a backend whose process the gateway owns — one declared
+    /// with a `command`. For an externally managed HTTP endpoint the gateway can
+    /// close its client connection but cannot stop the server on the other end,
+    /// so the setting is rejected at config load rather than silently accepted.
+    /// Locality does not grant ownership: a local HTTP MCP server is still not
+    /// ours to stop.
+    ///
+    /// `None` means never stop the backend once started, which is the historical
+    /// behaviour.
+    #[serde(default, with = "humantime_serde::option")]
+    pub stop_when_idle_for: Option<Duration>,
     /// Request timeout for this backend.
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
@@ -822,6 +873,7 @@ impl std::fmt::Debug for BackendConfig {
             .field("description", &self.description)
             .field("enabled", &self.enabled)
             .field("transport", &self.transport)
+            .field("stop_when_idle_for", &self.stop_when_idle_for)
             .field("timeout", &self.timeout)
             // `env` and `headers` values routinely carry credentials
             // (Authorization bearers, API keys, env-injected secrets). The
@@ -844,6 +896,7 @@ impl Default for BackendConfig {
             description: String::new(),
             enabled: true,
             transport: TransportConfig::default(),
+            stop_when_idle_for: None,
             timeout: Duration::from_secs(30),
             env: HashMap::new(),
             headers: HashMap::new(),
@@ -1050,6 +1103,28 @@ pub mod humantime_serde {
 
     use serde::{self, Deserialize, Deserializer, Serializer};
 
+    /// Parse a human-readable duration such as `"30s"`, `"5m"`, `"100ms"`.
+    ///
+    /// NOTE: `"ms"` is tested BEFORE `"s"`. The previous implementation tested
+    /// `"s"` first, so `"100ms"` took the seconds branch and failed to parse
+    /// `"100m"` as an integer — every `ms` value in every duration field was
+    /// rejected. Bare integers are seconds.
+    fn parse(text: &str) -> Result<Duration, String> {
+        let text = text.trim();
+        if let Some(ms) = text.strip_suffix("ms") {
+            ms.parse::<u64>().map(Duration::from_millis)
+        } else if let Some(secs) = text.strip_suffix('s') {
+            secs.parse::<u64>().map(Duration::from_secs)
+        } else if let Some(mins) = text.strip_suffix('m') {
+            mins.parse::<u64>().map(|m| Duration::from_secs(m * 60))
+        } else if let Some(hours) = text.strip_suffix('h') {
+            hours.parse::<u64>().map(|h| Duration::from_secs(h * 3600))
+        } else {
+            text.parse::<u64>().map(Duration::from_secs)
+        }
+        .map_err(|e| format!("invalid duration {text:?}: {e}"))
+    }
+
     /// Serialize `Duration` to a human-readable string (e.g., `"30s"`).
     ///
     /// # Errors
@@ -1062,33 +1137,53 @@ pub mod humantime_serde {
         serializer.serialize_str(&format!("{}s", duration.as_secs()))
     }
 
-    /// Deserialize a human-readable duration string (e.g., `"30s"`, `"5m"`, `"100ms"`).
+    /// Deserialize a human-readable duration string.
     ///
     /// # Errors
     ///
-    /// Returns a deserialization error if the string cannot be parsed as a duration.
+    /// Returns a deserialization error if the string cannot be parsed.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let text = String::deserialize(deserializer)?;
+        parse(&text).map_err(serde::de::Error::custom)
+    }
 
-        if let Some(secs) = s.strip_suffix('s') {
-            secs.parse::<u64>()
-                .map(Duration::from_secs)
-                .map_err(serde::de::Error::custom)
-        } else if let Some(mins) = s.strip_suffix('m') {
-            mins.parse::<u64>()
-                .map(|m| Duration::from_secs(m * 60))
-                .map_err(serde::de::Error::custom)
-        } else if let Some(ms) = s.strip_suffix("ms") {
-            ms.parse::<u64>()
-                .map(Duration::from_millis)
-                .map_err(serde::de::Error::custom)
-        } else {
-            s.parse::<u64>()
-                .map(Duration::from_secs)
-                .map_err(serde::de::Error::custom)
+    /// Same encoding for an optional duration. A missing key deserialises to
+    /// `None`, so "unset" stays distinguishable from any real value — no magic
+    /// zero standing in for "never".
+    pub mod option {
+        use std::time::Duration;
+
+        use serde::{Deserialize, Deserializer, Serializer};
+
+        /// # Errors
+        ///
+        /// Returns a serialization error if the serializer fails.
+        pub fn serialize<S>(value: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match value {
+                Some(d) => super::serialize(d, serializer),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        /// # Errors
+        ///
+        /// Returns a deserialization error if the string cannot be parsed.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            match Option::<String>::deserialize(deserializer)? {
+                None => Ok(None),
+                Some(text) => super::parse(&text)
+                    .map(Some)
+                    .map_err(serde::de::Error::custom),
+            }
         }
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -803,64 +803,113 @@ fn validate_accepts_identity_propagation_with_disabled_backend_oauth() {
     );
 }
 
-/// `idle_timeout` was accepted, documented as "hibernate after N idle", and read
-/// by nothing but a `Debug` impl. Parsing tolerates extra keys, so simply
-/// deleting the field would let it keep sitting in real configs looking
-/// effective. A retired key must announce itself — and the assertions below call
-/// the SHIPPED detector, not a copy of its logic.
+// ── GW.IDLE.3 — ownership validation ────────────────────────────────────────
+//
+// `stop_when_idle_for` promises the gateway will stop a process. It can only
+// honour that where it started the process. Accepting it elsewhere would repeat
+// nowhere, trusted by operators.
+
 #[test]
-fn config_with_retired_idle_timeout_still_loads() {
+fn stop_when_idle_for_is_accepted_on_a_gateway_started_backend() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("gateway.yaml");
-    // NOTE: `backends:` is the real key. An earlier version of this test used
-    // `servers:`, which the root config ignores — it loaded ZERO backends and so
-    // never exercised a backend carrying the retired key at all.
     std::fs::write(
         &path,
-        "backends:\n  demo:\n    command: \"echo hi\"\n    idle_timeout: 10m\n",
+        "backends:\n  owned:\n    command: \"echo hi\"\n    stop_when_idle_for: 5m\n",
     )
-    .expect("write config");
+    .expect("write");
 
-    let cfg = Config::load(Some(&path)).expect("a config carrying a retired key must still load");
-    assert!(
-        cfg.backends.contains_key("demo"),
-        "the backend carrying the retired key must survive parsing, \
-         otherwise this test proves nothing about that backend"
-    );
-}
-
-#[test]
-fn retired_idle_timeout_key_is_detected() {
-    let found = Config::retired_keys_in_str(
-        "backends:\n  demo:\n    command: \"echo hi\"\n    idle_timeout: 10m\n",
-    );
+    let cfg = Config::load(Some(&path)).expect("stdio backend may opt in");
+    let backend = cfg
+        .backends
+        .get("owned")
+        .expect("backend must survive parsing");
     assert_eq!(
-        found.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
-        vec!["idle_timeout"],
-        "the shipped detector must see the retired key"
+        backend.stop_when_idle_for,
+        Some(std::time::Duration::from_secs(300)),
+        "the duration must round-trip, not silently default"
     );
 }
 
 #[test]
-fn retired_key_detector_ignores_comments_and_clean_configs() {
+fn stop_when_idle_for_is_rejected_on_a_backend_the_gateway_does_not_start() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    // A LOCAL http backend: locality does not grant ownership. The gateway did
+    // not start this server and cannot stop it.
+    std::fs::write(
+        &path,
+        "backends:\n  external:\n    http_url: \"http://127.0.0.1:39400/mcp\"\n    stop_when_idle_for: 5m\n",
+    )
+    .expect("write");
+
+    let err =
+        Config::load(Some(&path)).expect_err("the gateway cannot stop a process it did not start");
+    let msg = err.to_string();
     assert!(
-        Config::retired_keys_in_str(
-            "backends:\n  demo:\n    # idle_timeout: 10m  (removed)\n    command: \"echo hi\"\n"
-        )
-        .is_empty(),
-        "a commented-out key must not warn"
+        msg.contains("external"),
+        "the error must name the offending backend, got: {msg}"
     );
     assert!(
-        Config::retired_keys_in_str("backends:\n  demo:\n    command: \"echo hi\"\n").is_empty(),
-        "a clean config must not warn"
+        msg.contains("stop_when_idle_for"),
+        "the error must name the setting, got: {msg}"
     );
 }
 
 #[test]
-fn retired_key_detector_sees_quoted_keys() {
+fn omitting_stop_when_idle_for_leaves_a_backend_running_indefinitely() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(&path, "backends:\n  owned:\n    command: \"echo hi\"\n").expect("write");
+
+    let cfg = Config::load(Some(&path)).expect("load");
+    assert_eq!(
+        cfg.backends
+            .get("owned")
+            .expect("backend")
+            .stop_when_idle_for,
+        None,
+        "absent must mean never stop - no magic default that changes behaviour on upgrade"
+    );
+}
+
+#[test]
+fn an_http_backend_without_the_setting_still_loads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &path,
+        "backends:\n  external:\n    http_url: \"http://127.0.0.1:39400/mcp\"\n",
+    )
+    .expect("write");
+
+    let cfg = Config::load(Some(&path)).expect("http backends are fine without the setting");
     assert!(
-        !Config::retired_keys_in_str("backends:\n  demo:\n    \"idle_timeout\": 10m\n").is_empty(),
-        "YAML permits quoting the key; the detector must not miss that spelling"
+        cfg.backends.contains_key("external"),
+        "control: the validation must reject only the setting, not the transport"
+    );
+}
+
+#[test]
+fn duration_parser_handles_milliseconds() {
+    // Regression: the parser tested the "s" suffix BEFORE "ms", so "100ms" took
+    // the seconds branch and failed to parse "100m" as an integer. Every ms value
+    // in every duration field was rejected.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &path,
+        "backends:\n  owned:\n    command: \"echo hi\"\n    stop_when_idle_for: 1500ms\n",
+    )
+    .expect("write");
+
+    let cfg = Config::load(Some(&path)).expect("ms suffix must parse");
+    assert_eq!(
+        cfg.backends
+            .get("owned")
+            .expect("backend")
+            .stop_when_idle_for,
+        Some(std::time::Duration::from_millis(1500))
     );
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -933,7 +933,7 @@ fn retired_key_detector_sees_flow_style_mappings() {
 fn retired_key_detector_ignores_the_name_inside_values() {
     assert!(
         Config::retired_keys_in_str(
-            "backends:\n  demo:\n    command: \"echo hi\"\n    description: |\n      idle_timeout: 10m was removed in 4.0.0\n"
+            "backends:\n  demo:\n    command: \"echo hi\"\n    description: |\n      idle_timeout: 10m is no longer supported\n"
         )
         .is_empty(),
         "the key name appearing inside a block scalar is text, not a set key"

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -802,3 +802,114 @@ fn validate_accepts_identity_propagation_with_disabled_backend_oauth() {
         "disabled backend oauth must not trip the F3 gate"
     );
 }
+
+/// `idle_timeout` was accepted, documented as "hibernate after N idle", and read
+/// by nothing but a `Debug` impl. Parsing tolerates extra keys, so simply
+/// deleting the field would let it keep sitting in real configs looking
+/// effective. A retired key must announce itself — and the assertions below call
+/// the SHIPPED detector, not a copy of its logic.
+#[test]
+fn config_with_retired_idle_timeout_still_loads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    // NOTE: `backends:` is the real key. An earlier version of this test used
+    // `servers:`, which the root config ignores — it loaded ZERO backends and so
+    // never exercised a backend carrying the retired key at all.
+    std::fs::write(
+        &path,
+        "backends:\n  demo:\n    command: \"echo hi\"\n    idle_timeout: 10m\n",
+    )
+    .expect("write config");
+
+    let cfg = Config::load(Some(&path)).expect("a config carrying a retired key must still load");
+    assert!(
+        cfg.backends.contains_key("demo"),
+        "the backend carrying the retired key must survive parsing, \
+         otherwise this test proves nothing about that backend"
+    );
+}
+
+#[test]
+fn retired_idle_timeout_key_is_detected() {
+    let found = Config::retired_keys_in_str(
+        "backends:\n  demo:\n    command: \"echo hi\"\n    idle_timeout: 10m\n",
+    );
+    assert_eq!(
+        found.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+        vec!["idle_timeout"],
+        "the shipped detector must see the retired key"
+    );
+}
+
+#[test]
+fn retired_key_detector_ignores_comments_and_clean_configs() {
+    assert!(
+        Config::retired_keys_in_str(
+            "backends:\n  demo:\n    # idle_timeout: 10m  (removed)\n    command: \"echo hi\"\n"
+        )
+        .is_empty(),
+        "a commented-out key must not warn"
+    );
+    assert!(
+        Config::retired_keys_in_str("backends:\n  demo:\n    command: \"echo hi\"\n").is_empty(),
+        "a clean config must not warn"
+    );
+}
+
+#[test]
+fn retired_key_detector_sees_quoted_keys() {
+    assert!(
+        !Config::retired_keys_in_str("backends:\n  demo:\n    \"idle_timeout\": 10m\n").is_empty(),
+        "YAML permits quoting the key; the detector must not miss that spelling"
+    );
+}
+
+/// Flow style is valid YAML and loads identically to the block form. A
+/// line-oriented detector saw nothing here, so an operator whose config used
+/// flow mappings got the removal with no warning at all — the exact silence
+/// this warning exists to break.
+#[test]
+fn retired_key_detector_sees_flow_style_mappings() {
+    assert!(
+        !Config::retired_keys_in_str("backends: {demo: {command: \"echo hi\", idle_timeout: 10m}}")
+            .is_empty(),
+        "flow-style mappings are valid YAML; the detector must see the key there too"
+    );
+}
+
+/// The mirror failure: the key's NAME inside a value is not a use of the key.
+/// A CHANGELOG excerpt or a description quoting `idle_timeout:` must not make
+/// the gateway warn about a config that never set it.
+#[test]
+fn retired_key_detector_ignores_the_name_inside_values() {
+    assert!(
+        Config::retired_keys_in_str(
+            "backends:\n  demo:\n    command: \"echo hi\"\n    description: |\n      idle_timeout: 10m was removed in 4.0.0\n"
+        )
+        .is_empty(),
+        "the key name appearing inside a block scalar is text, not a set key"
+    );
+}
+
+/// `Config::load` warns by reading the file from disk, a path the string-level
+/// tests never touch. Without this, the detector could be perfect and still be
+/// wired to nothing.
+#[test]
+fn retired_key_detector_reads_the_loaded_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &path,
+        "backends:\n  demo:\n    command: \"echo hi\"\n    idle_timeout: 10m\n",
+    )
+    .expect("write config");
+
+    assert_eq!(
+        Config::retired_keys_in_file(&path)
+            .iter()
+            .map(|(k, _)| *k)
+            .collect::<Vec<_>>(),
+        vec!["idle_timeout"],
+        "the file-reading path Config::load uses must find the retired key"
+    );
+}

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -93,6 +93,53 @@ pub async fn write_config_and_reload_outcome(
     Ok(None)
 }
 
+/// What a guarded read-modify-write did: either the change was applied and
+/// persisted, or the caller's own check rejected it and nothing was written.
+pub enum ConfigMutation<T, E> {
+    /// The change was applied, persisted, and (when a reload context exists)
+    /// reloaded.
+    Applied(T, Option<ReloadOutcome>),
+    /// The caller's closure refused the change. The file is untouched.
+    Rejected(E),
+}
+
+/// Read the config, apply `mutate` to it, and persist the result without
+/// letting another writer slip in between the read and the write.
+///
+/// Reading outside the lock is what makes edits vanish: two requests each read
+/// the same starting file, each apply their own change to that stale copy, and
+/// the second write erases the first change while reporting success. Doing the
+/// read inside the same critical section as the write is what stops it.
+///
+/// # Errors
+///
+/// Returns an error string on validation, write, rename, or reload failure. A
+/// refusal from `mutate` is not an error; it comes back as
+/// [`ConfigMutation::Rejected`] with the file untouched.
+pub async fn mutate_config_and_reload<T, E, F>(
+    path: &Path,
+    reload_context: Option<&ReloadContext>,
+    mutate: F,
+) -> Result<ConfigMutation<T, E>, String>
+where
+    F: FnOnce(&mut Config) -> Result<T, E>,
+{
+    if let Some(ctx) = reload_context {
+        return ctx.mutate_and_reload_outcome(path, mutate).await;
+    }
+
+    // No live gateway to reload, so no reload lock exists to hold. This path is
+    // the CLI acting on a config file nothing else is serving.
+    let mut config = load_config_or_default(path);
+    match mutate(&mut config) {
+        Ok(value) => {
+            write_config(path, &config)?;
+            Ok(ConfigMutation::Applied(value, None))
+        }
+        Err(rejection) => Ok(ConfigMutation::Rejected(rejection)),
+    }
+}
+
 fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
     #[cfg(windows)]
     {

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -102,10 +102,14 @@ fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
     #[cfg(not(windows))]
     {
         let tmp_path = temp_config_path(path);
-        std::fs::write(&tmp_path, yaml).map_err(|e| format!("Failed to write temp config: {e}"))?;
+        // Leave no debris behind on either failure. The scratch name is unique
+        // per call, so without cleanup each failure would strand one more file
+        // next to the config instead of reusing a single stale one.
+        std::fs::write(&tmp_path, yaml).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            format!("Failed to write temp config: {e}")
+        })?;
         std::fs::rename(&tmp_path, path).map_err(|e| {
-            // Leave no debris behind: the temp name is unique per call, so a
-            // failed rename would otherwise accumulate one orphan per failure.
             let _ = std::fs::remove_file(&tmp_path);
             format!("Failed to replace config file: {e}")
         })
@@ -181,17 +185,39 @@ mod tests {
     }
 
     /// Concurrent writers must each either persist their own bytes or fail
-    /// honestly. Against a shared temp path one writer's rename finds the file
-    /// already renamed away and fails with "Failed to replace config file".
+    /// honestly, and the file left behind must be exactly one writer's config.
+    /// Against a shared scratch path one writer's rename finds the file already
+    /// renamed away and fails with "Failed to replace config file", and the
+    /// bytes that land can belong to a writer that reported success elsewhere.
     #[test]
     fn concurrent_config_writes_do_not_lose_the_temp_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("gateway.yaml");
 
+        // Each writer's config is distinguishable, so the assertion below can
+        // tell "one writer won" from "the file is a mix of two writers".
+        let config_for = |writer: usize| {
+            let mut config = Config::default();
+            config.backends.insert(
+                format!("writer-{writer}"),
+                crate::config::BackendConfig {
+                    transport: crate::config::TransportConfig::Http {
+                        http_url: "http://127.0.0.1:9/mcp".to_string(),
+                        streamable_http: false,
+                        protocol_version: None,
+                    },
+                    ..crate::config::BackendConfig::default()
+                },
+            );
+            config
+        };
+
         for _ in 0..40 {
             let errors: Vec<String> = std::thread::scope(|scope| {
+                let path = &path;
+                let config_for = &config_for;
                 let handles: Vec<_> = (0..8)
-                    .map(|_| scope.spawn(|| write_config(&path, &Config::default())))
+                    .map(|writer| scope.spawn(move || write_config(path, &config_for(writer))))
                     .collect();
                 handles
                     .into_iter()
@@ -201,11 +227,31 @@ mod tests {
 
             assert!(
                 errors.is_empty(),
-                "concurrent writers collided on the temp file: {errors:?}"
+                "concurrent writers collided on the scratch file: {errors:?}"
+            );
+
+            let loaded = Config::load(Some(&path)).expect("config left unparseable");
+            let names: Vec<&String> = loaded.backends.keys().collect();
+            assert_eq!(
+                names.len(),
+                1,
+                "persisted config is not any single writer's: {names:?}"
+            );
+            assert!(
+                names[0].starts_with("writer-"),
+                "persisted config is not any single writer's: {names:?}"
             );
         }
 
-        assert!(Config::load(Some(&path)).is_ok(), "config left unparseable");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .filter(|name| name != "gateway.yaml")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "scratch files were left next to the config: {leftovers:?}"
+        );
     }
 
     #[test]

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -5,6 +5,8 @@
 use std::path::Path;
 #[cfg(not(windows))]
 use std::path::PathBuf;
+#[cfg(not(windows))]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::config::Config;
 use crate::config_reload::{ReloadContext, ReloadOutcome};
@@ -81,16 +83,13 @@ pub async fn write_config_and_reload_outcome(
     config: &Config,
     reload_context: Option<&ReloadContext>,
 ) -> Result<Option<ReloadOutcome>, String> {
-    write_config(path, config)?;
-
     if let Some(ctx) = reload_context {
-        let outcome = ctx
-            .reload_outcome()
-            .await
-            .map_err(|e| format!("Config written but reload failed: {e}"))?;
-        return Ok(Some(outcome));
+        // Write and reload share one lock inside the context. Writing here
+        // first would reopen the race the lock exists to close.
+        return ctx.write_and_reload_outcome(path, config).await.map(Some);
     }
 
+    write_config(path, config)?;
     Ok(None)
 }
 
@@ -104,14 +103,32 @@ fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
     {
         let tmp_path = temp_config_path(path);
         std::fs::write(&tmp_path, yaml).map_err(|e| format!("Failed to write temp config: {e}"))?;
-        std::fs::rename(&tmp_path, path).map_err(|e| format!("Failed to replace config file: {e}"))
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            // Leave no debris behind: the temp name is unique per call, so a
+            // failed rename would otherwise accumulate one orphan per failure.
+            let _ = std::fs::remove_file(&tmp_path);
+            format!("Failed to replace config file: {e}")
+        })
     }
 }
 
+/// A temp path unique to this call, in the same directory as `path` so the
+/// rename stays atomic.
+///
+/// Uniqueness is the point. A shared `<config>.tmp` lets two concurrent writers
+/// collide: both write the same temp file, the first rename ships whichever
+/// bytes landed last while reporting its own edit saved, and the second rename
+/// fails because the file it wrote is already gone.
 #[cfg(not(windows))]
 fn temp_config_path(path: &Path) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
     let mut tmp_path = path.as_os_str().to_os_string();
-    tmp_path.push(".tmp");
+    tmp_path.push(format!(
+        ".tmp.{}.{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
     PathBuf::from(tmp_path)
 }
 
@@ -140,6 +157,55 @@ mod tests {
         assert!(path.exists());
         let loaded = Config::load(Some(&path)).unwrap();
         assert_eq!(loaded.backends.len(), config.backends.len());
+    }
+
+    /// The temp file used by an atomic config write must be unique per call.
+    /// A shared `<config>.tmp` lets two concurrent writers clobber each other:
+    /// one renames the other's bytes into place and reports its own edit saved.
+    #[cfg(not(windows))]
+    #[test]
+    fn each_config_write_gets_its_own_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway.yaml");
+
+        let first = temp_config_path(&path);
+        let second = temp_config_path(&path);
+
+        assert_ne!(
+            first, second,
+            "two writers shared one temp path, so either can overwrite the other"
+        );
+        for tmp in [&first, &second] {
+            assert_eq!(tmp.parent(), path.parent(), "temp file left its directory");
+        }
+    }
+
+    /// Concurrent writers must each either persist their own bytes or fail
+    /// honestly. Against a shared temp path one writer's rename finds the file
+    /// already renamed away and fails with "Failed to replace config file".
+    #[test]
+    fn concurrent_config_writes_do_not_lose_the_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway.yaml");
+
+        for _ in 0..40 {
+            let errors: Vec<String> = std::thread::scope(|scope| {
+                let handles: Vec<_> = (0..8)
+                    .map(|_| scope.spawn(|| write_config(&path, &Config::default())))
+                    .collect();
+                handles
+                    .into_iter()
+                    .filter_map(|h| h.join().unwrap().err())
+                    .collect()
+            });
+
+            assert!(
+                errors.is_empty(),
+                "concurrent writers collided on the temp file: {errors:?}"
+            );
+        }
+
+        assert!(Config::load(Some(&path)).is_ok(), "config left unparseable");
     }
 
     #[test]

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -89,8 +89,7 @@ const NO_CHANGES_SUMMARY: &str = "no changes detected";
 /// fix, the other is normal shutdown, and they must not share an alert. The
 /// honest fix is a typed error, but `reload_outcome` returns `Result<_, String>`
 /// to callers outside this crate, so changing its shape is a next-major job.
-const SHUTDOWN_ABORTED_ERROR: &str =
-    "config reload aborted: the gateway is shutting down and refused to register \
+const SHUTDOWN_ABORTED_ERROR: &str = "config reload aborted: the gateway is shutting down and refused to register \
      one or more backends";
 
 /// Structured reload outcome for callers that need more than a log line.
@@ -769,13 +768,8 @@ impl ConfigWatcher {
             // covering the reload lock only ever exercised the other two entry
             // points: an edit that moved the lock here alone would not have
             // failed a single test.
-            let ctx = ReloadContext::new(
-                config_path,
-                live_config,
-                registry,
-                failsafe_cfg,
-                cache_ttl,
-            );
+            let ctx =
+                ReloadContext::new(config_path, live_config, registry, failsafe_cfg, cache_ttl);
 
             loop {
                 tokio::select! {
@@ -870,7 +864,6 @@ fn load_config_patch(
         Ok(Some((new_config, patch)))
     }
 }
-
 
 // ============================================================================
 // ReloadContext — imperative reload handle for the meta-tool

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -83,6 +83,16 @@ pub struct ConfigPatch {
 /// literal that could drift away from the one `no_changes` writes.
 const NO_CHANGES_SUMMARY: &str = "no changes detected";
 
+/// Error text a reload returns when the registry refused a backend because the
+/// gateway is shutting down. A shared constant because the file-watcher has to
+/// tell this apart from a bad config file: one is a broken file an operator must
+/// fix, the other is normal shutdown, and they must not share an alert. The
+/// honest fix is a typed error, but `reload_outcome` returns `Result<_, String>`
+/// to callers outside this crate, so changing its shape is a next-major job.
+const SHUTDOWN_ABORTED_ERROR: &str =
+    "config reload aborted: the gateway is shutting down and refused to register \
+     one or more backends";
+
 /// Structured reload outcome for callers that need more than a log line.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ReloadOutcome {
@@ -795,10 +805,19 @@ impl ConfigWatcher {
                                         "Config reload: complete"
                                     );
                                 }
+                                Err(e) if e == SHUTDOWN_ABORTED_ERROR => {
+                                    warn!(
+                                        "Config reload: aborted, the gateway is \
+                                         shutting down; keeping the previous live \
+                                         config rather than publishing one that \
+                                         describes backends which were never \
+                                         registered"
+                                    );
+                                }
                                 Err(e) => {
                                     warn!(
                                         error = %e,
-                                        "Config reload failed; keeping the current config"
+                                        "Config reload: failed to parse config file, keeping current config"
                                     );
                                 }
                             }
@@ -929,11 +948,7 @@ impl ReloadContext {
             // Publishing here would describe backends the registry refused, and
             // report a reload that did not happen. The caller asked for an
             // outcome; the honest one is an error.
-            return Err(
-                "config reload aborted: the gateway is shutting down and refused \
-                 to register one or more backends"
-                    .to_string(),
-            );
+            return Err(SHUTDOWN_ABORTED_ERROR.to_string());
         }
 
         self.live_config.set(new_config);

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -815,6 +815,13 @@ impl ConfigWatcher {
                                     );
                                 }
                                 Err(e) => {
+                                    // Every other error out of `reload_outcome`
+                                    // comes from reading or parsing the file:
+                                    // that call has exactly two failure sources
+                                    // and the arm above catches the other one. A
+                                    // third source added later lands here and
+                                    // would be mislabelled, so give it its own
+                                    // arm rather than widening this message.
                                     warn!(
                                         error = %e,
                                         "Config reload: failed to parse config file, keeping current config"

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -931,9 +931,10 @@ impl ReloadContext {
     /// Returns an error string if the config file cannot be read or parsed.
     pub async fn reload_outcome(&self) -> std::result::Result<ReloadOutcome, String> {
         // Serializes the whole reload transaction (#397) - read, diff, apply,
-        // publish. All three concurrent entry points (the meta-tool, the admin
-        // UI reload, and every admin UI backend edit) land here. See
-        // `apply_patch` for why the lock cannot live one level down.
+        // publish. All four concurrent entry points land here: the
+        // `gateway_reload_config` meta-tool, the admin UI reload, every admin UI
+        // backend edit, and the config-file watcher. See `apply_patch` for why
+        // the lock cannot live one level down.
         let _reload_guard = self.registry.lock_reload().await;
 
         let Some((new_config, patch)) = load_config_patch(&self.config_path, &self.live_config)?

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -449,6 +449,15 @@ fn backend_config_changed(old: &BackendConfig, new: &BackendConfig) -> bool {
 /// solely after the permanent shutdown latch, so the inconsistency is bounded
 /// to a gateway that is terminating anyway. If registration ever becomes
 /// refusable for another reason, this needs a rollback rather than a flag.
+/// The caller must hold [`BackendRegistry::lock_reload`] across the whole
+/// transaction that surrounds this call - reading the live config, diffing it,
+/// applying the patch, and publishing the new config (#397). Taking the lock
+/// inside this function is not enough: the patch is computed against the live
+/// config beforehand, so two reloads can each compute a patch that adds the
+/// same backend, queue here, and register two instances under one name. The
+/// second registration discards the first without stopping it, and if traffic
+/// started that first instance in the gap its child process is orphaned. Both
+/// callers in this module take the lock before they read the config.
 #[must_use = "a partly applied patch must not be published as the live config"]
 pub async fn apply_patch(
     patch: &ConfigPatch,
@@ -815,6 +824,15 @@ async fn reload_once(
     failsafe_cfg: &crate::config::FailsafeConfig,
     cache_ttl: Duration,
 ) {
+    // Serializes the whole reload transaction (#397): the config read, the
+    // diff, the patch, and the publish. Two reloads that each diff against the
+    // same live config would both decide to register the same backend, and the
+    // second registration discards the first without stopping it - leaking the
+    // child process if traffic started it in between. Taking this lock only
+    // around `apply_patch` would not help, because the stale diff is already
+    // computed by then.
+    let _reload_guard = registry.lock_reload().await;
+
     let Some((new_config, patch)) = (match load_config_patch(config_path, live_config) {
         Ok(result) => result,
         Err(e) => {
@@ -910,6 +928,12 @@ impl ReloadContext {
     ///
     /// Returns an error string if the config file cannot be read or parsed.
     pub async fn reload_outcome(&self) -> std::result::Result<ReloadOutcome, String> {
+        // Serializes the whole reload transaction (#397) - read, diff, apply,
+        // publish. All three concurrent entry points (the meta-tool, the admin
+        // UI reload, and every admin UI backend edit) land here. See
+        // `apply_patch` for why the lock cannot live one level down.
+        let _reload_guard = self.registry.lock_reload().await;
+
         let Some((new_config, patch)) = load_config_patch(&self.config_path, &self.live_config)?
         else {
             return Ok(ReloadOutcome::no_changes());

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -929,7 +929,36 @@ impl ReloadContext {
         // backend edit, and the config-file watcher. See `apply_patch` for why
         // the lock cannot live one level down.
         let _reload_guard = self.registry.lock_reload().await;
+        self.reload_outcome_locked().await
+    }
 
+    /// Write `config` to `path`, then reload, with both steps under one lock.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string on validation, serialization, write, rename, or
+    /// reload failure.
+    ///
+    /// The write must be inside the same critical section as the reload. Two
+    /// admin UI edits that write first and lock second can interleave so that
+    /// one reload reads the other's file, and the caller is told its own edit
+    /// was applied. Holding one guard across write-read-apply-publish is what
+    /// makes an edit's own bytes the ones it reloads.
+    pub async fn write_and_reload_outcome(
+        &self,
+        path: &std::path::Path,
+        config: &Config,
+    ) -> std::result::Result<ReloadOutcome, String> {
+        let _reload_guard = self.registry.lock_reload().await;
+        crate::config_persistence::write_config(path, config)?;
+        self.reload_outcome_locked()
+            .await
+            .map_err(|e| format!("Config written but reload failed: {e}"))
+    }
+
+    /// The reload transaction itself. The caller must already hold the reload
+    /// lock; taking it here as well would deadlock on the non-reentrant mutex.
+    async fn reload_outcome_locked(&self) -> std::result::Result<ReloadOutcome, String> {
         let Some((new_config, patch)) = load_config_patch(&self.config_path, &self.live_config)?
         else {
             return Ok(ReloadOutcome::no_changes());

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -956,6 +956,41 @@ impl ReloadContext {
             .map_err(|e| format!("Config written but reload failed: {e}"))
     }
 
+    /// Read the config, apply `mutate`, write, and reload, all under one guard.
+    ///
+    /// The read belongs inside the guard. Two admin UI edits that each read the
+    /// file before locking will each build their change on the same starting
+    /// copy, and whichever writes second erases the other's change while
+    /// telling its caller the edit was saved.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string on write, rename, or reload failure. A refusal
+    /// from `mutate` comes back as `ConfigMutation::Rejected`, not an error.
+    pub async fn mutate_and_reload_outcome<T, E, F>(
+        &self,
+        path: &std::path::Path,
+        mutate: F,
+    ) -> std::result::Result<crate::config_persistence::ConfigMutation<T, E>, String>
+    where
+        F: FnOnce(&mut Config) -> std::result::Result<T, E>,
+    {
+        use crate::config_persistence::ConfigMutation;
+
+        let _reload_guard = self.registry.lock_reload().await;
+        let mut config = crate::config_persistence::load_config_or_default(path);
+        let value = match mutate(&mut config) {
+            Ok(value) => value,
+            Err(rejection) => return Ok(ConfigMutation::Rejected(rejection)),
+        };
+        crate::config_persistence::write_config(path, &config)?;
+        let outcome = self
+            .reload_outcome_locked()
+            .await
+            .map_err(|e| format!("Config written but reload failed: {e}"))?;
+        Ok(ConfigMutation::Applied(value, Some(outcome)))
+    }
+
     /// The reload transaction itself. The caller must already hold the reload
     /// lock; taking it here as well would deadlock on the non-reentrant mutex.
     async fn reload_outcome_locked(&self) -> std::result::Result<ReloadOutcome, String> {

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -78,6 +78,11 @@ pub struct ConfigPatch {
     pub profiles_changed: bool,
 }
 
+/// Summary text a reload reports when the file on disk matches the live config.
+/// Shared so the file-watcher can recognise the no-op case without matching on a
+/// literal that could drift away from the one `no_changes` writes.
+const NO_CHANGES_SUMMARY: &str = "no changes detected";
+
 /// Structured reload outcome for callers that need more than a log line.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ReloadOutcome {
@@ -172,7 +177,7 @@ impl ReloadOutcome {
     #[must_use]
     pub fn no_changes() -> Self {
         Self {
-            changes: "no changes detected".to_string(),
+            changes: NO_CHANGES_SUMMARY.to_string(),
             restart_required: false,
             restart_reason: None,
         }
@@ -748,6 +753,20 @@ impl ConfigWatcher {
             let mut pending_trigger: Option<ReloadTrigger> = None;
             let mut ticker = tokio::time::interval(Duration::from_millis(100));
 
+            // The watcher runs the same reload transaction as the meta-tool and
+            // the admin UI, through the same function (#397). It used to have a
+            // private copy of that transaction, which meant the regression test
+            // covering the reload lock only ever exercised the other two entry
+            // points: an edit that moved the lock here alone would not have
+            // failed a single test.
+            let ctx = ReloadContext::new(
+                config_path,
+                live_config,
+                registry,
+                failsafe_cfg,
+                cache_ttl,
+            );
+
             loop {
                 tokio::select! {
                     Some(trigger) = event_rx.recv() => {
@@ -765,14 +784,24 @@ impl ConfigWatcher {
                             let trigger = pending_trigger.take().unwrap();
                             last_event = None;
                             log_reload_trigger(&trigger);
-                            reload_once(
-                                &config_path,
-                                &live_config,
-                                &registry,
-                                &failsafe_cfg,
-                                cache_ttl,
-                            )
-                            .await;
+                            match ctx.reload_outcome().await {
+                                Ok(outcome) if outcome.changes == NO_CHANGES_SUMMARY => {
+                                    tracing::debug!("Config reload: no changes detected");
+                                }
+                                Ok(outcome) => {
+                                    info!(
+                                        changes = %outcome.changes,
+                                        restart_required = outcome.restart_required,
+                                        "Config reload: complete"
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        error = %e,
+                                        "Config reload failed; keeping the current config"
+                                    );
+                                }
+                            }
                         }
                     }
                     _ = shutdown_rx.recv() => {
@@ -816,59 +845,6 @@ fn load_config_patch(
     }
 }
 
-/// Parse the config file, compute the diff, and apply the patch.
-async fn reload_once(
-    config_path: &std::path::Path,
-    live_config: &Arc<LiveConfig>,
-    registry: &Arc<BackendRegistry>,
-    failsafe_cfg: &crate::config::FailsafeConfig,
-    cache_ttl: Duration,
-) {
-    // Serializes the whole reload transaction (#397): the config read, the
-    // diff, the patch, and the publish. Two reloads that each diff against the
-    // same live config would both decide to register the same backend, and the
-    // second registration discards the first without stopping it - leaking the
-    // child process if traffic started it in between. Taking this lock only
-    // around `apply_patch` would not help, because the stale diff is already
-    // computed by then.
-    let _reload_guard = registry.lock_reload().await;
-
-    let Some((new_config, patch)) = (match load_config_patch(config_path, live_config) {
-        Ok(result) => result,
-        Err(e) => {
-            warn!(error = %e, "Config reload: failed to parse config file, keeping current config");
-            return;
-        }
-    }) else {
-        tracing::debug!("Config reload: no changes detected");
-        return;
-    };
-
-    info!(changes = %patch.summary(), "Config reload: applying patch");
-
-    let fully_applied = apply_patch(
-        &patch,
-        registry,
-        failsafe_cfg,
-        cache_ttl,
-        &new_config.runtime,
-    )
-    .await;
-
-    if !fully_applied {
-        warn!(
-            "Config reload: aborted, the gateway is shutting down; keeping the \
-             previous live config rather than publishing one that describes \
-             backends which were never registered"
-        );
-        return;
-    }
-
-    // Swap live config after patch is applied so readers see a consistent view.
-    live_config.set(new_config);
-
-    info!("Config reload: complete");
-}
 
 // ============================================================================
 // ReloadContext — imperative reload handle for the meta-tool

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -436,13 +436,29 @@ fn backend_config_changed(old: &BackendConfig, new: &BackendConfig) -> bool {
 ///   skipped.
 /// - **Profile changes**: logged at `INFO`; the `LiveConfig` is updated by the
 ///   caller after this function returns.
+///
+/// Returns `false` when the registry refused a registration because the gateway
+/// is shutting down. The patch is then only partly applied, so the caller must
+/// NOT publish the new config as live: doing so would describe backends that
+/// are not registered and report a reload that did not happen.
+///
+/// Not transactional, and deliberately not: additions and removals already
+/// applied stay applied, and a modified backend's old instance may already be
+/// stopped. Keeping the previous `LiveConfig` therefore does not describe the
+/// registry exactly either. That is acceptable only because a refusal happens
+/// solely after the permanent shutdown latch, so the inconsistency is bounded
+/// to a gateway that is terminating anyway. If registration ever becomes
+/// refusable for another reason, this needs a rollback rather than a flag.
+#[must_use = "a partly applied patch must not be published as the live config"]
 pub async fn apply_patch(
     patch: &ConfigPatch,
     registry: &BackendRegistry,
     failsafe_config: &crate::config::FailsafeConfig,
     cache_ttl: Duration,
     runtime_config: &RuntimeConfig,
-) {
+) -> bool {
+    let mut fully_applied = true;
+
     if patch.restart_required() {
         warn!("Config reload: server host/port changed — restart required to apply this change");
     }
@@ -456,8 +472,15 @@ pub async fn apply_patch(
             cache_ttl,
             runtime_plan,
         ));
-        registry.register(Arc::clone(&backend));
-        info!(backend = %name, transport = %cfg.transport.transport_type(), "Config reload: backend added");
+        if registry.register(Arc::clone(&backend)) {
+            info!(backend = %name, transport = %cfg.transport.transport_type(), "Config reload: backend added");
+        } else {
+            // The registry refuses registrations once shutdown has begun,
+            // because nothing would ever stop them. Reporting "added" here
+            // would tell an operator a backend exists when it does not.
+            warn!(backend = %name, "Config reload: backend not added, gateway is shutting down");
+            fully_applied = false;
+        }
     }
 
     for name in &patch.backends_removed {
@@ -486,13 +509,25 @@ pub async fn apply_patch(
             cache_ttl,
             runtime_plan,
         ));
-        registry.register(Arc::clone(&backend));
-        info!(backend = %name, transport = %cfg.transport.transport_type(), "Config reload: backend updated");
+        if registry.register(Arc::clone(&backend)) {
+            info!(backend = %name, transport = %cfg.transport.transport_type(), "Config reload: backend updated");
+        } else {
+            // The old instance was stopped above and the replacement refused,
+            // so depending on timing the map now holds a stopped backend or no
+            // entry at all under this name. Neither is worth repairing:
+            // refusal only happens after the permanent shutdown latch, so the
+            // gateway is going away regardless. What matters is that the caller
+            // does not treat this reload as applied.
+            warn!(backend = %name, "Config reload: backend not updated, gateway is shutting down");
+            fully_applied = false;
+        }
     }
 
     if patch.profiles_changed {
         info!("Config reload: meta/profile config updated (in-place)");
     }
+
+    fully_applied
 }
 
 // ============================================================================
@@ -793,7 +828,7 @@ async fn reload_once(
 
     info!(changes = %patch.summary(), "Config reload: applying patch");
 
-    apply_patch(
+    let fully_applied = apply_patch(
         &patch,
         registry,
         failsafe_cfg,
@@ -801,6 +836,15 @@ async fn reload_once(
         &new_config.runtime,
     )
     .await;
+
+    if !fully_applied {
+        warn!(
+            "Config reload: aborted, the gateway is shutting down; keeping the \
+             previous live config rather than publishing one that describes \
+             backends which were never registered"
+        );
+        return;
+    }
 
     // Swap live config after patch is applied so readers see a consistent view.
     live_config.set(new_config);
@@ -872,7 +916,7 @@ impl ReloadContext {
         };
 
         let outcome = patch.outcome();
-        apply_patch(
+        let fully_applied = apply_patch(
             &patch,
             &self.registry,
             &self.failsafe_config,
@@ -880,6 +924,18 @@ impl ReloadContext {
             &new_config.runtime,
         )
         .await;
+
+        if !fully_applied {
+            // Publishing here would describe backends the registry refused, and
+            // report a reload that did not happen. The caller asked for an
+            // outcome; the honest one is an error.
+            return Err(
+                "config reload aborted: the gateway is shutting down and refused \
+                 to register one or more backends"
+                    .to_string(),
+            );
+        }
+
         self.live_config.set(new_config);
 
         Ok(outcome)

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -875,3 +875,59 @@ async fn concurrent_reloads_do_not_both_add_the_same_backend() {
         "the backend should be registered after the reloads"
     );
 }
+
+/// The config write must happen inside the reload lock, not before it.
+///
+/// This is the assertion that pins the fix. If the write runs first and the
+/// lock is taken afterwards, two admin UI edits interleave: both write, then
+/// both reload, and each is told its own edit was applied while the file on
+/// disk holds only the last writer's bytes. Holding the guard here proves the
+/// write is inside the critical section, because a write that were outside it
+/// would land on disk while this test still owns the lock.
+#[tokio::test]
+async fn a_config_write_waits_for_the_reload_lock() {
+    // GIVEN: a context whose config file does not exist yet, so the file
+    // appearing is unambiguous evidence that the write ran.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+
+    let ctx = Arc::new(ReloadContext::new(
+        config_path.clone(),
+        Arc::new(LiveConfig::new(Config::default())),
+        Arc::new(crate::backend::BackendRegistry::new()),
+        crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+
+    // WHEN: a write starts while the reload lock is held
+    let started = Arc::new(tokio::sync::Barrier::new(2));
+    let guard = ctx.registry.lock_reload().await;
+    let writer = tokio::spawn({
+        let ctx = Arc::clone(&ctx);
+        let started = Arc::clone(&started);
+        let path = config_path.clone();
+        async move {
+            started.wait().await;
+            ctx.write_and_reload_outcome(&path, &Config::default())
+                .await
+        }
+    });
+    started.wait().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // THEN: nothing has been written - the writer is queued behind the lock
+    assert!(
+        !config_path.exists(),
+        "the config was written while the reload lock was held, so the write \
+         is outside the critical section and two edits can still interleave"
+    );
+
+    // AND: releasing the lock lets it finish
+    drop(guard);
+    let outcome = tokio::time::timeout(Duration::from_secs(5), writer)
+        .await
+        .expect("write did not finish after the lock was released")
+        .unwrap();
+    assert!(outcome.is_ok(), "write failed: {outcome:?}");
+    assert!(config_path.exists(), "config was never written");
+}

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -811,16 +811,35 @@ async fn concurrent_reloads_do_not_both_add_the_same_backend() {
     ));
 
     // WHEN: two reloads start while the reload lock is held, so both are queued
-    // before either can read the config
+    // before either can read the config.
+    //
+    // The barrier is what makes that claim checkable. Spawning alone proves
+    // nothing: a task that the runtime has not scheduled yet has also not read
+    // the config, so releasing the guard before it starts would let this test
+    // pass even with the lock in the wrong place. Waiting on a barrier that only
+    // opens once all three parties have arrived proves both tasks are running
+    // and inside the closure. The sleep that follows covers the remaining few
+    // instructions between the barrier and the lock, which is a window no
+    // synchronisation primitive can close from outside the function under test.
+    let started = Arc::new(tokio::sync::Barrier::new(3));
     let guard = ctx.registry.lock_reload().await;
     let first = tokio::spawn({
         let ctx = Arc::clone(&ctx);
-        async move { ctx.reload_outcome().await }
+        let started = Arc::clone(&started);
+        async move {
+            started.wait().await;
+            ctx.reload_outcome().await
+        }
     });
     let second = tokio::spawn({
         let ctx = Arc::clone(&ctx);
-        async move { ctx.reload_outcome().await }
+        let started = Arc::clone(&started);
+        async move {
+            started.wait().await;
+            ctx.reload_outcome().await
+        }
     });
+    started.wait().await;
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
         ctx.registry.get("svc").is_none(),

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -768,3 +768,91 @@ fn control_plane_role_mapping_change_is_detected() {
         "control_plane change should set profiles_changed"
     );
 }
+
+// -------------------------------------------------------------------------
+// Reload serialization (#397)
+// -------------------------------------------------------------------------
+
+/// Two config reloads must not overlap, and the lock has to cover the config
+/// read as well as the patch.
+///
+/// A reload compares the file on disk against the live config, then applies the
+/// difference. Registration replaces by name and does not stop what it
+/// displaces, so two reloads that both compare against the same live config
+/// both decide to add the same backend: the second registration discards the
+/// first, and if traffic started that first instance in the gap its child
+/// process is orphaned (#397).
+///
+/// This test drives the stale-comparison case directly. It holds the reload
+/// lock, starts two reloads against a config file that adds one backend, then
+/// releases. Serialized correctly, the first reload adds the backend and
+/// publishes, so the second one compares against the published config and finds
+/// nothing to do. If the lock is taken any later than the config read - inside
+/// `apply_patch`, say - both reloads decide "backend added" before they queue
+/// and both register, which this test sees as a second reload reporting a
+/// change instead of reporting none.
+#[tokio::test]
+async fn concurrent_reloads_do_not_both_add_the_same_backend() {
+    // GIVEN: a live config with no backends, and a file on disk that adds one
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &config_path,
+        "backends:\n  svc:\n    http_url: \"http://127.0.0.1:9/mcp\"\n",
+    )
+    .unwrap();
+
+    let ctx = Arc::new(ReloadContext::new(
+        config_path,
+        Arc::new(LiveConfig::new(Config::default())),
+        Arc::new(crate::backend::BackendRegistry::new()),
+        crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+
+    // WHEN: two reloads start while the reload lock is held, so both are queued
+    // before either can read the config
+    let guard = ctx.registry.lock_reload().await;
+    let first = tokio::spawn({
+        let ctx = Arc::clone(&ctx);
+        async move { ctx.reload_outcome().await }
+    });
+    let second = tokio::spawn({
+        let ctx = Arc::clone(&ctx);
+        async move { ctx.reload_outcome().await }
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        ctx.registry.get("svc").is_none(),
+        "a reload applied while the reload lock was held"
+    );
+    drop(guard);
+
+    let first = tokio::time::timeout(Duration::from_secs(5), first)
+        .await
+        .expect("first reload did not finish")
+        .expect("first reload task panicked")
+        .expect("first reload failed");
+    let second = tokio::time::timeout(Duration::from_secs(5), second)
+        .await
+        .expect("second reload did not finish")
+        .expect("second reload task panicked")
+        .expect("second reload failed");
+
+    // THEN: exactly one of them added the backend; the other saw an up-to-date
+    // config and did nothing
+    let added = [first.changes.as_str(), second.changes.as_str()]
+        .into_iter()
+        .filter(|c| c.contains("svc"))
+        .count();
+    assert_eq!(
+        added, 1,
+        "both reloads registered the same backend, so one instance was \
+         displaced without being stopped (#397); outcomes were {:?} and {:?}",
+        first.changes, second.changes
+    );
+    assert!(
+        ctx.registry.get("svc").is_some(),
+        "the backend should be registered after the reloads"
+    );
+}

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -931,3 +931,80 @@ async fn a_config_write_waits_for_the_reload_lock() {
     assert!(outcome.is_ok(), "write failed: {outcome:?}");
     assert!(config_path.exists(), "config was never written");
 }
+
+/// An edit must not erase a change that landed while it was queued. Reading the
+/// config outside the lock is what loses one: the queued edit starts from the
+/// copy it read before waiting, so its write drops whatever landed in the
+/// meantime while still reporting success.
+#[tokio::test]
+async fn a_queued_edit_does_not_erase_the_edit_it_waited_for() {
+    // GIVEN: a config file with no backends in it
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    crate::config_persistence::write_config(&config_path, &Config::default()).unwrap();
+
+    let ctx = Arc::new(ReloadContext::new(
+        config_path.clone(),
+        Arc::new(LiveConfig::new(Config::default())),
+        Arc::new(crate::backend::BackendRegistry::new()),
+        crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+
+    // WHEN: an edit adding "beta" is queued behind the reload lock
+    let started = Arc::new(tokio::sync::Barrier::new(2));
+    let guard = ctx.registry.lock_reload().await;
+    let queued_edit = tokio::spawn({
+        let ctx = Arc::clone(&ctx);
+        let started = Arc::clone(&started);
+        let path = config_path.clone();
+        async move {
+            started.wait().await;
+            ctx.mutate_and_reload_outcome(&path, |config: &mut Config| {
+                config.backends.insert("beta".to_string(), test_backend());
+                Ok::<(), ()>(())
+            })
+            .await
+        }
+    });
+    started.wait().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // AND: the edit that holds the lock adds "alpha" and finishes first
+    let mut won_the_lock = Config::default();
+    won_the_lock
+        .backends
+        .insert("alpha".to_string(), test_backend());
+    crate::config_persistence::write_config(&config_path, &won_the_lock).unwrap();
+    drop(guard);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), queued_edit)
+        .await
+        .expect("the queued edit never finished")
+        .unwrap();
+    assert!(result.is_ok(), "the queued edit failed: {:?}", result.err());
+
+    // THEN: the saved config has both, not just the queued edit's own change
+    let saved = Config::load(Some(&config_path)).unwrap();
+    let mut names: Vec<&String> = saved.backends.keys().collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["alpha", "beta"],
+        "the queued edit erased the change it was waiting behind"
+    );
+}
+
+/// A backend config that passes validation, for tests that only care about the
+/// name.
+#[cfg(test)]
+fn test_backend() -> crate::config::BackendConfig {
+    crate::config::BackendConfig {
+        transport: crate::config::TransportConfig::Http {
+            http_url: "http://127.0.0.1:9/mcp".to_string(),
+            streamable_http: false,
+            protocol_version: None,
+        },
+        ..crate::config::BackendConfig::default()
+    }
+}

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -3075,7 +3075,7 @@ mod identity_propagation_enforcement_tests {
             captured: Arc::clone(&captured),
             captured_identity: Arc::clone(&captured_identity),
         }));
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let mut m = MetaMcp::new(registry);
         let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
@@ -3378,7 +3378,7 @@ mod identity_propagation_enforcement_tests {
             &crate::config::FailsafeConfig::default(),
             std::time::Duration::from_secs(60),
         ));
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let m = MetaMcp::new(registry);
         let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
@@ -3419,7 +3419,7 @@ mod identity_propagation_enforcement_tests {
             &crate::config::FailsafeConfig::default(),
             std::time::Duration::from_secs(60),
         ));
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let m = MetaMcp::new(registry);
         let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));

--- a/src/gateway/meta_mcp/protocol.rs
+++ b/src/gateway/meta_mcp/protocol.rs
@@ -478,7 +478,7 @@ mod tests {
             std::time::Duration::from_secs(60),
         ));
         let registry = Arc::new(BackendRegistry::new());
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let m = MetaMcp::new(registry);
         m.set_multi_user(true);
@@ -526,7 +526,7 @@ mod tests {
             std::time::Duration::from_secs(60),
         ));
         let registry = Arc::new(BackendRegistry::new());
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let m = MetaMcp::new(registry);
         m.set_multi_user(true);

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -709,7 +709,7 @@ async fn gateway_invocation_attaches_context_integrity_metadata_to_risky_tool_ou
         }),
     });
     backend.set_transport_for_test(transport);
-    registry.register(backend);
+    let _ = registry.register(backend);
 
     let meta = MetaMcp::new(registry);
     let result = meta
@@ -771,7 +771,7 @@ async fn gateway_search_includes_stale_non_empty_backend_cache() {
         "zero TTL should make the cache stale immediately"
     );
 
-    registry.register(backend);
+    let _ = registry.register(backend);
     let meta = MetaMcp::new(registry).with_code_mode(true);
 
     let result = meta
@@ -832,7 +832,7 @@ async fn gateway_search_server_qualified_query_fills_empty_backend_cache() {
     backend.set_transport_for_test(transport_dyn);
 
     assert_eq!(backend.cached_tools_count(), 0);
-    registry.register(backend);
+    let _ = registry.register(backend);
     let meta = MetaMcp::new(registry).with_code_mode(true);
 
     let result = meta
@@ -890,7 +890,7 @@ async fn code_mode_discovery_omits_oauth_isolated_backend_on_multi_user_gateway(
     backend.set_transport_for_test(transport);
 
     let registry = Arc::new(BackendRegistry::new());
-    registry.register(backend);
+    let _ = registry.register(backend);
     let meta = MetaMcp::new(registry).with_code_mode(true);
     meta.set_multi_user(true);
 
@@ -955,7 +955,7 @@ async fn tools_resolve_omits_oauth_isolated_backend_on_multi_user_gateway() {
     );
 
     let registry = Arc::new(BackendRegistry::new());
-    registry.register(backend);
+    let _ = registry.register(backend);
     let meta = MetaMcp::new(registry);
     meta.set_multi_user(true);
 
@@ -1396,7 +1396,7 @@ fn tools_list_includes_surfaced_tool_when_in_backend_cache() {
     // Directly populate the cache via get_cached_tool_names by writing to the backend
     // Since tools_cache is private, we test via the public API after warming via reflection.
     // Instead: verify that without cache, surfaced tool is absent.
-    registry.register(backend);
+    let _ = registry.register(backend);
 
     let surfaced = vec![SurfacedToolConfig {
         server: "my_server".to_string(),
@@ -1651,7 +1651,7 @@ fn revive_server_resets_a_tripped_circuit_breaker() {
         CircuitState::Open,
         "precondition: breaker must be open"
     );
-    registry.register(Arc::clone(&backend));
+    let _ = registry.register(Arc::clone(&backend));
     let mm = MetaMcp::new(registry);
 
     // WHEN: the operator runs gateway_revive_server
@@ -1990,7 +1990,7 @@ mod attestation_wiring {
             result: json!({"content": [{"type": "text", "text": "ok"}], "isError": false}),
         });
         backend.set_transport_for_test(transport);
-        registry.register(backend);
+        let _ = registry.register(backend);
         registry
     }
 
@@ -2049,7 +2049,7 @@ mod attestation_wiring {
             }),
         });
         backend.set_transport_for_test(transport);
-        registry.register(backend);
+        let _ = registry.register(backend);
 
         let meta = MetaMcp::new(registry);
         let result = invoke_docs_search(&meta).await;

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -821,6 +821,7 @@ mod health_predicate_tests {
         BackendStatus {
             name: name.to_string(),
             running: true,
+            lifecycle: crate::backend::BackendLifecycle::Running,
             transport: "http".to_string(),
             tools_cached: 0,
             circuit_state: circuit.to_string(),

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -169,7 +169,7 @@ fn test_router_app_state_with_code_mode(enabled: bool) -> Arc<AppState> {
 
 fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
     let state = test_router_app_state();
-    state.backends.register(backend);
+    let _ = state.backends.register(backend);
     state
 }
 
@@ -178,7 +178,7 @@ fn test_router_app_state_with_backend(backend: Arc<Backend>) -> Arc<AppState> {
 /// Uses a fixed signer key so a twin validator can verify the receipt.
 fn test_router_app_state_with_provenance_backend(backend: Arc<Backend>) -> Arc<AppState> {
     let backends = Arc::new(BackendRegistry::new());
-    backends.register(backend);
+    let _ = backends.register(backend);
     let mut meta = MetaMcp::new(Arc::clone(&backends));
     // Derive the receipt-domain subkey before stamping, mirroring the
     // production `resolve_provenance_signer` wiring in `gateway::server`
@@ -244,7 +244,7 @@ fn test_router_app_state_minting_without_route_audit(backend: Arc<Backend>) -> A
     use crate::security::transparency_log::TransparencyLogConfig;
 
     let backends = Arc::new(BackendRegistry::new());
-    backends.register(backend);
+    let _ = backends.register(backend);
     let mut meta = MetaMcp::new(Arc::clone(&backends));
     let key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
     meta.set_identity_propagation(Arc::new(SignedAssertionStrategy::new(key, 300)));
@@ -1243,7 +1243,7 @@ async fn backend_handler_tools_call_enforces_api_key_tool_scope() {
     backend.set_transport_for_test(transport_dyn);
 
     let state = test_router_app_state_with_auth(&scoped_auth_config(false));
-    state.backends.register(backend);
+    let _ = state.backends.register(backend);
     let router = create_router(state);
     let request = axum::http::Request::builder()
         .method("POST")
@@ -1516,7 +1516,7 @@ fn surfaced_tool_calls_resolve_to_backend_authorization_target() {
 #[test]
 fn authorize_tool_target_blocks_ssrf_when_protection_enabled() {
     let state = test_router_app_state_with_ssrf(true, false);
-    state
+    let _ = state
         .backends
         .register(http_backend_at("loopback", "http://127.0.0.1:9000/mcp"));
     let args = json!({});
@@ -1544,7 +1544,7 @@ fn authorize_tool_target_blocks_ssrf_when_protection_enabled() {
 #[test]
 fn authorize_tool_target_allows_public_host_when_ssrf_protection_enabled() {
     let state = test_router_app_state_with_ssrf(true, false);
-    state
+    let _ = state
         .backends
         .register(http_backend_at("public", "https://gateway-public.test/mcp"));
     let args = json!({});
@@ -1571,7 +1571,7 @@ fn authorize_tool_target_allows_public_host_when_ssrf_protection_enabled() {
 #[test]
 fn authorize_tool_target_skips_ssrf_when_trust_configured_backends_enabled() {
     let state = test_router_app_state_with_ssrf(true, true);
-    state
+    let _ = state
         .backends
         .register(http_backend_at("loopback", "http://127.0.0.1:9000/mcp"));
     let args = json!({});

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -393,7 +393,13 @@ impl Gateway {
                 config.meta_mcp.cache_ttl,
                 runtime_plan,
             );
-            backends.register(Arc::new(backend));
+            // Construction time: this registry is brand new and cannot be
+            // shutting down, so a refusal here is unreachable. Asserted rather
+            // than ignored, so the day that stops being true is not silent.
+            assert!(
+                backends.register(Arc::new(backend)),
+                "a freshly built registry refused a backend registration"
+            );
             info!(backend = %name, transport = %backend_config.transport.transport_type(), "Registered backend");
         }
 
@@ -1270,38 +1276,10 @@ impl Gateway {
             }
         });
 
-        // Start idle checker task: evict per-user transport/session slots
-        // (MIK-6735) that have been idle past the TTL. The canonical shared slot
-        // is never touched here; whole-backend hibernation remains future work.
-        let backends_idle = Arc::clone(&self.backends);
-        let mut shutdown_rx2 = shutdown_tx.subscribe();
-
-        tokio::spawn(async move {
-            // ponytail: fixed 5-min idle TTL; make it configurable if operators
-            // need per-backend tuning.
-            const PER_USER_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(300);
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        for backend in backends_idle.all() {
-                            let closed =
-                                backend.evict_idle_per_user_entries(PER_USER_IDLE_TTL).await;
-                            if closed > 0 {
-                                debug!(
-                                    backend = %backend.name,
-                                    closed,
-                                    "Evicted idle per-user transport slots"
-                                );
-                            }
-                        }
-                    }
-                    _ = shutdown_rx2.recv() => {
-                        break;
-                    }
-                }
-            }
-        });
+        // Idle reaper. Shared with `run_stdio`: a setting that works in one serve
+        // mode and silently does nothing in the other is the same class of defect
+        // this feature exists to correct.
+        spawn_idle_reaper(Arc::clone(&self.backends), Some(shutdown_tx.subscribe()));
 
         // Spawn periodic cost-governance persistence (every 5 minutes)
         #[cfg(feature = "cost-governance")]
@@ -1463,6 +1441,12 @@ impl Gateway {
             spawn_warm_start_task(&self.backends, warm_start_list, WarmStartMode::Stdio);
         }
 
+        // Reap what warm-start and lazy starts spawn. Without this the setting
+        // is accepted and validated in stdio mode and then never acted on.
+        // There is no broadcast shutdown channel in stdio mode, so the handle is
+        // kept and aborted explicitly at EOF below.
+        let idle_reaper = spawn_idle_reaper(Arc::clone(&self.backends), None);
+
         info!("MCP Gateway stdio mode ready — reading JSON-RPC from stdin");
 
         // ── Read → dispatch → write loop ────────────────────────────────────
@@ -1523,6 +1507,12 @@ impl Gateway {
         }
 
         info!("stdio: EOF reached, shutting down");
+        // Stop sweeping before tearing the backends down. The reaper holds an
+        // Arc on the registry and has no shutdown channel in this mode, so
+        // leaving it running keeps both alive after run_stdio returns. Harmless
+        // when the process exits immediately after; a leak that keeps sweeping
+        // forever when the gateway is embedded or driven from a test.
+        idle_reaper.abort();
         self.backends.stop_all().await;
         Ok(())
     }
@@ -1742,6 +1732,66 @@ fn leaky_single_user_backends(config: &Config) -> Vec<&str> {
         })
         .map(|(name, _)| name.as_str())
         .collect()
+}
+
+/// Spawn the backend idle reaper.
+///
+/// Two jobs on one 60s tick: evict per-user transport slots idle past a fixed TTL
+/// (MIK-6735), and stop backends that opted into `stop_when_idle_for`.
+///
+/// Called from BOTH the HTTP serve path and `run_stdio`. Living only in the
+/// former would mean a stdio-mode gateway accepted the setting, validated it, and
+/// then never acted on it - indistinguishable from the dead `idle_timeout` this
+/// replaces.
+///
+/// `shutdown` is `None` in stdio mode, where the process exits with its read loop
+/// and there is no broadcast channel to observe.
+fn spawn_idle_reaper(
+    backends: Arc<BackendRegistry>,
+    shutdown: Option<tokio::sync::broadcast::Receiver<()>>,
+) -> tokio::task::JoinHandle<()> {
+    /// Per-user slots keep their own fixed TTL. Pointing them at
+    /// `stop_when_idle_for` would silently repurpose a backend-lifetime setting
+    /// into a per-user session lifetime, discarding stateful HTTP sessions and
+    /// OAuth refresh state at that cadence.
+    const PER_USER_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+    const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+        let mut shutdown = shutdown;
+        loop {
+            let tick = interval.tick();
+            if let Some(rx) = shutdown.as_mut() {
+                tokio::select! {
+                    _ = tick => {}
+                    _ = rx.recv() => break,
+                }
+            } else {
+                tick.await;
+            }
+
+            for backend in backends.all() {
+                let closed = backend.evict_idle_per_user_entries(PER_USER_IDLE_TTL).await;
+                if closed > 0 {
+                    debug!(
+                        backend = %backend.name,
+                        closed,
+                        "Evicted idle per-user transport slots"
+                    );
+                }
+
+                // No-op unless this backend opted in AND the gateway owns its
+                // process; declines while work is in flight.
+                if backend.stop_if_idle().await {
+                    debug!(
+                        backend = %backend.name,
+                        "Stopped idle backend; next request restarts it"
+                    );
+                }
+            }
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -8,6 +8,7 @@
 //! future HTTP handlers can call the same functions directly.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +39,15 @@ pub struct BackendInfo {
     pub url: Option<String>,
     /// Environment variables.
     pub env: HashMap<String, String>,
+    /// Seconds of idleness after which the gateway stops this backend, or
+    /// `None` when it is never stopped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_when_idle_for_secs: Option<u64>,
+    /// Whether this backend can be stopped when idle at all. False for a backend
+    /// reached over a URL the gateway did not start: it can close the connection
+    /// but cannot stop the server. The panel should hide or disable the control
+    /// rather than let an operator set something that will be refused.
+    pub can_stop_when_idle: bool,
 }
 
 /// Partial update applied by [`update_backend`].
@@ -53,6 +63,13 @@ pub struct BackendUpdate {
     pub enabled: Option<bool>,
     /// Replace the transport (overrides existing when `Some`).
     pub transport: Option<TransportConfig>,
+    /// Stop this backend when it has been idle this long, or clear the setting.
+    ///
+    /// Double `Option` on purpose: the outer layer distinguishes "the panel did
+    /// not send this field" (leave it alone) from "the panel sent it" (apply),
+    /// and the inner one carries `None` to mean "never stop". Collapsing them
+    /// would make the setting impossible to turn off once enabled.
+    pub stop_when_idle_for: Option<Option<Duration>>,
 }
 
 // ── Core operations ───────────────────────────────────────────────────────────
@@ -130,6 +147,19 @@ pub fn update_backend(
     }
     if let Some(transport) = update.transport {
         backend.transport = transport;
+    }
+    if let Some(idle) = update.stop_when_idle_for {
+        // Refuse rather than silently drop. The panel is a place operators trust
+        // to tell them what is in effect; accepting a setting the gateway cannot
+        // honour is how `idle_timeout` came to sit on 24 backends doing nothing.
+        if idle.is_some() && !matches!(backend.transport, TransportConfig::Stdio { .. }) {
+            return Err(format!(
+                "Backend '{name}' is reached over a URL the gateway did not start, so the \
+                 gateway cannot stop it. 'Stop when idle' is available only for backends the \
+                 gateway launches itself (those with a command)."
+            ));
+        }
+        backend.stop_when_idle_for = idle;
     }
 
     Ok(())
@@ -295,11 +325,15 @@ fn backend_to_info(name: &str, backend: &BackendConfig) -> BackendInfo {
         TransportConfig::A2a { a2a_url, .. } => ("a2a".to_string(), None, Some(a2a_url.clone())),
     };
 
+    let can_stop_when_idle = matches!(backend.transport, TransportConfig::Stdio { .. });
+
     BackendInfo {
         name: name.to_string(),
         description: backend.description.clone(),
         transport: transport_kind,
         enabled: backend.enabled,
+        stop_when_idle_for_secs: backend.stop_when_idle_for.map(|d| d.as_secs()),
+        can_stop_when_idle,
         command,
         url,
         env: backend.env.clone(),
@@ -712,5 +746,137 @@ mod tests {
         assert!(json.contains("\"TOKEN\":\"abc\""));
         // command should not appear for http transport
         assert!(!json.contains("\"command\""));
+    }
+}
+
+#[cfg(test)]
+mod stop_when_idle_ui_tests {
+    use super::*;
+
+    fn stdio_backend() -> BackendConfig {
+        BackendConfig {
+            transport: TransportConfig::Stdio {
+                command: "echo hi".to_string(),
+                cwd: None,
+                protocol_version: None,
+            },
+            ..BackendConfig::default()
+        }
+    }
+
+    fn http_backend() -> BackendConfig {
+        BackendConfig {
+            transport: TransportConfig::Http {
+                http_url: "http://127.0.0.1:39400/mcp".to_string(),
+                streamable_http: false,
+                protocol_version: None,
+            },
+            ..BackendConfig::default()
+        }
+    }
+
+    fn config_with(name: &str, backend: BackendConfig) -> Config {
+        let mut c = Config::default();
+        c.backends.insert(name.to_string(), backend);
+        c
+    }
+
+    // GW.IDLE.10 - settable from the panel on a backend the gateway starts.
+    #[test]
+    fn panel_can_set_and_clear_stop_when_idle_on_an_owned_backend() {
+        let mut config = config_with("owned", stdio_backend());
+
+        update_backend(
+            &mut config,
+            "owned",
+            BackendUpdate {
+                stop_when_idle_for: Some(Some(Duration::from_secs(300))),
+                ..Default::default()
+            },
+        )
+        .expect("an owned backend may opt in");
+        assert_eq!(
+            config.backends["owned"].stop_when_idle_for,
+            Some(Duration::from_secs(300))
+        );
+
+        // And it must be switchable back off, or the panel is a one-way door.
+        update_backend(
+            &mut config,
+            "owned",
+            BackendUpdate {
+                stop_when_idle_for: Some(None),
+                ..Default::default()
+            },
+        )
+        .expect("clearing must be possible");
+        assert_eq!(config.backends["owned"].stop_when_idle_for, None);
+    }
+
+    // The panel must refuse, not silently drop. Silently dropping is exactly how
+    // `idle_timeout` came to sit on 24 backends doing nothing.
+    #[test]
+    fn panel_refuses_stop_when_idle_on_a_backend_the_gateway_does_not_start() {
+        let mut config = config_with("external", http_backend());
+
+        let err = update_backend(
+            &mut config,
+            "external",
+            BackendUpdate {
+                stop_when_idle_for: Some(Some(Duration::from_secs(300))),
+                ..Default::default()
+            },
+        )
+        .expect_err("the gateway cannot stop a process it did not start");
+
+        assert!(err.contains("external"), "must name the backend: {err}");
+        assert_eq!(
+            config.backends["external"].stop_when_idle_for, None,
+            "a refused update must not partially apply"
+        );
+    }
+
+    // An omitted field must leave the existing setting alone.
+    #[test]
+    fn an_unrelated_panel_edit_does_not_disturb_the_setting() {
+        let mut config = config_with("owned", stdio_backend());
+        config.backends.get_mut("owned").unwrap().stop_when_idle_for =
+            Some(Duration::from_secs(600));
+
+        update_backend(
+            &mut config,
+            "owned",
+            BackendUpdate {
+                description: Some("renamed".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("update");
+
+        assert_eq!(
+            config.backends["owned"].stop_when_idle_for,
+            Some(Duration::from_secs(600)),
+            "editing the description must not silently clear an unrelated setting"
+        );
+    }
+
+    // The panel needs to know whether to offer the control at all.
+    #[test]
+    fn backend_info_reports_whether_the_control_is_offerable() {
+        let owned = config_with("owned", stdio_backend());
+        let external = config_with("external", http_backend());
+
+        assert!(
+            get_backend(&owned, "owned")
+                .expect("info")
+                .can_stop_when_idle,
+            "a gateway-started backend can be stopped"
+        );
+        assert!(
+            !get_backend(&external, "external")
+                .expect("info")
+                .can_stop_when_idle,
+            "the panel must hide the control for a backend the gateway did not start"
+        );
     }
 }

--- a/src/gateway/ui/backends.rs
+++ b/src/gateway/ui/backends.rs
@@ -25,15 +25,14 @@ use serde_json::json;
 
 use super::{
     backend_ops::{
-        BackendUpdate, add_backend as add_backend_config, load_config_or_default,
-        remove_backend as remove_backend_config, resolve_transport,
-        update_backend as update_backend_config,
+        BackendUpdate, add_backend as add_backend_config, remove_backend as remove_backend_config,
+        resolve_transport, update_backend as update_backend_config,
     },
     errors::{admin_auth_required, config_path_unavailable, flat_error},
     is_admin,
 };
 use crate::config::TransportConfig;
-use crate::config_persistence::write_config_and_reload_outcome;
+use crate::config_persistence::{ConfigMutation, mutate_config_and_reload};
 use crate::gateway::auth::AuthenticatedClient;
 use crate::gateway::router::AppState;
 use crate::registry::server_registry;
@@ -179,25 +178,27 @@ async fn add_backend(
         }
     };
 
-    // Load current config and check for duplicates
-    let mut config = load_config_or_default(config_path);
-    if add_backend_config(&mut config, &req.name, transport, description, req.env).is_err() {
-        return flat_error(
-            StatusCode::CONFLICT,
-            format!("Backend '{}' already exists", req.name),
-        )
-        .into_response();
-    }
-
-    // Persist and reload
-    let reload = match write_config_and_reload_outcome(
+    // Load, check for duplicates, persist and reload - all inside one lock, so
+    // a second request cannot build its change on the pre-edit config.
+    let mutation = mutate_config_and_reload(
         config_path,
-        &config,
         state.meta_mcp.reload_context().as_deref(),
+        |config| {
+            add_backend_config(config, &req.name, transport, description, req.env).map_err(|_| {
+                (
+                    StatusCode::CONFLICT,
+                    format!("Backend '{}' already exists", req.name),
+                )
+            })
+        },
     )
-    .await
-    {
-        Ok(reload) => reload,
+    .await;
+
+    let reload = match mutation {
+        Ok(ConfigMutation::Applied((), reload)) => reload,
+        Ok(ConfigMutation::Rejected((code, message))) => {
+            return flat_error(code, message).into_response();
+        }
         Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     };
 
@@ -225,20 +226,22 @@ async fn remove_backend(
         return config_path_unavailable().into_response();
     };
 
-    let mut config = load_config_or_default(config_path);
-    if remove_backend_config(&mut config, &name).is_err() {
-        return flat_error(StatusCode::NOT_FOUND, format!("Backend '{name}' not found"))
-            .into_response();
-    }
-
-    if let Err(e) = write_config_and_reload_outcome(
+    let mutation = mutate_config_and_reload(
         config_path,
-        &config,
         state.meta_mcp.reload_context().as_deref(),
+        |config| {
+            remove_backend_config(config, &name)
+                .map_err(|_| (StatusCode::NOT_FOUND, format!("Backend '{name}' not found")))
+        },
     )
-    .await
-    {
-        return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response();
+    .await;
+
+    match mutation {
+        Ok(ConfigMutation::Applied((), _)) => {}
+        Ok(ConfigMutation::Rejected((code, message))) => {
+            return flat_error(code, message).into_response();
+        }
+        Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     }
 
     (StatusCode::NO_CONTENT, Json(json!({}))).into_response()
@@ -316,75 +319,81 @@ async fn update_backend(
         .into_response();
     }
 
-    let mut config = load_config_or_default(config_path);
-    if !config.backends.contains_key(&name) {
-        return flat_error(StatusCode::NOT_FOUND, format!("Backend '{name}' not found"))
-            .into_response();
-    }
-
-    let transport = command
-        .map(|command| TransportConfig::Stdio {
-            command,
-            cwd: None,
-            protocol_version: None,
-        })
-        .or_else(|| {
-            url.map(|http_url| TransportConfig::Http {
-                http_url,
-                streamable_http: false,
-                protocol_version: None,
-            })
-        });
-
-    let env = env.map(|env_patch| {
-        let mut merged = config
-            .backends
-            .get(&name)
-            .expect("checked above")
-            .env
-            .clone();
-        merged.extend(env_patch);
-        merged
-    });
-
-    let stop_when_idle_for = stop_when_idle_for_secs.map(|secs| {
-        if secs == 0 {
-            None // explicit clear: never stop
-        } else {
-            Some(std::time::Duration::from_secs(secs))
-        }
-    });
-
-    if let Err(message) = update_backend_config(
-        &mut config,
-        &name,
-        BackendUpdate {
-            description,
-            env,
-            enabled,
-            transport,
-            stop_when_idle_for,
-        },
-    ) {
-        // Surface the refusal verbatim. An operator setting "stop when idle" on a
-        // backend the gateway does not start needs to be told why, not silently
-        // ignored - being silently ignored is what this whole change corrects.
-        let code = if message.contains("not found") {
-            StatusCode::NOT_FOUND
-        } else {
-            StatusCode::BAD_REQUEST
-        };
-        return flat_error(code, message).into_response();
-    }
-
-    let reload = match write_config_and_reload_outcome(
+    // Everything from here reads the config and writes it back, so it all runs
+    // inside one lock. Splitting the read from the write is what lets one edit
+    // overwrite another.
+    let mutation = mutate_config_and_reload(
         config_path,
-        &config,
         state.meta_mcp.reload_context().as_deref(),
+        |config| {
+            if !config.backends.contains_key(&name) {
+                return Err((StatusCode::NOT_FOUND, format!("Backend '{name}' not found")));
+            }
+
+            let transport = command
+                .map(|command| TransportConfig::Stdio {
+                    command,
+                    cwd: None,
+                    protocol_version: None,
+                })
+                .or_else(|| {
+                    url.map(|http_url| TransportConfig::Http {
+                        http_url,
+                        streamable_http: false,
+                        protocol_version: None,
+                    })
+                });
+
+            let env = env.map(|env_patch| {
+                let mut merged = config
+                    .backends
+                    .get(&name)
+                    .expect("checked above")
+                    .env
+                    .clone();
+                merged.extend(env_patch);
+                merged
+            });
+
+            let stop_when_idle_for = stop_when_idle_for_secs.map(|secs| {
+                if secs == 0 {
+                    None // explicit clear: never stop
+                } else {
+                    Some(std::time::Duration::from_secs(secs))
+                }
+            });
+
+            update_backend_config(
+                config,
+                &name,
+                BackendUpdate {
+                    description,
+                    env,
+                    enabled,
+                    transport,
+                    stop_when_idle_for,
+                },
+            )
+            .map_err(|message| {
+                // Surface the refusal verbatim. An operator setting "stop when idle" on a
+                // backend the gateway does not start needs to be told why, not silently
+                // ignored - being silently ignored is what this whole change corrects.
+                let code = if message.contains("not found") {
+                    StatusCode::NOT_FOUND
+                } else {
+                    StatusCode::BAD_REQUEST
+                };
+                (code, message)
+            })
+        },
     )
-    .await
-    {
-        Ok(reload) => reload,
+    .await;
+
+    let reload = match mutation {
+        Ok(ConfigMutation::Applied((), reload)) => reload,
+        Ok(ConfigMutation::Rejected((code, message))) => {
+            return flat_error(code, message).into_response();
+        }
         Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     };
 

--- a/src/gateway/ui/backends.rs
+++ b/src/gateway/ui/backends.rs
@@ -69,6 +69,12 @@ pub struct UpdateBackendRequest {
     pub env: Option<HashMap<String, String>>,
     /// Whether the backend is enabled.
     pub enabled: Option<bool>,
+    /// Seconds of idleness after which the gateway stops this backend.
+    ///
+    /// Absent leaves the current setting alone. `0` clears it, meaning never
+    /// stop — without an explicit clear the setting would be impossible to turn
+    /// off from the panel once enabled.
+    pub stop_when_idle_for_secs: Option<u64>,
 }
 
 /// Query parameters for `GET /ui/api/registry/search`.
@@ -259,13 +265,17 @@ async fn revive_backend(
 
     let breaker_was_open = backend.is_circuit_tripped();
     backend.reset_circuit_breaker();
-    let rebuilt = backend.force_restart().await.is_ok();
+    // A backend that is shutting down reports Ok without rebuilding anything;
+    // saying "revived" there would misreport it to the operator.
+    let outcome = backend.force_restart().await;
+    let rebuilt = matches!(outcome, Ok(crate::backend::RestartOutcome::Rebuilt));
+    let status = if rebuilt { "revived" } else { "not_revived" };
 
     (
         StatusCode::OK,
         Json(json!({
             "backend": name,
-            "status": "revived",
+            "status": status,
             "breaker_was_open": breaker_was_open,
             "transport_rebuilt": rebuilt,
         })),
@@ -289,6 +299,7 @@ async fn update_backend(
     };
 
     let UpdateBackendRequest {
+        stop_when_idle_for_secs,
         command,
         url,
         description,
@@ -336,7 +347,15 @@ async fn update_backend(
         merged
     });
 
-    if update_backend_config(
+    let stop_when_idle_for = stop_when_idle_for_secs.map(|secs| {
+        if secs == 0 {
+            None // explicit clear: never stop
+        } else {
+            Some(std::time::Duration::from_secs(secs))
+        }
+    });
+
+    if let Err(message) = update_backend_config(
         &mut config,
         &name,
         BackendUpdate {
@@ -344,12 +363,18 @@ async fn update_backend(
             env,
             enabled,
             transport,
+            stop_when_idle_for,
         },
-    )
-    .is_err()
-    {
-        return flat_error(StatusCode::NOT_FOUND, format!("Backend '{name}' not found"))
-            .into_response();
+    ) {
+        // Surface the refusal verbatim. An operator setting "stop when idle" on a
+        // backend the gateway does not start needs to be told why, not silently
+        // ignored - being silently ignored is what this whole change corrects.
+        let code = if message.contains("not found") {
+            StatusCode::NOT_FOUND
+        } else {
+            StatusCode::BAD_REQUEST
+        };
+        return flat_error(code, message).into_response();
     }
 
     let reload = match write_config_and_reload_outcome(

--- a/tests/backend_tests.rs
+++ b/tests/backend_tests.rs
@@ -18,6 +18,7 @@ fn create_test_backend(name: &str, command: &str) -> Backend {
             cwd: None,
             protocol_version: None,
         },
+        stop_when_idle_for: None,
         timeout: Duration::from_secs(30),
         env: HashMap::default(),
         headers: HashMap::default(),
@@ -78,7 +79,7 @@ async fn test_backend_registry() {
     let registry = BackendRegistry::new();
 
     let backend = Arc::new(create_test_backend("test1", "echo"));
-    registry.register(backend);
+    let _ = registry.register(backend);
 
     assert!(registry.get("test1").is_some());
     assert!(registry.get("nonexistent").is_none());

--- a/tests/backend_tests.rs
+++ b/tests/backend_tests.rs
@@ -18,7 +18,6 @@ fn create_test_backend(name: &str, command: &str) -> Backend {
             cwd: None,
             protocol_version: None,
         },
-        idle_timeout: Duration::from_secs(60),
         timeout: Duration::from_secs(30),
         env: HashMap::default(),
         headers: HashMap::default(),

--- a/tests/webui_management_tests.rs
+++ b/tests/webui_management_tests.rs
@@ -297,7 +297,7 @@ fn register_http_backend_with_url(
         &FailsafeConfig::default(),
         Duration::from_secs(60),
     ));
-    state.backends.register(Arc::clone(&backend));
+    let _ = state.backends.register(Arc::clone(&backend));
     backend
 }
 


### PR DESCRIPTION
Closes #392.

Adds a per-backend `stop_when_idle_for`. When a backend the gateway **started** has been unused for that long, its process is stopped; the next request transparently restarts it.

Measured motivation on a six-day-uptime machine: `codex` held 37 MB for 21 hours to do 1.8 seconds of work; `trvl` 67 MB for 11.6 hours to do 7.6 seconds.

**Ownership, not transport type, is the axis.** Valid only for a backend with a `command`; rejected at config load for URL-reached backends, local HTTP included — locality does not grant ownership. A hibernated backend reports a third lifecycle state, `Dormant`, recorded rather than inferred; it must not trip or heal a circuit breaker and must not be probed.

## The concurrency work, which was most of this

Every fix below is the same shape, and it took several review rounds to stop making the same mistake: **check-then-act cannot be repaired with more atomics or more checks — only a lock spanning both operations works.**

- **Lease claims** increment `in_flight` under the transport READ guard plus the pool shard guard, while the reaper checks it under the WRITE guard. `SeqCst` alone cannot help: it does not make the reaper's earlier read conditional on a claim that lands later. `stop_if_idle` records `stopped_when_idle` under the same write guard that takes the transport, and `health_probe` bails on that flag — otherwise the sweep stops a backend and the probe instantly restarts it, every sweep.
- **A replaced transport** is closed when its LAST owner releases it, with no deadline. Every capped variant was rejected: a fixed cap is arbitrary, and one derived from config is unsound because a single logical attempt can re-handshake and retry in ways no formula sees. Dropping instead of closing was also rejected — HTTP needs `close()` for its per-session DELETEs.
- **Shutdown versus starting.** The check belongs at the *publish*, not in callers: `start_entry` is the one place a transport becomes reachable, and guarding callers individually missed the ordinary request path entirely. `stop()` holds the cleanup lock across latching AND emptying the pool, waits for `starts_in_flight` to reach zero, and `start_entry` takes its `StartGuard` **before** reading the latch — so a start cannot both escape the counter and read a stale latch. `stop_all` runs backends concurrently, or each backend's bounded budget multiplies by their number.

## Known limitations — deliberate, bounded, logged

Every shutdown wait is bounded: a start that never resolves is abandoned rather than allowed to wedge the gateway, and its process outlives `stop()` until that start finishes. The pooled-close stage and cleanup drain each abandon remaining work at their deadline. `apply_patch` is not transactional, acceptable only because refusal happens after the permanent shutdown latch.

**Documented separately in `registry.rs` and NOT fixed here:** concurrent config reloads can displace a started backend without stopping it. `ReloadContext` has no serialization and is reachable from three concurrent HTTP paths. Pre-existing, now known reachable, and needs a reload transaction plus safe duplicate-registration semantics — neither belongs in idle stopping.

## On the tests

Six tests in the first attempt asserted state **after** a race window instead of the window itself and passed against broken code; two survived sabotage checking. Every behavioural claim here is therefore sabotage-verified — fault injected, the named test fails at its intended assertion, fault reverted — and concurrency claims are positioned *inside* the window. The strongest use an external witness: the process table via `kill(1)`, or an on-disk spawn log.

Two gaps are stated rather than covered, because neither is deterministically reachable through the public API: the lease-acquisition window, and the insert-then-check window in `register`. Both are safe by construction and the code says so.

`cargo test --lib` 3488 passed / 0 failed; `backend_tests` 3 passed; `cargo clippy --all-targets --all-features` clean.

Top of a four-branch stack. Targets #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)