### PR TITLE
fix(transport): tell a permanent spawn failure from a transient one

### DIFF
--- a/src/chains/retry.rs
+++ b/src/chains/retry.rs
@@ -151,6 +151,10 @@ where
 /// Transient network and I/O errors are retryable; protocol/config errors
 /// signal a permanent failure that retrying will not fix.
 fn is_retryable(error: &Error) -> bool {
+    // `TransportPermanent` is deliberately absent: it is the transport saying
+    // the configuration cannot work, and a retry loop is the wrong answer to
+    // that. Plain `Transport` stays retryable, because it means "failed, cause
+    // unknown".
     matches!(
         error,
         Error::Transport(_) | Error::BackendTimeout(_) | Error::Http(_) | Error::Io(_)
@@ -167,6 +171,18 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
+
+    #[test]
+    fn a_permanent_transport_failure_is_not_retried() {
+        // Both consumers must agree on the new variant, or a caller's retry
+        // behaviour depends on which helper it happened to use.
+        assert!(!is_retryable(&Error::TransportPermanent(
+            "bad command".to_string()
+        )));
+        assert!(is_retryable(&Error::Transport(
+            "connection refused".to_string()
+        )));
+    }
 
     #[test]
     fn backoff_grows_exponentially() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,32 @@ pub enum Error {
     #[error("Transport error: {0}")]
     Transport(String),
 
+    /// A transport failure that waiting cannot fix.
+    ///
+    /// `Transport` means "failed, cause unknown, possibly transient", which is
+    /// the honest answer at most of its ~59 construction sites. This variant is
+    /// for the few that genuinely know better: a command path that does not
+    /// exist, a file that is not executable, a request the server calls
+    /// malformed.
+    ///
+    /// The distinction has a caller. Warm-start retries indefinitely while a
+    /// backend's tool cache is empty, so before this a mistyped command path
+    /// produced a respawn attempt once a minute for the whole process lifetime,
+    /// with nothing in the logs saying the configuration was simply wrong.
+    ///
+    /// When in doubt, use `Transport`. An unknown failure retrying is a cost;
+    /// a recoverable failure classified permanent needs a restart to notice.
+    ///
+    /// HTTP status codes are deliberately NOT classified here, and the attempt
+    /// is worth recording. A first pass marked 4xx permanent; two existing
+    /// tests refused it, because this protocol overloads BOTH 404 and 400 to
+    /// mean "your MCP session expired, reinitialise and retry" (#247). A
+    /// status-only classifier is therefore unsafe in this codebase, whatever it
+    /// would mean in a plain REST API. Classifying an HTTP failure needs the
+    /// body, not just the code.
+    #[error("Transport error (permanent): {0}")]
+    TransportPermanent(String),
+
     /// Protocol error
     #[error("Protocol error: {0}")]
     Protocol(String),
@@ -149,7 +175,11 @@ impl Error {
             Self::BackendUnavailable(_)
             | Self::CircuitOpen(_)
             | Self::BackendTimeout(_)
-            | Self::Transport(_) => -32000,
+            | Self::Transport(_)
+            // Same class as `Transport` to a JSON-RPC caller: a backend-side
+            // failure, not a gateway fault. Omitting it reported a missing
+            // backend command as an internal error.
+            | Self::TransportPermanent(_) => -32000,
             _ => -32603, // Internal error
         }
     }
@@ -171,4 +201,24 @@ pub mod rpc_codes {
     pub const SERVER_ERROR_START: i32 = -32000;
     /// Server error range end
     pub const SERVER_ERROR_END: i32 = -32099;
+}
+
+#[cfg(test)]
+mod rpc_code_tests {
+    use super::Error;
+
+    #[test]
+    fn a_permanent_transport_failure_reports_as_a_backend_error() {
+        // Omitting the variant here reported a missing backend command as an
+        // INTERNAL error, blaming the gateway for the operator's typo.
+        assert_eq!(
+            Error::TransportPermanent("Failed to spawn: no such file".to_string()).to_rpc_code(),
+            -32000,
+        );
+        assert_eq!(
+            Error::Transport("connection refused".to_string()).to_rpc_code(),
+            -32000,
+            "the two transport variants must look the same to a JSON-RPC caller"
+        );
+    }
 }

--- a/src/gateway/server/warmstart.rs
+++ b/src/gateway/server/warmstart.rs
@@ -86,18 +86,21 @@ fn gap_before_attempt(policy: &WarmStartPolicy, attempt: u32, elapsed: Duration)
 /// anything not listed here must stop the loop: no amount of waiting turns an
 /// unsupported protocol version into a working backend.
 ///
-/// KNOWN LIMITATION, measured rather than assumed. The transport layer flattens
-/// its failures into `Error::Transport(String)` — `stdio.rs` maps a spawn
-/// failure to `Transport("Failed to spawn: …")` — so a mistyped command path is
-/// indistinguishable here from a port that is not listening yet, and both are
-/// retried. Classifying it properly means preserving typed errors across the
-/// transport boundary, which is a change to every backend call path rather than
-/// to warm-start. Filed, not bodged: string-matching the message would be a
-/// guess that breaks the first time the wording changes.
+/// The transport reports what it knows. `TransportPermanent` is the transport
+/// saying "this cannot work as configured" -- a missing command path, a file
+/// that is not executable, a request the server calls malformed -- and plain
+/// `Transport` remains "failed, cause unknown", which is the honest answer at
+/// most of its construction sites and stays retryable here.
 ///
-/// The `Io` narrowing below therefore protects only the paths that do surface a
-/// typed error today. It is correct, and it is not the whole story.
+/// Not every permanent failure is classified yet: only the sites that
+/// genuinely know map to the permanent variant, and the rest still arrive as
+/// `Transport` and are still retried. That is the safe direction of error --
+/// an unknown failure retrying costs a request a minute, while a recoverable
+/// one wrongly called permanent needs a gateway restart to notice.
 fn is_readiness_error(error: &Error) -> bool {
+    // `TransportPermanent` is deliberately unlisted: it is the transport saying
+    // the configuration cannot work, so retrying respawns a typo once a minute
+    // forever. It falls through to the catch-all below.
     match error {
         Error::Transport(_) | Error::BackendTimeout(_) | Error::BackendUnavailable(_) => true,
         Error::Io(e) => is_transient_io(e.kind()),
@@ -627,6 +630,33 @@ mod tests {
         ] {
             assert!(is_readiness_error(&e), "{e} must be retried");
         }
+    }
+
+    #[test]
+    fn a_transport_failure_the_transport_calls_permanent_stops_the_loop() {
+        // The whole point of the typed variant. Before it, a mistyped command
+        // path arrived as plain `Transport` and was respawned once a minute for
+        // the life of the process, with nothing saying the config was wrong.
+        let e = Error::TransportPermanent("Failed to spawn: no such file".to_string());
+
+        assert!(
+            !is_readiness_error(&e),
+            "a permanent transport failure must stop the loop"
+        );
+    }
+
+    #[test]
+    fn an_unclassified_transport_failure_is_still_retried() {
+        // The safe direction of error: most of the ~59 construction sites do not
+        // know whether their failure is permanent, so they still say `Transport`
+        // and are still retried. A recoverable failure wrongly called permanent
+        // would need a gateway restart to notice.
+        let e = Error::Transport("connection refused".to_string());
+
+        assert!(
+            is_readiness_error(&e),
+            "an unknown transport failure must stay retryable"
+        );
     }
 
     #[test]

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -47,6 +47,7 @@ fn same_origin(a: &Url, b: &Url) -> bool {
 /// Extracted from the [`reqwest::redirect::Policy::custom`] closure so the
 /// policy is unit-testable: reqwest's `Attempt` cannot be constructed in a
 /// test, but this pure decision can. See [`evaluate_redirect`].
+
 #[derive(Debug, PartialEq, Eq)]
 enum RedirectDecision {
     /// Hop budget exhausted — stop and surface the last response as-is.

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -158,9 +158,17 @@ impl StdioTransport {
             cmd.current_dir(cwd);
         }
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| Error::Transport(format!("Failed to spawn: {e}")))?;
+        let mut child = cmd.spawn().map_err(|e| match e.kind() {
+            // A command path that does not exist, or a file that is not
+            // executable. No amount of waiting fixes either, and warm-start
+            // retries transport failures indefinitely -- so before this, a
+            // typo in a backend command was respawned once a minute for the
+            // life of the process with no indication the config was wrong.
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => {
+                Error::TransportPermanent(format!("Failed to spawn: {e}"))
+            }
+            _ => Error::Transport(format!("Failed to spawn: {e}")),
+        })?;
 
         let stdin = child
             .stdin
@@ -882,6 +890,38 @@ done
             .status();
         panic!(
             "child survived dropping every handle to its transport: pid {pid} still alive after 2s"
+        );
+    }
+}
+
+#[cfg(test)]
+mod spawn_classification_tests {
+    use super::StdioTransport;
+    use crate::Error;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn a_missing_command_is_reported_as_permanent() {
+        // END TO END, not a synthetic classifier input: this really tries to
+        // spawn, so it pins the actual io::ErrorKind the OS returns rather than
+        // the one this code assumes it returns.
+        let transport = StdioTransport::new(
+            "/nonexistent/definitely-not-a-real-binary",
+            HashMap::new(),
+            None,
+            Duration::from_secs(1),
+            None,
+        );
+
+        let err = transport
+            .start()
+            .await
+            .expect_err("spawning a missing binary must fail");
+
+        assert!(
+            matches!(err, Error::TransportPermanent(_)),
+            "a missing command must be permanent, got {err:?}"
         );
     }
 }


### PR DESCRIPTION
Closes #425.

A spawn failure lost its `io::ErrorKind` at the transport boundary — every one became `Error::Transport(String)`. So a mistyped command path was indistinguishable from a port that was not listening yet, and warm-start (which retries while a tool cache is empty) respawned the typo once a minute for the life of the process, with nothing in the logs saying the configuration was simply wrong.

## What this does not do

`Error::Transport` is constructed in **59 places**, most of which genuinely do not know whether their failure is permanent. Turning it into a structured variant would rewrite all 59 and make most of them assert something they cannot know. Instead: one new variant, changed only at the sites that do know.

| site | condition |
|---|---|
| stdio spawn | `NotFound` — the command path does not exist |
| stdio spawn | `PermissionDenied` — the file is not executable |

Everything else still says `Transport` and is still retried. That is the safe direction of error: an unknown failure retrying costs a request a minute, while a recoverable one wrongly called permanent needs a gateway restart to notice.

## HTTP status codes are deliberately not classified

The first pass marked 4xx permanent. **Two existing tests refused it**, and they were right: this protocol overloads both **404 and 400** to mean "your MCP session expired, reinitialise and retry" (#247). A status-only classifier is unsafe in this codebase whatever it would mean in a plain REST API — classifying an HTTP failure needs the body, not just the code. That is recorded in the code rather than left as a trap for the next person.

Design review also caught the first draft sweeping up 409, 421 and 423 as permanent, which pushed the rule from "4xx except a few" to an explicit allowlist before the tests finished the job.

## Tests

- a real spawn of a missing binary yields the permanent variant — end to end, so it pins the error kind the OS actually returns rather than the one this code assumes
- both retry predicates stop on it, and still retry plain `Transport`
- it reports as a backend-side JSON-RPC code, not an internal error; omitting that blamed the gateway for the operator's typo

3528 tests pass, clippy clean under `-D warnings`, format clean.

Reviewed by GPT-5.x (SHIP; both improvements included above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
