### PR TITLE
3.4.0: config write hardening, verified alert rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-export is provided, because a re-export from `config_persistence` would
   recreate the cycle it removes. The break is documented here rather than
   deferred to 4.0.0 deliberately: two of the four names are new in this release
-  and never shipped, and the library surface has no known dependents.
+  and never shipped, and crates.io lists no reverse dependencies on this crate
+  (`/api/v1/crates/mcp-gateway/reverse_dependencies`, total 0, checked
+  2026-07-27). Private consumers outside the registry cannot be ruled out.
 
 - **`failsafe.retry.max_attempts` now means attempts, not retries.** It was
   passed straight to `backon`, which counts retries, so every backend made

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,9 +241,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own `promtool` checks it on four cases: silent when the counter is flat, firing
   after a single increment, resolving once that increment ages out of the window,
   and firing per backend rather than across all of them. The rules and their
-  tests live in `deploy/prometheus/`. A test also proves the counter reaches the
-  scrape output with its `backend` label, which until now was read from the code
-  rather than observed.
+  tests live in `deploy/prometheus/`. A test also covers the export half of the
+  counter's path, that the recorder carries this metric name and its `backend`
+  label through to scrape output. It issues the counter directly rather than
+  driving a real failing shutdown, so it pairs with the existing pool tests
+  covering the increment itself; neither half was observed before.
 
 ## [3.3.2] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,10 +212,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reload lock with no bound, and that lock is held across a whole reload:
   stopping backends, re-registering, republishing. One slow backend shutdown
   parked every settings-panel edit indefinitely, with retries queueing behind
-  it. Writes now give up after five seconds and answer 503, which is a refusal
-  the caller can retry rather than a request that never returns. Reloads
-  themselves stay unbounded on purpose: refusing one would silently drop a
-  change already written to disk, and a refused write changed nothing.
+  it. A write that is *waiting* for the lock now gives up after five seconds and
+  answers 503, which is a refusal the caller can retry rather than a request
+  that never returns. The bound covers the wait only. Once a write wins the
+  lock it still runs the reload to completion, so the one edit that triggers a
+  slow backend shutdown can still take as long as that shutdown takes; what no
+  longer happens is every other edit queueing behind it forever. Reloads stay
+  unbounded on purpose: refusing one would silently drop a change already
+  written to disk, and a refused write changed nothing.
 
 - **The scratch file a config save writes through could be silently reused.**
   The name came from a counter private to one process, and it was opened in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING for library users: four config-writing functions moved module.**
+  `write_config_and_reload`, `write_config_and_reload_outcome`,
+  `mutate_config_and_reload`, and `ConfigMutation` now live in `config_reload`
+  instead of `config_persistence`. Rust code calling them by the old path stops
+  compiling and needs one import changed; `load_config_or_default` and
+  `write_config` did not move. Nothing changes for anyone running the binary.
+
+  The two modules referenced each other in a cycle, which no Rust build
+  complains about and which made both harder to reason about. No compatibility
+  re-export is provided, because a re-export from `config_persistence` would
+  recreate the cycle it removes. The break is documented here rather than
+  deferred to 4.0.0 deliberately: two of the four names are new in this release
+  and never shipped, and the library surface has no known dependents.
+
 - **`failsafe.retry.max_attempts` now means attempts, not retries.** It was
   passed straight to `backon`, which counts retries, so every backend made
   `max_attempts + 1` calls: a configured `3` produced four, and the shipped
@@ -191,6 +205,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `100m` as an integer. Affected every duration field in the config. Values
   using `ms` failed the config load outright rather than being misread, so no
   config that previously loaded changes meaning.
+
+- **Config writes could park an admin request forever.** A save waited on the
+  reload lock with no bound, and that lock is held across a whole reload:
+  stopping backends, re-registering, republishing. One slow backend shutdown
+  parked every settings-panel edit indefinitely, with retries queueing behind
+  it. Writes now give up after five seconds and answer 503, which is a refusal
+  the caller can retry rather than a request that never returns. Reloads
+  themselves stay unbounded on purpose: refusing one would silently drop a
+  change already written to disk, and a refused write changed nothing.
+
+- **The scratch file a config save writes through could be silently reused.**
+  The name came from a counter private to one process, and it was opened in a
+  mode that truncates whatever is already there. A second gateway process, a
+  leftover from a crashed run, or a wrapped counter put two writers on one file.
+  The save now claims the file exclusively and moves to the next name rather
+  than truncating a file someone else holds. It never deletes a scratch file it
+  did not create, since a live writer may own it.
+
+- **On Windows the config was written in place, so a crash mid-write truncated
+  it.** Every other platform wrote to a scratch file and renamed it into place,
+  which is atomic; Windows took a separate branch that did not, and no test
+  reached it. Both branches are gone, replaced by one path every platform takes,
+  with a bounded retry for the sharing violations Windows raises when another
+  handle is momentarily open. The remaining Windows-specific piece, classifying
+  OS error 32 as transient, is unverified on Windows itself.
+
+- **A config write could block a runtime worker thread.** The rename retry above
+  slept between attempts, in a synchronous function reached from an async task
+  that holds the reload lock, lengthening the exact wait the five-second bound
+  exists to cap. It also retried on permission errors, which are permanent on
+  Unix, paying every sleep before failing anyway. Retries are immediate now.
+
+- **The alert rule this release documents is now tested, offline.** Prometheus'
+  own `promtool` checks it on four cases: silent when the counter is flat, firing
+  after a single increment, resolving once that increment ages out of the window,
+  and firing per backend rather than across all of them. The rules and their
+  tests live in `deploy/prometheus/`. A test also proves the counter reaches the
+  scrape output with its `backend` label, which until now was read from the code
+  rather than observed.
 
 ## [3.3.2] - 2026-07-15
 

--- a/deploy/prometheus/mcp-gateway-alerts-test.yml
+++ b/deploy/prometheus/mcp-gateway-alerts-test.yml
@@ -1,0 +1,80 @@
+# Unit tests for deploy/prometheus/mcp-gateway-alerts.yml, run offline with
+# `promtool test rules`. No scrape target, no Prometheus server, no network.
+#
+# Interval is 1m so that "single increment ages out of the 15m window" can be
+# expressed in a small, readable number of eval steps.
+rule_files:
+  - mcp-gateway-alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  # (a) Counter never increments -> no alert, ever.
+  - interval: 1m
+    input_series:
+      - series: 'mcp_backend_idle_stop_close_failures{backend="stdio-a"}'
+        values: "0x20"
+
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: McpBackendIdleStopCloseFailures
+        exp_alerts: []
+
+  # (b) A single increment fires the alert, with the backend label attached.
+  - interval: 1m
+    input_series:
+      - series: 'mcp_backend_idle_stop_close_failures{backend="stdio-a"}'
+        values: "0x5 1 1x14"
+
+    alert_rule_test:
+      # increase() needs at least two samples spanning the step for the
+      # extrapolated rate to register; one step after the bump is enough.
+      - eval_time: 6m
+        alertname: McpBackendIdleStopCloseFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              backend: stdio-a
+            exp_annotations:
+              summary: "Backend stdio-a did not stop cleanly when idle"
+
+  # (c) The alert resolves once the single increment ages out of the 15m
+  # increase() window -- no `for`, so this is a pure function of the window.
+  - interval: 1m
+    input_series:
+      - series: 'mcp_backend_idle_stop_close_failures{backend="stdio-a"}'
+        values: "0x5 1 1x30"
+
+    alert_rule_test:
+      # Still inside the 15m window after the bump at t=5m: firing.
+      - eval_time: 15m
+        alertname: McpBackendIdleStopCloseFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              backend: stdio-a
+            exp_annotations:
+              summary: "Backend stdio-a did not stop cleanly when idle"
+      # Now the bump (t=5m) is more than 15m behind eval_time (t=21m):
+      # resolved.
+      - eval_time: 21m
+        alertname: McpBackendIdleStopCloseFailures
+        exp_alerts: []
+
+  # (d) Per-backend: a failure on one backend must not page for another.
+  - interval: 1m
+    input_series:
+      - series: 'mcp_backend_idle_stop_close_failures{backend="stdio-a"}'
+        values: "0x5 1 1x14"
+      - series: 'mcp_backend_idle_stop_close_failures{backend="stdio-b"}'
+        values: "0x20"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: McpBackendIdleStopCloseFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              backend: stdio-a
+            exp_annotations:
+              summary: "Backend stdio-a did not stop cleanly when idle"

