### PR TITLE
fix(backend): let warm-start re-ask a backend that answered with no tools

### DIFF
--- a/src/backend/cached_metadata.rs
+++ b/src/backend/cached_metadata.rs
@@ -81,6 +81,22 @@ impl<T> CachedMetadata<T> {
         state.cached_at = Some(Instant::now());
     }
 
+    /// Forget the cached value so the next call fetches from the backend.
+    ///
+    /// Exists because a cached answer cannot otherwise be re-asked, and one
+    /// answer needs re-asking: an EMPTY tool list. It is stored with a fresh
+    /// timestamp like any other, so a caller that retries reads the same empty
+    /// list back within microseconds and never reaches the backend at all --
+    /// the retry looks like diligence and is a no-op.
+    ///
+    /// Deliberately does NOT cancel an in-flight fetch: that fetch is already
+    /// going to the backend, which is what the caller wanted.
+    pub(super) fn invalidate(&self) {
+        let mut state = self.state.write();
+        state.value = None;
+        state.cached_at = None;
+    }
+
     fn acquire(&self, ttl: Duration) -> CacheFetchState<'_, T> {
         {
             let state = self.state.read();
@@ -143,5 +159,83 @@ impl<T> CachedMetadata<T> {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CachedMetadata;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    const LONG_TTL: Duration = Duration::from_secs(300);
+
+    #[tokio::test]
+    async fn an_empty_result_is_cached_like_any_other() {
+        // The behaviour that made a retry meaningless, pinned so the fix below
+        // is understood as deliberate rather than incidental.
+        let cache: CachedMetadata<Vec<u8>> = CachedMetadata::new();
+        let calls = Arc::new(AtomicU32::new(0));
+
+        for _ in 0..3 {
+            let seen = Arc::clone(&calls);
+            let _ = cache
+                .get_or_fetch_shared(LONG_TTL, || {
+                    let seen = Arc::clone(&seen);
+                    async move {
+                        seen.fetch_add(1, Ordering::SeqCst);
+                        Ok(Vec::new())
+                    }
+                })
+                .await;
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "an empty result is served from cache, so retrying never re-asks"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_makes_the_next_call_reach_the_backend() {
+        let cache: CachedMetadata<Vec<u8>> = CachedMetadata::new();
+        let calls = Arc::new(AtomicU32::new(0));
+
+        for round in 0..3 {
+            if round > 0 {
+                cache.invalidate();
+            }
+            let seen = Arc::clone(&calls);
+            let _ = cache
+                .get_or_fetch_shared(LONG_TTL, || {
+                    let seen = Arc::clone(&seen);
+                    async move {
+                        seen.fetch_add(1, Ordering::SeqCst);
+                        Ok(Vec::new())
+                    }
+                })
+                .await;
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "each invalidated round must actually ask the backend again"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_on_an_empty_cache_is_harmless() {
+        let cache: CachedMetadata<Vec<u8>> = CachedMetadata::new();
+        cache.invalidate();
+
+        let value = cache
+            .get_or_fetch_shared(LONG_TTL, || async { Ok(vec![1u8, 2, 3]) })
+            .await
+            .expect("fetch after a no-op invalidate");
+
+        assert_eq!(*value, vec![1u8, 2, 3]);
     }
 }

--- a/src/backend/cached_metadata.rs
+++ b/src/backend/cached_metadata.rs
@@ -81,7 +81,7 @@ impl<T> CachedMetadata<T> {
         state.cached_at = Some(Instant::now());
     }
 
-    /// Forget the cached value so the next call fetches from the backend.
+    /// Forget the cached value only if it still satisfies `discard`.
     ///
     /// Exists because a cached answer cannot otherwise be re-asked, and one
     /// answer needs re-asking: an EMPTY tool list. It is stored with a fresh
@@ -89,12 +89,23 @@ impl<T> CachedMetadata<T> {
     /// list back within microseconds and never reaches the backend at all --
     /// the retry looks like diligence and is a no-op.
     ///
+    /// CONDITIONAL, deliberately, and there is no unconditional form. Clearing
+    /// whatever is there races with a real cost, raised in review: a caller that
+    /// observed an EMPTY list, then invalidated, could erase a non-empty list
+    /// another reader had populated in between -- turning a backend that had
+    /// just become discoverable back into an invisible one. The predicate runs
+    /// under the same write lock as the clear, so nothing slips between the
+    /// decision and the effect.
+    ///
     /// Deliberately does NOT cancel an in-flight fetch: that fetch is already
     /// going to the backend, which is what the caller wanted.
-    pub(super) fn invalidate(&self) {
+    pub(super) fn invalidate_if(&self, discard: impl Fn(&T) -> bool) {
         let mut state = self.state.write();
-        state.value = None;
-        state.cached_at = None;
+        let should_clear = state.value.as_ref().is_some_and(|v| discard(v));
+        if should_clear {
+            state.value = None;
+            state.cached_at = None;
+        }
     }
 
     fn acquire(&self, ttl: Duration) -> CacheFetchState<'_, T> {
@@ -205,7 +216,7 @@ mod tests {
 
         for round in 0..3 {
             if round > 0 {
-                cache.invalidate();
+                cache.invalidate_if(Vec::is_empty);
             }
             let seen = Arc::clone(&calls);
             let _ = cache
@@ -227,9 +238,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalidate_if_never_erases_a_value_that_no_longer_matches() {
+        // Raised in review, and it is the dangerous direction: a caller that
+        // observed an EMPTY list and then invalidated could erase a non-empty
+        // list another reader had populated in between -- turning a backend
+        // that had just become discoverable back into an invisible one.
+        let cache: CachedMetadata<Vec<u8>> = CachedMetadata::new();
+        let _ = cache
+            .get_or_fetch_shared(LONG_TTL, || async { Ok(vec![1u8, 2, 3]) })
+            .await;
+
+        cache.invalidate_if(Vec::is_empty);
+
+        let calls = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&calls);
+        let value = cache
+            .get_or_fetch_shared(LONG_TTL, || {
+                let seen = Arc::clone(&seen);
+                async move {
+                    seen.fetch_add(1, Ordering::SeqCst);
+                    Ok(Vec::new())
+                }
+            })
+            .await
+            .expect("the populated value must survive");
+
+        assert_eq!(*value, vec![1u8, 2, 3], "a populated list was erased");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "and it should not have refetched"
+        );
+    }
+
+    #[tokio::test]
     async fn invalidate_on_an_empty_cache_is_harmless() {
         let cache: CachedMetadata<Vec<u8>> = CachedMetadata::new();
-        cache.invalidate();
+        cache.invalidate_if(Vec::is_empty);
 
         let value = cache
             .get_or_fetch_shared(LONG_TTL, || async { Ok(vec![1u8, 2, 3]) })

--- a/src/backend/metadata.rs
+++ b/src/backend/metadata.rs
@@ -31,6 +31,15 @@ impl Backend {
         self.tools_cache.is_fresh(self.cache_ttl)
     }
 
+    /// Forget the cached tool list so the next fetch reaches the backend.
+    ///
+    /// The one caller that needs this is warm-start reconfirming an EMPTY list.
+    /// An empty result is cached with a fresh timestamp like any other, so
+    /// without this a retry re-reads the same empty answer and never re-asks.
+    pub fn invalidate_tools_cache(&self) {
+        self.tools_cache.invalidate();
+    }
+
     /// Return the number of tools in the cache (non-blocking, no network I/O).
     ///
     /// Returns `0` when the cache is empty or has never been populated.

--- a/src/backend/metadata.rs
+++ b/src/backend/metadata.rs
@@ -37,7 +37,12 @@ impl Backend {
     /// An empty result is cached with a fresh timestamp like any other, so
     /// without this a retry re-reads the same empty answer and never re-asks.
     pub fn invalidate_tools_cache(&self) {
-        self.tools_cache.invalidate();
+        // Conditional on purpose: only an EMPTY list is discarded. Clearing
+        // unconditionally could erase a tool list another reader populated
+        // between the caller observing emptiness and acting on it, which would
+        // turn a backend that had just become discoverable back into an
+        // invisible one. The check happens under the cache's own write lock.
+        self.tools_cache.invalidate_if(Vec::is_empty);
     }
 
     /// Return the number of tools in the cache (non-blocking, no network I/O).

--- a/src/gateway/server/warmstart.rs
+++ b/src/gateway/server/warmstart.rs
@@ -131,6 +131,14 @@ const fn is_transient_io(kind: std::io::ErrorKind) -> bool {
 
 /// How many times warm-start re-asks a backend that answered with no tools.
 ///
+/// ACCEPTED RESIDUAL, raised in review: this budget is per warm-start task, not
+/// per backend instance, so a config reload that replaces a backend mid-loop
+/// inherits whatever the count had reached. A replacement whose tools register
+/// late therefore gets fewer than the full number of re-asks. Keying the count
+/// to the instance means tracking identity through the retry closure, which is
+/// more machinery than the case earns: the failure is reduced patience for a
+/// backend that was reloaded in the same minute it started, not invisibility.
+///
 /// A backend may register its tools a moment after it starts answering, so the
 /// first empty list is not proof. It may also genuinely have none, so this is
 /// bounded rather than endless -- polling and restarting a resource-only

--- a/src/gateway/server/warmstart.rs
+++ b/src/gateway/server/warmstart.rs
@@ -129,6 +129,14 @@ const fn is_transient_io(kind: std::io::ErrorKind) -> bool {
     )
 }
 
+/// How many times warm-start re-asks a backend that answered with no tools.
+///
+/// A backend may register its tools a moment after it starts answering, so the
+/// first empty list is not proof. It may also genuinely have none, so this is
+/// bounded rather than endless -- polling and restarting a resource-only
+/// backend for the gateway's lifetime would be the mirror mistake.
+const EMPTY_TOOL_LISTS_BEFORE_ACCEPTING: u32 = 3;
+
 /// How many consecutive rounds warm-start yields to the idle reaper before it
 /// insists on one more fetch.
 ///
@@ -237,6 +245,7 @@ where
 {
     let started = tokio::time::Instant::now();
     let mut n = 0u32;
+    let mut empty_lists = 0u32;
 
     loop {
         n += 1;
@@ -252,24 +261,33 @@ where
         // call, so it never moves under a request already in flight.
         let attempt_ceiling = ceiling();
         match tokio::time::timeout(attempt_ceiling, attempt()).await {
-            // An empty tool list ends the loop, and the backend stays
-            // undiscoverable because discovery skips an empty cache. That is a
-            // KNOWN GAP, not an oversight, and briefly it was a bounded retry
-            // that did nothing: `get_tools_shared` caches an empty result with a
-            // fresh timestamp, so the follow-up attempts re-read the same cached
-            // answer milliseconds later without contacting the backend at all.
-            // Confirming an empty list needs a cache-bypassing refetch, which
-            // `CachedMetadata` does not expose. Filed rather than looped over.
-            Ok(Ok(tools)) => {
-                if tools == 0 {
-                    debug!(
-                        backend = %name,
-                        attempt = n,
-                        "Backend reports no tools; it will not appear in discovery"
-                    );
-                }
-                return Some(tools);
+            // An EMPTY tool list is not yet an answer. Discovery skips a backend
+            // with an empty cache, so accepting the first empty result reports
+            // "warm-started" about a backend nobody can find.
+            //
+            // Bounded, and it now RE-ASKS rather than re-reading: an empty
+            // result is cached with a fresh timestamp like any other, so the
+            // earlier version of this retry read the same cached emptiness back
+            // within microseconds and never reached the backend at all. The
+            // caller invalidates before each reconfirmation, which is the whole
+            // reason `invalidate_tools_cache` exists.
+            Ok(Ok(0)) if empty_lists < EMPTY_TOOL_LISTS_BEFORE_ACCEPTING => {
+                empty_lists += 1;
+                debug!(
+                    backend = %name,
+                    attempt = n,
+                    "Backend reports no tools; re-asking rather than accepting a cached empty list"
+                );
             }
+            Ok(Ok(0)) => {
+                debug!(
+                    backend = %name,
+                    attempt = n,
+                    "Backend consistently reports no tools; accepting that it has none"
+                );
+                return Some(0);
+            }
+            Ok(Ok(tools)) => return Some(tools),
             Ok(Err(e)) if is_readiness_error(&e) => {
                 debug!(backend = %name, attempt = n, error = %e, "Warm-start not ready, retrying");
             }
@@ -447,6 +465,9 @@ async fn warm_start_until_cached(
     // Shared rather than borrowed: each attempt is an async block that outlives
     // the closure call, so a plain `&mut` counter cannot escape into it.
     let dormant_yields = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    // Set when an attempt came back with no tools, so the NEXT attempt knows to
+    // discard the cached emptiness and actually re-ask.
+    let saw_empty_list = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let outcome = retry_warm_start_attempts(
         name,
@@ -460,6 +481,7 @@ async fn warm_start_until_cached(
         },
         || {
             let dormant_yields = Arc::clone(&dormant_yields);
+            let saw_empty_list = Arc::clone(&saw_empty_list);
             async move {
             // Resolved per attempt, never captured: a config reload can replace
             // the instance under us, and a task holding the old `Arc` would keep
@@ -500,7 +522,17 @@ async fn warm_start_until_cached(
             // duplicate subprocess.
             backend.ensure_started().await?;
 
-            backend.get_tools_shared().await.map(|tools| tools.len())
+            // Reconfirming an empty list means ASKING again. Without this the
+            // cached empty answer is served straight back, and the bounded retry
+            // above observes nothing it has not already seen.
+            if saw_empty_list.swap(false, ordering) {
+                backend.invalidate_tools_cache();
+            }
+            let count = backend.get_tools_shared().await.map(|tools| tools.len())?;
+            if count == 0 {
+                saw_empty_list.store(true, ordering);
+            }
+            Ok(count)
             }
         },
     )
@@ -539,10 +571,11 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        ATTEMPT_REQUEST_BUDGET, DORMANT_YIELDS_BEFORE_RETRY, DormantAction, WarmStartMode,
-        WarmStartPolicy, dormant_action, effective_attempt_timeout, gap_before_attempt,
-        is_readiness_error, resolve_warm_start_names, retry_warm_start_attempts,
-        spawn_warm_start_task, warm_start_prefetches_tools,
+        ATTEMPT_REQUEST_BUDGET, DORMANT_YIELDS_BEFORE_RETRY, DormantAction,
+        EMPTY_TOOL_LISTS_BEFORE_ACCEPTING, WarmStartMode, WarmStartPolicy, dormant_action,
+        effective_attempt_timeout, gap_before_attempt, is_readiness_error,
+        resolve_warm_start_names, retry_warm_start_attempts, spawn_warm_start_task,
+        warm_start_prefetches_tools,
     };
     use crate::Error;
 
@@ -722,6 +755,61 @@ mod tests {
 
         assert_eq!(cached, Some(7));
         assert_eq!(calls.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_empty_tool_list_is_re_asked_a_bounded_number_of_times() {
+        // A backend may register its tools a moment after it starts answering,
+        // so the first empty list is not proof. It may also genuinely have none,
+        // so the re-asking is bounded rather than endless.
+        let calls = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&calls);
+        let attempt = move || {
+            let n = seen.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(Ok(if n < 2 { 0 } else { 4 }))
+        };
+
+        let cached = retry_warm_start_attempts(
+            "late-registrar",
+            &WarmStartPolicy::default(),
+            no_extra_ceiling(),
+            attempt,
+        )
+        .await;
+
+        assert_eq!(
+            cached,
+            Some(4),
+            "the tools that appeared late must be picked up"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_backend_that_really_has_no_tools_is_accepted() {
+        // The mirror case: a resource-only backend must not be re-asked and
+        // restarted for the gateway's lifetime just because it exposes no tools.
+        let calls = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&calls);
+        let attempt = move || {
+            seen.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(Ok(0))
+        };
+
+        let cached = retry_warm_start_attempts(
+            "resources-only",
+            &WarmStartPolicy::default(),
+            no_extra_ceiling(),
+            attempt,
+        )
+        .await;
+
+        assert_eq!(cached, Some(0));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            EMPTY_TOOL_LISTS_BEFORE_ACCEPTING + 1,
+            "bounded: a few chances to register tools, then believed"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Discovery skips a backend whose tool cache is empty, so accepting the first empty `tools/list` reports success about a backend nobody can find.

An earlier bounded retry looked right and **did nothing**: an empty result is cached with a fresh timestamp like any other, so each attempt re-read the same cached emptiness within microseconds and never reached the backend. That retry was removed rather than left as decoration; this restores it with the mechanism that makes it real.

## The change

- cache invalidation, so a cached answer can actually be asked again
- warm-start re-asks a bounded number of times before believing an empty list
- a test pinning that an empty result *is* cached, which is what made the old retry inert

## Review caught a race, and it was the dangerous direction

Invalidating unconditionally could erase a tool list another reader had populated between the caller observing emptiness and acting on it — turning a backend that had just become discoverable back into an invisible one.

Invalidation is now **conditional and evaluated under the same write lock as the clear**, so nothing slips between the decision and the effect. There is no unconditional form at all; leaving one would leave the footgun for the next caller. A test asserts a populated value survives an invalidate-if-empty and is not refetched.

## Accepted residual, stated rather than hidden

The empty-list budget is per warm-start task, not per backend instance, so a config reload that replaces a backend mid-loop inherits whatever the count had reached — a replacement whose tools register late gets fewer than the full number of re-asks. Keying the count to the instance means tracking identity through the retry closure, which is more machinery than the case earns: the failure is reduced patience for a backend reloaded in the same minute it started, not invisibility. Recorded in the code.

3529 tests pass, clippy clean under `-D warnings`, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
