### PR TITLE
chore(deps): migrate jsonwebtoken from 10.4.0 to 11.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ hex = "0.4"
 ring = "0.17"
 # Key Server: OIDC JWT verification
 # aws_lc_rs backend avoids the rsa crate (RUSTSEC-2023-0071 Marvin Attack)
-jsonwebtoken = { version = "10.4", features = ["use_pem", "aws_lc_rs"] }
+jsonwebtoken = { version = "11.0", features = ["use_pem", "aws_lc_rs"] }
 # Constant-time comparison (prevent timing attacks in admin token check)
 subtle = "2.6"
 # OS advisory file locking for the control-plane store's cross-process

--- a/src/key_server/oidc.rs
+++ b/src/key_server/oidc.rs
@@ -515,7 +515,10 @@ fn find_key_in_jwks(jwks: &JwkSet, kid: &str) -> Option<DecodingKey> {
             AlgorithmParameters::EllipticCurve(ec) => {
                 DecodingKey::from_ec_components(&ec.x, &ec.y).ok()
             }
-            AlgorithmParameters::OctetKey(_) | AlgorithmParameters::OctetKeyPair(_) => None,
+            // jsonwebtoken marks this enum non-exhaustive. Unknown future key
+            // types, along with known unsupported key families, must remain
+            // fail-closed until support is implemented.
+            _ => None,
         };
     }
     None
@@ -698,6 +701,16 @@ mod tests {
 
         // THEN: error
         assert!(check_audience(&aud, &expected).is_err());
+    }
+
+    #[test]
+    fn find_key_rejects_unknown_jwk_types() {
+        let jwks: JwkSet = serde_json::from_value(serde_json::json!({
+            "keys": [{"kid": "future-key", "kty": "FUTURE", "x-vendor": "opaque"}]
+        }))
+        .expect("unknown JWK types should remain deserializable");
+
+        assert!(find_key_in_jwks(&jwks, "future-key").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update jsonwebtoken to 11.0.0
- adapt the OIDC JWK matcher to the now non-exhaustive key-family enum
- keep unknown and unsupported key types fail-closed
- add a regression test for a synthetic future JWK type
- supersede stale Dependabot PR #412 with a branch based on current main

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (all tests and benchmark harnesses passed; 3547 library tests passed, 2 ignored)
- `git diff --check`