--- a/deploy/prometheus/mcp-gateway-alerts.yml
+++ b/deploy/prometheus/mcp-gateway-alerts.yml
@@ -1,0 +1,14 @@
+# Prometheus alert rules for mcp-gateway.
+#
+# Source of truth for the prose rationale: docs/DEPLOYMENT.md, section
+# "Alerting on a backend that would not stop". Keep this file and that
+# section in sync — this is the copy promtool actually validates.
+groups:
+  - name: mcp-gateway
+    rules:
+      - alert: McpBackendIdleStopCloseFailures
+        expr: increase(mcp_backend_idle_stop_close_failures[15m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backend {{ $labels.backend }} did not stop cleanly when idle"

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //! Shared helpers for mutating and persisting gateway config files.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -149,6 +150,14 @@ const RENAME_ATTEMPTS: u32 = 8;
 /// on the failure path.
 const RENAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
 
+/// How many scratch names are tried before a write gives up.
+///
+/// Each name is probed with an exclusive create, so a collision means some
+/// other writer owns that name right now. A handful of probes clears any
+/// realistic amount of concurrency; past that, failing is more honest than
+/// reusing a name whose owner is still writing to it.
+const SCRATCH_ATTEMPTS: u64 = 8;
+
 /// Write `yaml` to a scratch file next to `path`, then rename it over `path`.
 ///
 /// The rename is what makes the write atomic: a reader sees either the old
@@ -160,18 +169,54 @@ const RENAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis
 /// place on Windows, so the one platform without a crash-safe write was also
 /// the one no test covered.
 fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
-    let tmp_path = temp_config_path(path);
+    let (mut file, tmp_path) = create_scratch_exclusive(path, next_scratch_seed())?;
 
     // Leave no debris behind on any failure. The scratch name is unique per
     // call, so without cleanup each failure would strand one more file next to
     // the config instead of reusing a single stale one.
-    let cleanup = |e: std::io::Error, what: &str| {
+    let cleanup = |e: &std::io::Error, what: &str| {
         let _ = std::fs::remove_file(&tmp_path);
         format!("Failed to {what} config: {e}")
     };
 
-    std::fs::write(&tmp_path, yaml).map_err(|e| cleanup(e, "write temp"))?;
-    rename_with_retry(&tmp_path, path).map_err(|e| cleanup(e, "replace"))
+    // Write through the handle the exclusive create returned. Reopening by
+    // path would reopen the gap the exclusive create just closed.
+    file.write_all(yaml.as_bytes())
+        .and_then(|()| file.sync_all())
+        .map_err(|e| cleanup(&e, "write temp"))?;
+    drop(file);
+
+    rename_with_retry(&tmp_path, path).map_err(|e| cleanup(&e, "replace"))
+}
+
+/// Claim a scratch file next to `path` that no other writer holds.
+///
+/// The create is exclusive, so a name already in use is refused rather than
+/// truncated. A refused name belongs to another live writer, so it is left
+/// alone and the next name is tried.
+///
+/// # Errors
+///
+/// Returns an error when every candidate name is taken, or on any I/O failure
+/// other than a collision.
+fn create_scratch_exclusive(path: &Path, first: u64) -> Result<(std::fs::File, PathBuf), String> {
+    for seed in first..first.wrapping_add(SCRATCH_ATTEMPTS) {
+        let candidate = scratch_candidate(path, seed);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => return Ok((file, candidate)),
+            // Someone else's scratch file. Not ours to write to, and not ours
+            // to delete either.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(format!("Failed to create temp config: {e}")),
+        }
+    }
+    Err(format!(
+        "Failed to create temp config: {SCRATCH_ATTEMPTS} scratch names next to the config were all in use"
+    ))
 }
 
 /// Rename `from` over `to`, retrying while the OS reports a transient refusal.
@@ -202,22 +247,20 @@ fn is_transient(e: &std::io::Error) -> bool {
     matches!(e.kind(), std::io::ErrorKind::PermissionDenied) || e.raw_os_error() == Some(32)
 }
 
-/// A temp path unique to this call, in the same directory as `path` so the
-/// rename stays atomic.
-///
-/// Uniqueness is the point. A shared `<config>.tmp` lets two concurrent writers
-/// collide: both write the same temp file, the first rename ships whichever
-/// bytes landed last while reporting its own edit saved, and the second rename
-/// fails because the file it wrote is already gone.
-fn temp_config_path(path: &Path) -> PathBuf {
+/// The next scratch seed no other writer in this process will pick.
+fn next_scratch_seed() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
 
+/// The scratch path for a given seed.
+///
+/// Split from the counter so a test can name a candidate deterministically.
+/// Probing the shared counter to predict the next name is flaky: tests run in
+/// parallel threads of one binary and any other write moves it.
+fn scratch_candidate(path: &Path, seed: u64) -> PathBuf {
     let mut tmp_path = path.as_os_str().to_os_string();
-    tmp_path.push(format!(
-        ".tmp.{}.{}",
-        std::process::id(),
-        COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
+    tmp_path.push(format!(".tmp.{}.{seed}", std::process::id()));
     PathBuf::from(tmp_path)
 }
 
@@ -290,13 +333,54 @@ mod tests {
         );
     }
 
+    /// A scratch name already in use belongs to another live writer. Claiming
+    /// it truncates bytes that writer is about to rename over the config, so
+    /// its edit ships half-written or vanishes entirely.
+    #[test]
+    fn a_scratch_name_already_in_use_is_never_claimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway.yaml");
+        let taken = scratch_candidate(&path, 7);
+        std::fs::write(&taken, b"another writer's bytes").unwrap();
+
+        let (_file, chosen) = create_scratch_exclusive(&path, 7).unwrap();
+
+        assert_ne!(
+            chosen, taken,
+            "the write claimed a scratch file another writer already held"
+        );
+        assert_eq!(
+            std::fs::read(&taken).unwrap(),
+            b"another writer's bytes",
+            "the write truncated another writer's scratch file"
+        );
+    }
+
+    /// Exhausting every candidate must fail rather than reuse a live name.
+    #[test]
+    fn a_write_fails_when_every_scratch_name_is_taken() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway.yaml");
+        for seed in 0..SCRATCH_ATTEMPTS {
+            std::fs::write(scratch_candidate(&path, seed), b"held").unwrap();
+        }
+
+        let error = create_scratch_exclusive(&path, 0).unwrap_err();
+
+        assert!(
+            error.contains("were all in use"),
+            "exhaustion is not distinguishable from an I/O failure: {error}"
+        );
+    }
+
     #[test]
     fn each_config_write_gets_its_own_temp_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("gateway.yaml");
 
-        let first = temp_config_path(&path);
-        let second = temp_config_path(&path);
+        let (_first_handle, first) = create_scratch_exclusive(&path, next_scratch_seed()).unwrap();
+        let (_second_handle, second) =
+            create_scratch_exclusive(&path, next_scratch_seed()).unwrap();
 
         assert_ne!(
             first, second,

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -136,6 +136,15 @@ fn create_scratch_exclusive(path: &Path, first: u64) -> Result<(std::fs::File, P
 /// Rename `from` over `to`, retrying while the OS reports a transient refusal.
 ///
 /// Retries are immediate; see [`RENAME_ATTEMPTS`] for why this must not sleep.
+///
+/// `std::fs::rename` replaces an existing `to` on every platform we support,
+/// Windows included: std documents the call as "replacing the original file if
+/// `to` already exists", and the Windows implementation is `MoveFileExW` with
+/// `MOVEFILE_REPLACE_EXISTING` (std `sys/fs/windows.rs`). Two separate reviews
+/// have read this loop and reported that Windows renames fail once the config
+/// exists; both were wrong. Do not add a `remove_file(to)` before the rename to
+/// "fix" it -- that would reintroduce the window where the config is missing,
+/// which is the whole thing this function exists to avoid.
 fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
     let mut last = None;
     for _ in 0..RENAME_ATTEMPTS {

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -55,11 +55,14 @@ pub fn write_config(path: &Path, config: &Config) -> Result<(), String> {
 /// holding the destination open produces a sharing violation, which is
 /// transient rather than fatal. Retrying a bounded number of times rides that
 /// out; giving up after it leaves the previous config in place.
+///
+/// Retries are immediate and never sleep. The write path is synchronous but is
+/// reached from an async task that holds the reload lock, so parking the thread
+/// here would stall an executor worker and lengthen exactly the lock hold that
+/// the caller's busy bound exists to cap. An immediate retry only rides out a
+/// violation that clears within the syscall round trip; a longer-lived one is
+/// reported instead of waited on.
 const RENAME_ATTEMPTS: u32 = 8;
-
-/// Pause between rename attempts. Eight attempts cost at most ~35ms, and only
-/// on the failure path.
-const RENAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
 
 /// How many scratch names are tried before a write gives up.
 ///
@@ -131,17 +134,14 @@ fn create_scratch_exclusive(path: &Path, first: u64) -> Result<(std::fs::File, P
 }
 
 /// Rename `from` over `to`, retrying while the OS reports a transient refusal.
+///
+/// Retries are immediate; see [`RENAME_ATTEMPTS`] for why this must not sleep.
 fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
     let mut last = None;
-    for attempt in 0..RENAME_ATTEMPTS {
+    for _ in 0..RENAME_ATTEMPTS {
         match std::fs::rename(from, to) {
             Ok(()) => return Ok(()),
-            Err(e) if is_transient(&e) => {
-                if attempt + 1 < RENAME_ATTEMPTS {
-                    std::thread::sleep(RENAME_RETRY_DELAY);
-                }
-                last = Some(e);
-            }
+            Err(e) if is_transient(&e) => last = Some(e),
             Err(e) => return Err(e),
         }
     }
@@ -244,9 +244,26 @@ mod tests {
         );
     }
 
-    /// A scratch name already in use belongs to another live writer. Claiming
-    /// it truncates bytes that writer is about to rename over the config, so
-    /// its edit ships half-written or vanishes entirely.
+    /// The write path runs on an async executor worker while the reload lock is
+    /// held. Parking that thread stalls unrelated requests and lengthens the
+    /// hold that the busy bound exists to cap, so no sleep may creep back in.
+    #[test]
+    fn the_write_path_never_parks_the_thread_it_runs_on() {
+        // Split so this needle does not match the line that defines it.
+        let needle = concat!("thread::", "sleep");
+        let source = include_str!("config_persistence.rs");
+        let sleeps: Vec<&str> = source
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.starts_with("//"))
+            .filter(|line| line.contains(needle))
+            .collect();
+        assert!(
+            sleeps.is_empty(),
+            "the config write path blocks its executor thread: {sleeps:?}"
+        );
+    }
+
     #[test]
     fn a_scratch_name_already_in_use_is_never_claimed() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //! Shared helpers for mutating and persisting gateway config files.
 
-use std::path::Path;
-#[cfg(not(windows))]
-use std::path::PathBuf;
-#[cfg(not(windows))]
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::config::Config;
@@ -140,27 +137,69 @@ where
     }
 }
 
-fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
-    #[cfg(windows)]
-    {
-        std::fs::write(path, yaml).map_err(|e| format!("Failed to write config: {e}"))
-    }
+/// How many times a rename is retried before the write is reported failed.
+///
+/// Windows can refuse a rename that Unix would complete: another process
+/// holding the destination open produces a sharing violation, which is
+/// transient rather than fatal. Retrying a bounded number of times rides that
+/// out; giving up after it leaves the previous config in place.
+const RENAME_ATTEMPTS: u32 = 8;
 
-    #[cfg(not(windows))]
-    {
-        let tmp_path = temp_config_path(path);
-        // Leave no debris behind on either failure. The scratch name is unique
-        // per call, so without cleanup each failure would strand one more file
-        // next to the config instead of reusing a single stale one.
-        std::fs::write(&tmp_path, yaml).map_err(|e| {
-            let _ = std::fs::remove_file(&tmp_path);
-            format!("Failed to write temp config: {e}")
-        })?;
-        std::fs::rename(&tmp_path, path).map_err(|e| {
-            let _ = std::fs::remove_file(&tmp_path);
-            format!("Failed to replace config file: {e}")
-        })
+/// Pause between rename attempts. Eight attempts cost at most ~35ms, and only
+/// on the failure path.
+const RENAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// Write `yaml` to a scratch file next to `path`, then rename it over `path`.
+///
+/// The rename is what makes the write atomic: a reader sees either the old
+/// file or the new one, never a half-written one. Writing in place instead
+/// would leave the config truncated if the process died mid-write, which is
+/// exactly the config a restart needs to be intact.
+///
+/// This path is deliberately not platform-gated. An earlier version wrote in
+/// place on Windows, so the one platform without a crash-safe write was also
+/// the one no test covered.
+fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
+    let tmp_path = temp_config_path(path);
+
+    // Leave no debris behind on any failure. The scratch name is unique per
+    // call, so without cleanup each failure would strand one more file next to
+    // the config instead of reusing a single stale one.
+    let cleanup = |e: std::io::Error, what: &str| {
+        let _ = std::fs::remove_file(&tmp_path);
+        format!("Failed to {what} config: {e}")
+    };
+
+    std::fs::write(&tmp_path, yaml).map_err(|e| cleanup(e, "write temp"))?;
+    rename_with_retry(&tmp_path, path).map_err(|e| cleanup(e, "replace"))
+}
+
+/// Rename `from` over `to`, retrying while the OS reports a transient refusal.
+fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
+    let mut last = None;
+    for attempt in 0..RENAME_ATTEMPTS {
+        match std::fs::rename(from, to) {
+            Ok(()) => return Ok(()),
+            Err(e) if is_transient(&e) => {
+                if attempt + 1 < RENAME_ATTEMPTS {
+                    std::thread::sleep(RENAME_RETRY_DELAY);
+                }
+                last = Some(e);
+            }
+            Err(e) => return Err(e),
+        }
     }
+    Err(last.unwrap_or_else(|| std::io::Error::other("rename exhausted its retries")))
+}
+
+/// Whether an error is the kind another process can stop causing.
+///
+/// A Windows sharing violation surfaces as `PermissionDenied` or, on older
+/// mappings, uncategorised. On Unix neither classification is reachable from a
+/// rename inside a directory the process just wrote to, so the retry loop
+/// costs nothing there.
+fn is_transient(e: &std::io::Error) -> bool {
+    matches!(e.kind(), std::io::ErrorKind::PermissionDenied) || e.raw_os_error() == Some(32)
 }
 
 /// A temp path unique to this call, in the same directory as `path` so the
@@ -170,7 +209,6 @@ fn write_yaml(path: &Path, yaml: &str) -> Result<(), String> {
 /// collide: both write the same temp file, the first rename ships whichever
 /// bytes landed last while reporting its own edit saved, and the second rename
 /// fails because the file it wrote is already gone.
-#[cfg(not(windows))]
 fn temp_config_path(path: &Path) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -213,7 +251,45 @@ mod tests {
     /// The temp file used by an atomic config write must be unique per call.
     /// A shared `<config>.tmp` lets two concurrent writers clobber each other:
     /// one renames the other's bytes into place and reports its own edit saved.
-    #[cfg(not(windows))]
+    /// Every platform writes through a scratch file and renames it into place.
+    ///
+    /// Windows used to write the config in place, so a crash mid-write left a
+    /// truncated config behind — on the one platform no test covered. This
+    /// asserts the observable half of the unified path: the scratch file is
+    /// gone, the config parses, and nothing extra is left in the directory.
+    #[test]
+    fn a_config_write_leaves_no_scratch_file_on_any_platform() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gateway.yaml");
+
+        write_config(&path, &Config::default()).unwrap();
+
+        assert!(Config::load(Some(&path)).is_ok(), "config is not parseable");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|e| e.file_name()))
+            .filter(|name| name != "gateway.yaml")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "the write left scratch files next to the config: {leftovers:?}"
+        );
+    }
+
+    /// A rename that fails for a reason another process can stop causing is
+    /// retried; one that cannot succeed is reported immediately.
+    #[test]
+    fn only_transient_rename_errors_are_retried() {
+        assert!(
+            is_transient(&std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            "a sharing violation would be reported as a permanent failure"
+        );
+        assert!(
+            !is_transient(&std::io::Error::from(std::io::ErrorKind::NotFound)),
+            "a missing scratch file would be retried until the attempts ran out"
+        );
+    }
+
     #[test]
     fn each_config_write_gets_its_own_temp_file() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/config_persistence.rs
+++ b/src/config_persistence.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::config::Config;
-use crate::config_reload::{ReloadContext, ReloadOutcome};
 
 /// Load config from `path`, returning `Config::default()` when the file is absent
 /// or cannot be parsed.
@@ -48,94 +47,6 @@ pub fn write_config(path: &Path, config: &Config) -> Result<(), String> {
     let yaml =
         serde_yaml::to_string(config).map_err(|e| format!("Failed to serialize config: {e}"))?;
     write_yaml(path, &yaml)
-}
-
-/// Serialize `config`, write it atomically, then trigger hot-reload when a
-/// reload context is available.
-///
-/// Persistence is always authoritative for the on-disk file. Hot-reload then
-/// applies only the subset of changes supported by [`ReloadContext`] (for
-/// example, backend changes); server listener changes remain on disk until the
-/// process is restarted.
-///
-/// # Errors
-///
-/// Returns an error string on serialization, write, rename, or reload failure.
-pub async fn write_config_and_reload(
-    path: &Path,
-    config: &Config,
-    reload_context: Option<&ReloadContext>,
-) -> Result<(), String> {
-    write_config_and_reload_outcome(path, config, reload_context)
-        .await
-        .map(|_| ())
-}
-
-/// Serialize `config`, write it atomically, then return any hot-reload outcome.
-///
-/// # Errors
-///
-/// Returns an error string on serialization, write, rename, or reload failure.
-pub async fn write_config_and_reload_outcome(
-    path: &Path,
-    config: &Config,
-    reload_context: Option<&ReloadContext>,
-) -> Result<Option<ReloadOutcome>, String> {
-    if let Some(ctx) = reload_context {
-        // Write and reload share one lock inside the context. Writing here
-        // first would reopen the race the lock exists to close.
-        return ctx.write_and_reload_outcome(path, config).await.map(Some);
-    }
-
-    write_config(path, config)?;
-    Ok(None)
-}
-
-/// What a guarded read-modify-write did: either the change was applied and
-/// persisted, or the caller's own check rejected it and nothing was written.
-pub enum ConfigMutation<T, E> {
-    /// The change was applied, persisted, and (when a reload context exists)
-    /// reloaded.
-    Applied(T, Option<ReloadOutcome>),
-    /// The caller's closure refused the change. The file is untouched.
-    Rejected(E),
-}
-
-/// Read the config, apply `mutate` to it, and persist the result without
-/// letting another writer slip in between the read and the write.
-///
-/// Reading outside the lock is what makes edits vanish: two requests each read
-/// the same starting file, each apply their own change to that stale copy, and
-/// the second write erases the first change while reporting success. Doing the
-/// read inside the same critical section as the write is what stops it.
-///
-/// # Errors
-///
-/// Returns an error string on validation, write, rename, or reload failure. A
-/// refusal from `mutate` is not an error; it comes back as
-/// [`ConfigMutation::Rejected`] with the file untouched.
-pub async fn mutate_config_and_reload<T, E, F>(
-    path: &Path,
-    reload_context: Option<&ReloadContext>,
-    mutate: F,
-) -> Result<ConfigMutation<T, E>, String>
-where
-    F: FnOnce(&mut Config) -> Result<T, E>,
-{
-    if let Some(ctx) = reload_context {
-        return ctx.mutate_and_reload_outcome(path, mutate).await;
-    }
-
-    // No live gateway to reload, so no reload lock exists to hold. This path is
-    // the CLI acting on a config file nothing else is serving.
-    let mut config = load_config_or_default(path);
-    match mutate(&mut config) {
-        Ok(value) => {
-            write_config(path, &config)?;
-            Ok(ConfigMutation::Applied(value, None))
-        }
-        Err(rejection) => Ok(ConfigMutation::Rejected(rejection)),
-    }
 }
 
 /// How many times a rename is retried before the write is reported failed.
@@ -482,31 +393,5 @@ mod tests {
 
         assert!(matches!(result, Err(msg) if msg.contains("Failed to validate config")));
         assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn write_config_and_reload_without_context_persists_yaml() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gateway.yaml");
-        let config = Config::default();
-
-        write_config_and_reload(&path, &config, None).await.unwrap();
-
-        assert!(path.exists());
-        let loaded = Config::load(Some(&path)).unwrap();
-        assert_eq!(loaded.backends.len(), config.backends.len());
-    }
-
-    #[tokio::test]
-    async fn write_config_and_reload_outcome_without_context_returns_none() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gateway.yaml");
-        let config = Config::default();
-
-        let outcome = write_config_and_reload_outcome(&path, &config, None)
-            .await
-            .unwrap();
-
-        assert!(outcome.is_none());
     }
 }

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -1035,11 +1035,17 @@ impl ReloadContext {
 
     /// Take the reload lock, giving up after `wait`.
     ///
-    /// Only config *writes* are bounded. A reload triggered by the meta-tool,
-    /// the admin UI reload button, or the file watcher still waits as long as
-    /// it takes: refusing one of those would silently drop a config change the
-    /// operator already made on disk, which trades a hang for a lost edit.
-    /// A refused write, by contrast, has changed nothing and can be retried.
+    /// The bound covers *acquiring* the lock, not holding it. A write that wins
+    /// the lock then runs its reload to completion, however long that takes;
+    /// what the bound prevents is every other write queueing behind that one
+    /// forever.
+    ///
+    /// Only config *writes* are bounded at all. A reload triggered by the
+    /// meta-tool, the admin UI reload button, or the file watcher still waits as
+    /// long as it takes: refusing one of those would silently drop a config
+    /// change the operator already made on disk, which trades a hang for a lost
+    /// edit. A refused write, by contrast, has changed nothing and can be
+    /// retried.
     async fn lock_reload_within(
         &self,
         wait: Duration,

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -934,10 +934,14 @@ impl ReloadContext {
 
     /// Write `config` to `path`, then reload, with both steps under one lock.
     ///
+    /// Waits [`RELOAD_LOCK_WAIT`] for the reload lock. See
+    /// [`Self::write_and_reload_outcome_within`] for why the wait is bounded.
+    ///
     /// # Errors
     ///
-    /// Returns an error string on validation, serialization, write, rename, or
-    /// reload failure.
+    /// [`ConfigWriteError::Busy`] when the lock did not come free in time, and
+    /// [`ConfigWriteError::Failed`] on validation, serialization, write,
+    /// rename, or reload failure.
     ///
     /// The write must be inside the same critical section as the reload. Two
     /// admin UI edits that write first and lock second can interleave so that
@@ -948,12 +952,30 @@ impl ReloadContext {
         &self,
         path: &std::path::Path,
         config: &Config,
-    ) -> std::result::Result<ReloadOutcome, String> {
-        let _reload_guard = self.registry.lock_reload().await;
+    ) -> std::result::Result<ReloadOutcome, ConfigWriteError> {
+        self.write_and_reload_outcome_within(path, RELOAD_LOCK_WAIT, config)
+            .await
+    }
+
+    /// [`Self::write_and_reload_outcome`] with an explicit bound on the wait.
+    ///
+    /// The bound is a parameter so a test can prove the busy path without
+    /// spending the production wait in wall-clock time.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::write_and_reload_outcome`].
+    pub async fn write_and_reload_outcome_within(
+        &self,
+        path: &std::path::Path,
+        wait: Duration,
+        config: &Config,
+    ) -> std::result::Result<ReloadOutcome, ConfigWriteError> {
+        let _reload_guard = self.lock_reload_within(wait).await?;
         crate::config_persistence::write_config(path, config)?;
         self.reload_outcome_locked()
             .await
-            .map_err(|e| format!("Config written but reload failed: {e}"))
+            .map_err(|e| ConfigWriteError::Failed(format!("Config written but reload failed: {e}")))
     }
 
     /// Read the config, apply `mutate`, write, and reload, all under one guard.
@@ -963,30 +985,68 @@ impl ReloadContext {
     /// copy, and whichever writes second erases the other's change while
     /// telling its caller the edit was saved.
     ///
+    /// Waits [`RELOAD_LOCK_WAIT`] for the reload lock. See
+    /// [`Self::mutate_and_reload_outcome_within`] for why the wait is bounded.
+    ///
     /// # Errors
     ///
-    /// Returns an error string on write, rename, or reload failure. A refusal
-    /// from `mutate` comes back as `ConfigMutation::Rejected`, not an error.
+    /// [`ConfigWriteError::Busy`] when the lock did not come free in time, and
+    /// [`ConfigWriteError::Failed`] on write, rename, or reload failure. A
+    /// refusal from `mutate` is not an error; it comes back as
+    /// [`ConfigMutation::Rejected`].
     pub async fn mutate_and_reload_outcome<T, E, F>(
         &self,
         path: &std::path::Path,
         mutate: F,
-    ) -> std::result::Result<ConfigMutation<T, E>, String>
+    ) -> std::result::Result<ConfigMutation<T, E>, ConfigWriteError>
     where
         F: FnOnce(&mut Config) -> std::result::Result<T, E>,
     {
-        let _reload_guard = self.registry.lock_reload().await;
+        self.mutate_and_reload_outcome_within(path, RELOAD_LOCK_WAIT, mutate)
+            .await
+    }
+
+    /// [`Self::mutate_and_reload_outcome`] with an explicit bound on the wait.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::mutate_and_reload_outcome`].
+    pub async fn mutate_and_reload_outcome_within<T, E, F>(
+        &self,
+        path: &std::path::Path,
+        wait: Duration,
+        mutate: F,
+    ) -> std::result::Result<ConfigMutation<T, E>, ConfigWriteError>
+    where
+        F: FnOnce(&mut Config) -> std::result::Result<T, E>,
+    {
+        let _reload_guard = self.lock_reload_within(wait).await?;
         let mut config = crate::config_persistence::load_config_or_default(path);
         let value = match mutate(&mut config) {
             Ok(value) => value,
             Err(rejection) => return Ok(ConfigMutation::Rejected(rejection)),
         };
         crate::config_persistence::write_config(path, &config)?;
-        let outcome = self
-            .reload_outcome_locked()
-            .await
-            .map_err(|e| format!("Config written but reload failed: {e}"))?;
+        let outcome = self.reload_outcome_locked().await.map_err(|e| {
+            ConfigWriteError::Failed(format!("Config written but reload failed: {e}"))
+        })?;
         Ok(ConfigMutation::Applied(value, Some(outcome)))
+    }
+
+    /// Take the reload lock, giving up after `wait`.
+    ///
+    /// Only config *writes* are bounded. A reload triggered by the meta-tool,
+    /// the admin UI reload button, or the file watcher still waits as long as
+    /// it takes: refusing one of those would silently drop a config change the
+    /// operator already made on disk, which trades a hang for a lost edit.
+    /// A refused write, by contrast, has changed nothing and can be retried.
+    async fn lock_reload_within(
+        &self,
+        wait: Duration,
+    ) -> std::result::Result<tokio::sync::MutexGuard<'_, ()>, ConfigWriteError> {
+        tokio::time::timeout(wait, self.registry.lock_reload())
+            .await
+            .map_err(|_| ConfigWriteError::Busy)
     }
 
     /// The reload transaction itself. The caller must already hold the reload
@@ -1020,6 +1080,44 @@ impl ReloadContext {
     }
 }
 
+/// How long a config write waits for the reload lock before reporting busy.
+///
+/// Long enough to sit out a normal reload — stopping and re-registering
+/// backends — and short enough that a stuck one surfaces as a refusal the
+/// caller can act on rather than a request that never returns.
+const RELOAD_LOCK_WAIT: Duration = Duration::from_secs(5);
+
+/// Why a config write did not happen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigWriteError {
+    /// Another reload or write held the reload lock for longer than this write
+    /// was willing to wait. Nothing was read, written, or reloaded, so the same
+    /// request can simply be retried.
+    Busy,
+    /// The write itself failed. The message describes which step.
+    Failed(String),
+}
+
+impl std::fmt::Display for ConfigWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Busy => write!(
+                f,
+                "the gateway is applying another config change; nothing was written, retry shortly"
+            ),
+            Self::Failed(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigWriteError {}
+
+impl From<String> for ConfigWriteError {
+    fn from(message: String) -> Self {
+        Self::Failed(message)
+    }
+}
+
 /// Serialize `config`, write it atomically, then trigger hot-reload when a
 /// reload context is available.
 ///
@@ -1030,12 +1128,13 @@ impl ReloadContext {
 ///
 /// # Errors
 ///
-/// Returns an error string on serialization, write, rename, or reload failure.
+/// [`ConfigWriteError::Busy`] when a reload held the lock too long, and
+/// [`ConfigWriteError::Failed`] on serialization, write, rename, or reload failure.
 pub async fn write_config_and_reload(
     path: &Path,
     config: &Config,
     reload_context: Option<&ReloadContext>,
-) -> std::result::Result<(), String> {
+) -> std::result::Result<(), ConfigWriteError> {
     write_config_and_reload_outcome(path, config, reload_context)
         .await
         .map(|_| ())
@@ -1045,12 +1144,13 @@ pub async fn write_config_and_reload(
 ///
 /// # Errors
 ///
-/// Returns an error string on serialization, write, rename, or reload failure.
+/// [`ConfigWriteError::Busy`] when a reload held the lock too long, and
+/// [`ConfigWriteError::Failed`] on serialization, write, rename, or reload failure.
 pub async fn write_config_and_reload_outcome(
     path: &Path,
     config: &Config,
     reload_context: Option<&ReloadContext>,
-) -> std::result::Result<Option<ReloadOutcome>, String> {
+) -> std::result::Result<Option<ReloadOutcome>, ConfigWriteError> {
     if let Some(ctx) = reload_context {
         // Write and reload share one lock inside the context. Writing here
         // first would reopen the race the lock exists to close.
@@ -1081,14 +1181,15 @@ pub enum ConfigMutation<T, E> {
 ///
 /// # Errors
 ///
-/// Returns an error string on validation, write, rename, or reload failure. A
-/// refusal from `mutate` is not an error; it comes back as
+/// [`ConfigWriteError::Busy`] when a reload held the lock too long, and
+/// [`ConfigWriteError::Failed`] on validation, write, rename, or reload failure.
+/// A refusal from `mutate` is not an error; it comes back as
 /// [`ConfigMutation::Rejected`] with the file untouched.
 pub async fn mutate_config_and_reload<T, E, F>(
     path: &Path,
     reload_context: Option<&ReloadContext>,
     mutate: F,
-) -> std::result::Result<ConfigMutation<T, E>, String>
+) -> std::result::Result<ConfigMutation<T, E>, ConfigWriteError>
 where
     F: FnOnce(&mut Config) -> std::result::Result<T, E>,
 {

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -39,7 +39,7 @@
 //! # });
 //! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -971,12 +971,10 @@ impl ReloadContext {
         &self,
         path: &std::path::Path,
         mutate: F,
-    ) -> std::result::Result<crate::config_persistence::ConfigMutation<T, E>, String>
+    ) -> std::result::Result<ConfigMutation<T, E>, String>
     where
         F: FnOnce(&mut Config) -> std::result::Result<T, E>,
     {
-        use crate::config_persistence::ConfigMutation;
-
         let _reload_guard = self.registry.lock_reload().await;
         let mut config = crate::config_persistence::load_config_or_default(path);
         let value = match mutate(&mut config) {
@@ -1019,6 +1017,94 @@ impl ReloadContext {
         self.live_config.set(new_config);
 
         Ok(outcome)
+    }
+}
+
+/// Serialize `config`, write it atomically, then trigger hot-reload when a
+/// reload context is available.
+///
+/// Persistence is always authoritative for the on-disk file. Hot-reload then
+/// applies only the subset of changes supported by [`ReloadContext`] (for
+/// example, backend changes); server listener changes remain on disk until the
+/// process is restarted.
+///
+/// # Errors
+///
+/// Returns an error string on serialization, write, rename, or reload failure.
+pub async fn write_config_and_reload(
+    path: &Path,
+    config: &Config,
+    reload_context: Option<&ReloadContext>,
+) -> std::result::Result<(), String> {
+    write_config_and_reload_outcome(path, config, reload_context)
+        .await
+        .map(|_| ())
+}
+
+/// Serialize `config`, write it atomically, then return any hot-reload outcome.
+///
+/// # Errors
+///
+/// Returns an error string on serialization, write, rename, or reload failure.
+pub async fn write_config_and_reload_outcome(
+    path: &Path,
+    config: &Config,
+    reload_context: Option<&ReloadContext>,
+) -> std::result::Result<Option<ReloadOutcome>, String> {
+    if let Some(ctx) = reload_context {
+        // Write and reload share one lock inside the context. Writing here
+        // first would reopen the race the lock exists to close.
+        return ctx.write_and_reload_outcome(path, config).await.map(Some);
+    }
+
+    crate::config_persistence::write_config(path, config)?;
+    Ok(None)
+}
+
+/// What a guarded read-modify-write did: either the change was applied and
+/// persisted, or the caller's own check rejected it and nothing was written.
+pub enum ConfigMutation<T, E> {
+    /// The change was applied, persisted, and (when a reload context exists)
+    /// reloaded.
+    Applied(T, Option<ReloadOutcome>),
+    /// The caller's closure refused the change. The file is untouched.
+    Rejected(E),
+}
+
+/// Read the config, apply `mutate` to it, and persist the result without
+/// letting another writer slip in between the read and the write.
+///
+/// Reading outside the lock is what makes edits vanish: two requests each read
+/// the same starting file, each apply their own change to that stale copy, and
+/// the second write erases the first change while reporting success. Doing the
+/// read inside the same critical section as the write is what stops it.
+///
+/// # Errors
+///
+/// Returns an error string on validation, write, rename, or reload failure. A
+/// refusal from `mutate` is not an error; it comes back as
+/// [`ConfigMutation::Rejected`] with the file untouched.
+pub async fn mutate_config_and_reload<T, E, F>(
+    path: &Path,
+    reload_context: Option<&ReloadContext>,
+    mutate: F,
+) -> std::result::Result<ConfigMutation<T, E>, String>
+where
+    F: FnOnce(&mut Config) -> std::result::Result<T, E>,
+{
+    if let Some(ctx) = reload_context {
+        return ctx.mutate_and_reload_outcome(path, mutate).await;
+    }
+
+    // No live gateway to reload, so no reload lock exists to hold. This path is
+    // the CLI acting on a config file nothing else is serving.
+    let mut config = crate::config_persistence::load_config_or_default(path);
+    match mutate(&mut config) {
+        Ok(value) => {
+            crate::config_persistence::write_config(path, &config)?;
+            Ok(ConfigMutation::Applied(value, None))
+        }
+        Err(rejection) => Ok(ConfigMutation::Rejected(rejection)),
     }
 }
 

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -1060,3 +1060,130 @@ fn config_persistence_does_not_depend_on_config_reload() {
         "config_persistence reaches back into config_reload, restoring the cycle: {offenders:?}"
     );
 }
+
+/// A config write must not queue behind a stuck reload forever.
+///
+/// The reload lock is held across a full reload: stop backends, re-register
+/// them, republish. A backend that is slow to shut down holds it for as long as
+/// it takes. Every admin UI backend edit waits on that same lock with no bound,
+/// so the HTTP handler blocks, the request times out somewhere the operator
+/// cannot see, and the retry queues behind the first one. Reporting "busy" lets
+/// the caller decide, and lets the UI answer 503 instead of hanging.
+#[tokio::test]
+async fn a_config_write_reports_busy_instead_of_waiting_forever() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    let ctx = test_reload_context(&config_path);
+
+    let guard = ctx.registry.lock_reload().await;
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        ctx.mutate_and_reload_outcome_within(
+            &config_path,
+            std::time::Duration::from_millis(50),
+            |config: &mut Config| -> std::result::Result<(), ()> {
+                config
+                    .backends
+                    .insert("blocked".to_string(), test_backend());
+                Ok(())
+            },
+        ),
+    )
+    .await
+    .expect("the write hung on the reload lock instead of reporting busy");
+
+    drop(guard);
+
+    assert!(
+        matches!(result, Err(ConfigWriteError::Busy)),
+        "a write blocked behind a held reload lock did not report busy"
+    );
+    assert!(
+        !config_path.exists(),
+        "a write that reported busy still touched the config file"
+    );
+}
+
+/// The same bound applies to the whole-config write path, not just the
+/// read-modify-write one.
+#[tokio::test]
+async fn a_whole_config_write_reports_busy_instead_of_waiting_forever() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    let ctx = test_reload_context(&config_path);
+
+    let guard = ctx.registry.lock_reload().await;
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        ctx.write_and_reload_outcome_within(
+            &config_path,
+            std::time::Duration::from_millis(50),
+            &Config::default(),
+        ),
+    )
+    .await
+    .expect("the write hung on the reload lock instead of reporting busy");
+
+    drop(guard);
+
+    assert!(
+        matches!(result, Err(ConfigWriteError::Busy)),
+        "a whole-config write blocked behind a held reload lock did not report busy"
+    );
+}
+
+/// A write that waits and then gets the lock must still succeed. The bound is
+/// there to stop unbounded queueing, not to fail edits that arrive during a
+/// normal reload.
+#[tokio::test]
+async fn a_write_that_gets_the_lock_within_its_bound_still_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("gateway.yaml");
+    let ctx = std::sync::Arc::new(test_reload_context(&config_path));
+
+    let guard = ctx.registry.lock_reload().await;
+
+    let writer = tokio::spawn({
+        let ctx = std::sync::Arc::clone(&ctx);
+        let config_path = config_path.clone();
+        async move {
+            ctx.mutate_and_reload_outcome_within(
+                &config_path,
+                std::time::Duration::from_secs(5),
+                |config: &mut Config| -> std::result::Result<(), ()> {
+                    config
+                        .backends
+                        .insert("patient".to_string(), test_backend());
+                    Ok(())
+                },
+            )
+            .await
+        }
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    drop(guard);
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), writer)
+        .await
+        .expect("the write never completed after the lock was released")
+        .expect("the write task panicked");
+
+    assert!(
+        matches!(result, Ok(ConfigMutation::Applied((), _))),
+        "a write that waited out a normal reload was refused as busy"
+    );
+}
+
+/// A reload context wired to a scratch config path, with no live backends.
+fn test_reload_context(config_path: &std::path::Path) -> ReloadContext {
+    ReloadContext::new(
+        config_path.to_path_buf(),
+        Arc::new(LiveConfig::new(Config::default())),
+        Arc::new(crate::backend::BackendRegistry::new()),
+        crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    )
+}

--- a/src/config_reload/tests.rs
+++ b/src/config_reload/tests.rs
@@ -1008,3 +1008,55 @@ fn test_backend() -> crate::config::BackendConfig {
         ..crate::config::BackendConfig::default()
     }
 }
+
+/// Without a live gateway there is nothing to reload, so the write still has
+/// to land on disk and report no reload outcome rather than failing.
+#[tokio::test]
+async fn write_config_and_reload_without_context_persists_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("gateway.yaml");
+    let config = Config::default();
+
+    write_config_and_reload(&path, &config, None).await.unwrap();
+
+    assert!(path.exists());
+    let loaded = Config::load(Some(&path)).unwrap();
+    assert_eq!(loaded.backends.len(), config.backends.len());
+}
+
+#[tokio::test]
+async fn write_config_and_reload_outcome_without_context_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("gateway.yaml");
+    let config = Config::default();
+
+    let outcome = write_config_and_reload_outcome(&path, &config, None)
+        .await
+        .unwrap();
+
+    assert!(outcome.is_none());
+}
+
+/// `config_persistence` must not reach back into `config_reload`.
+///
+/// The two modules used to import each other: persistence called the reload
+/// context, and the reload context called persistence. A cycle like that has no
+/// build order to reason about, so a change to either module can only be
+/// reviewed by reading both. The dependency now points one way — reload knows
+/// about persistence, never the reverse — and this test is what keeps it that
+/// way, because nothing else in the build will complain if someone adds the
+/// import back.
+#[test]
+fn config_persistence_does_not_depend_on_config_reload() {
+    let source = include_str!("../config_persistence.rs");
+
+    let offenders: Vec<_> = source
+        .lines()
+        .filter(|line| line.contains("config_reload"))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "config_persistence reaches back into config_reload, restoring the cycle: {offenders:?}"
+    );
+}

--- a/src/gateway/ui/backends.rs
+++ b/src/gateway/ui/backends.rs
@@ -32,7 +32,7 @@ use super::{
     is_admin,
 };
 use crate::config::TransportConfig;
-use crate::config_persistence::{ConfigMutation, mutate_config_and_reload};
+use crate::config_reload::{ConfigMutation, mutate_config_and_reload};
 use crate::gateway::auth::AuthenticatedClient;
 use crate::gateway::router::AppState;
 use crate::registry::server_registry;

--- a/src/gateway/ui/backends.rs
+++ b/src/gateway/ui/backends.rs
@@ -32,7 +32,7 @@ use super::{
     is_admin,
 };
 use crate::config::TransportConfig;
-use crate::config_reload::{ConfigMutation, mutate_config_and_reload};
+use crate::config_reload::{ConfigMutation, ConfigWriteError, mutate_config_and_reload};
 use crate::gateway::auth::AuthenticatedClient;
 use crate::gateway::router::AppState;
 use crate::registry::server_registry;
@@ -199,7 +199,14 @@ async fn add_backend(
         Ok(ConfigMutation::Rejected((code, message))) => {
             return flat_error(code, message).into_response();
         }
-        Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        // A busy gateway has written nothing, so this is a retry-me, not a
+        // failure. 500 would tell the operator their edit broke something.
+        Err(e @ ConfigWriteError::Busy) => {
+            return flat_error(StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response();
+        }
+        Err(e) => {
+            return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
     };
 
     (
@@ -241,7 +248,14 @@ async fn remove_backend(
         Ok(ConfigMutation::Rejected((code, message))) => {
             return flat_error(code, message).into_response();
         }
-        Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        // A busy gateway has written nothing, so this is a retry-me, not a
+        // failure. 500 would tell the operator their edit broke something.
+        Err(e @ ConfigWriteError::Busy) => {
+            return flat_error(StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response();
+        }
+        Err(e) => {
+            return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
     }
 
     (StatusCode::NO_CONTENT, Json(json!({}))).into_response()
@@ -394,7 +408,14 @@ async fn update_backend(
         Ok(ConfigMutation::Rejected((code, message))) => {
             return flat_error(code, message).into_response();
         }
-        Err(e) => return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        // A busy gateway has written nothing, so this is a retry-me, not a
+        // failure. 500 would tell the operator their edit broke something.
+        Err(e @ ConfigWriteError::Busy) => {
+            return flat_error(StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response();
+        }
+        Err(e) => {
+            return flat_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
     };
 
     Json(json!({"status": "updated", "name": name, "reload": reload})).into_response()

--- a/tests/metrics_export_test.rs
+++ b/tests/metrics_export_test.rs
@@ -15,7 +15,13 @@
 #![cfg(feature = "metrics")]
 
 #[test]
-fn idle_stop_close_failure_counter_reaches_metrics_render() {
+fn a_counter_named_like_the_idle_stop_failure_metric_survives_render() {
+    // Scope, stated so the name cannot drift from what is proven: this
+    // exercises the EXPORT half only. It issues the same macro call, name, and
+    // label shape as `Backend::stop_when_idle` in `src/backend/pool.rs`, and
+    // proves the recorder carries them through to scrape output. It does NOT
+    // drive a real failing close; that the production path increments at all is
+    // covered by the pool tests. The two halves together are the chain.
     mcp_gateway::metrics::install();
 
     // Baseline: before this specific counter/label pair is ever incremented,

--- a/tests/metrics_export_test.rs
+++ b/tests/metrics_export_test.rs
@@ -10,7 +10,7 @@
 //! a PROCESS-GLOBAL recorder behind a `OnceLock` (src/metrics.rs `HANDLE`).
 //! A second test in the same binary calling `install()`/`render()` would
 //! share that global state and race on it. Run only this binary:
-//!   cargo test --features metrics --test metrics_export_test
+//!   `cargo test --features metrics --test metrics_export_test`
 
 #![cfg(feature = "metrics")]
 

--- a/tests/metrics_export_test.rs
+++ b/tests/metrics_export_test.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Proves `mcp_backend_idle_stop_close_failures` (src/backend/pool.rs)
+//! actually reaches the Prometheus text-exposition output produced by
+//! `mcp_gateway::metrics::render()` -- the claim docs/DEPLOYMENT.md's
+//! alerting section rests on, previously backed only by reading the code.
+//!
+//! Isolated in its own integration test binary on purpose:
+//! `metrics_exporter_prometheus::PrometheusBuilder::install_recorder` installs
+//! a PROCESS-GLOBAL recorder behind a `OnceLock` (src/metrics.rs `HANDLE`).
+//! A second test in the same binary calling `install()`/`render()` would
+//! share that global state and race on it. Run only this binary:
+//!   cargo test --features metrics --test metrics_export_test
+
+#![cfg(feature = "metrics")]
+
+#[test]
+fn idle_stop_close_failure_counter_reaches_metrics_render() {
+    mcp_gateway::metrics::install();
+
+    // Baseline: before this specific counter/label pair is ever incremented,
+    // the metric name must not already be present -- otherwise the assertion
+    // below would pass for a reason unrelated to the increment.
+    let before = mcp_gateway::metrics::render();
+    assert!(
+        !before.contains("mcp_backend_idle_stop_close_failures"),
+        "metric name present before any increment; test would not be proving \
+         anything. Rendered output:\n{before}"
+    );
+
+    telemetry_metrics::counter!(
+        "mcp_backend_idle_stop_close_failures",
+        "backend" => "test-backend"
+    )
+    .increment(1);
+
+    let after = mcp_gateway::metrics::render();
+
+    assert!(
+        after.contains("mcp_backend_idle_stop_close_failures"),
+        "expected mcp_backend_idle_stop_close_failures in rendered output \
+         after increment, got:\n{after}"
+    );
+    assert!(
+        after.contains("backend=\"test-backend\""),
+        "expected the backend label to survive to the rendered output, got:\n{after}"
+    );
+}


### PR DESCRIPTION
Ships the 3.4.0 backlog: two config-file write races fixed, four known rough edges closed, and the alert rule in `docs/DEPLOYMENT.md` proven correct offline instead of asserted.

## What changed

- Config writes wait a bounded 5s for the reload lock instead of forever, and return a distinct busy error. Admin backend edits answer 503 for busy, 500 for a real failure.
- Scratch files are created exclusively (`O_EXCL`), so two concurrent writers cannot land on the same temp name. A writer never removes a scratch file it did not create.
- Windows uses the same write-then-rename path as Unix; OS error 32 is classified as a retryable sharing violation.
- The write path no longer parks an executor thread on a blocking sleep.
- `deploy/prometheus/mcp-gateway-alerts.yml` plus a `promtool test rules` suite: 4 cases, including flat-counter silence and per-backend isolation.
- `tests/metrics_export_test.rs` proves the export half of `mcp_backend_idle_stop_close_failures` reaches scrape output.

## Breaking, for library users only

`write_config_and_reload`, `write_config_and_reload_outcome`, `mutate_config_and_reload`, and `ConfigMutation` moved from `config_persistence` to `config_reload`, removing a module cycle. One import changes. No compatibility re-export, because a re-export would recreate the cycle. crates.io lists 0 reverse dependencies. Nothing changes for anyone running the binary.

## Evidence

- Full suite: 3509 unit + 213 integration + 41 doctests, 0 failures.
- `cargo fmt --check` clean, `cargo clippy --all-features --all-targets -- -D warnings` clean.
- `promtool check rules` SUCCESS; `promtool test rules` SUCCESS on 4 cases. Threshold mutated to `> 999` to confirm the tests can fail.

## Not verified

- The Windows error-32 classification is untested on Windows; this repo has no Windows CI.
- The 5s lock-wait default has not been exercised against a genuinely slow backend shutdown.
- The new metrics test covers the export half only; that the production path increments is covered separately by the pool tests.
