### PR TITLE
docs: correct claims that contradict the code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ This is why `src/gateway/meta_mcp/prompt_cache.rs` exists even though the projec
 
 ## Meta-Tools
 
-The gateway advertises up to 9 meta-tools to connecting clients. The base set of 4 is always present; the rest are conditional on configuration.
+The gateway advertises 14 to 17 meta-tools to connecting clients. The base set of 4 is always present; `gateway_cost_report` is always built at runtime; the rest are conditional on configuration. When `code_mode.enabled` is set, this whole set is replaced by two tools, `gateway_search` and `gateway_execute`.
 
 | Tool | Always | Purpose |
 |------|--------|---------|
@@ -48,12 +48,20 @@ The gateway advertises up to 9 meta-tools to connecting clients. The base set of
 | `gateway_search_tools` | yes | Keyword search across all backends with ranked results |
 | `gateway_invoke` | yes | Call any tool on any backend. Handles caching, idempotency, kill switch |
 | `gateway_get_stats` | if stats enabled | Usage stats: invocations, cache hits, token savings, top tools, cost |
+| `gateway_cost_report` | yes | Current session and API-key spend |
 | `gateway_webhook_status` | if webhooks enabled | List webhook endpoints and delivery stats |
 | `gateway_run_playbook` | yes | Execute a multi-step playbook as a single call |
 | `gateway_kill_server` | yes | Operator kill switch: immediately disable routing to a backend |
 | `gateway_revive_server` | yes | Re-enable a killed backend and reset its error budget |
+| `gateway_set_profile` | yes | Switch the active routing profile for this session |
+| `gateway_get_profile` | yes | Show the active routing profile and what it allows or denies |
+| `gateway_list_disabled_capabilities` | yes | List capabilities auto-disabled for a high error rate |
+| `gateway_list_profiles` | yes | List available routing profiles |
+| `gateway_set_state` | yes | Transition the session to a new workflow state |
+| `gateway_reload_config` | if reload enabled | Reload `config.yaml` from disk without restarting |
+| `gateway_reload_capabilities` | yes | Re-read capability YAML files and rebuild the registry |
 
-Defined in `src/gateway/meta_mcp_helpers.rs`, function `build_meta_tools()` (line 347).
+Defined in `src/gateway/meta_mcp_tool_defs.rs`, function `build_meta_tools()` (line 543).
 
 ## Tool Discovery Resolution Order
 
@@ -123,7 +131,8 @@ stateDiagram-v2
     [*] --> Registered: Gateway::new() registers backend
     Registered --> WarmStarting: tokio::spawn warm-start task
     WarmStarting --> Active: backend.start() + get_tools() succeeds
-    WarmStarting --> Failed: start or prefetch fails
+    WarmStarting --> WarmStarting: transient failure, retried with backoff
+    WarmStarting --> Failed: permanent failure, retries stop
     Failed --> Active: manual retry via gateway_list_tools(server=X)
 
     Active --> CircuitOpen: failure_threshold exceeded
@@ -142,9 +151,9 @@ stateDiagram-v2
 
 `Gateway::new()` iterates `config.enabled_backends()`, creates `Backend` instances with transport config and failsafe settings, registers them in `BackendRegistry`.
 
-### Warm-start (`gateway/server.rs:348`)
+### Warm-start (`gateway/server/warmstart.rs`)
 
-A spawned task connects each backend and prefetches its tool list into cache. If `config.meta_mcp.warm_start` is empty, ALL backends are warmed.
+A spawned task connects each backend and prefetches its tool list into cache. If `config.meta_mcp.warm_start` is empty, ALL backends are warmed. An attempt that fails because the backend is not ready yet is retried automatically until the tool cache is populated: gaps double from 2s up to 30s for the first 180s, then settle at 60s. A failure the transport classifies as permanent stops the retries, and that backend then needs a manual `gateway_list_tools(server=X)`.
 
 ### Health check (`gateway/server.rs:397`)
 
@@ -381,4 +390,4 @@ Implemented in `gateway/server.rs:441-491`.
 
 Runtime: `axum` (HTTP), `tokio` (async), `reqwest` (HTTP client), `tower` (middleware), `serde_json` (serialization), `dashmap` (concurrent maps), `parking_lot` (fast locks), `governor` (rate limiting), `notify` (file watching for hot-reload), `figment` (config), `sha2`/`hmac` (hashing/signatures).
 
-No `unsafe` code (enforced via `#![forbid(unsafe_code)]`).
+No `unsafe` code (enforced via `#![deny(unsafe_code)]`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 - Published on crates.io + Homebrew + Glama + VS Code + Cursor one-click install
 - **Meta-MCP surface**: 14-16 tools in production scenarios (README benchmark scenario)
 - **Capability backends**: 110+ REST capabilities + MCP backends routed via the same surface
-- **Security**: unsafe forbidden; dependency-status badge; OWASP Agentic AI 10/10 docs at `docs/OWASP_AGENTIC_AI_COMPLIANCE.md`
+- **Security**: unsafe denied (`#![deny(unsafe_code)]`); dependency-status badge; OWASP Agentic AI 10/10 docs at `docs/OWASP_AGENTIC_AI_COMPLIANCE.md`
 - **Benchmarks**: machine-readable claims in `benchmarks/public_claims.json` with CI drift check
 - **Independent reviews**: Ruach Tov Collective's five-tool comparison + mcp-gateway deep dive (linked in README)
 
@@ -151,7 +151,7 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 - **Bloating the Meta-MCP surface** — every new meta-tool eats the context-savings story. Default to dynamic discovery; add a meta-tool only if the user-visible workflow demands it.
 - **Treating the gateway like an OpenAI proxy** — it is not. Model calls go to the connected client via `sampling/createMessage`. The prompt-cache helpers are a compatibility shim, not a product surface.
 - **Skipping SHA-256 integrity pinning on a new capability** — the capability system depends on hash verification end-to-end.
-- **Adding `unsafe` without an ADR** — the `forbid(unsafe_code)` gate is deliberate; any exception needs `docs/architecture/` justification.
+- **Adding `unsafe` without an ADR** — the `deny(unsafe_code)` gate is deliberate; any exception needs `docs/architecture/` justification.
 - **Duplicating MIK-2985 annotation policy work across mcp-gateway and mcp-gateway-private** — resolve the pass-through vs override decision once in an ADR and apply to both.
 - **Ignoring `benchmarks/public_claims.json` drift** — the CI check is there because README numerical claims have drifted before.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/crates/d/mcp-gateway.svg)](https://crates.io/crates/mcp-gateway)
 [![Rust](https://img.shields.io/badge/rust-1.95+-blue.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-PolyForm--NC%20%2B%20MIT%20core-blue.svg)](https://github.com/MikkoParkkola/mcp-gateway/blob/main/LICENSES.md)
-[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+[![unsafe denied](https://img.shields.io/badge/unsafe-denied-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![dependency status](https://deps.rs/repo/github/MikkoParkkola/mcp-gateway/status.svg)](https://deps.rs/repo/github/MikkoParkkola/mcp-gateway)
 [![Capabilities](https://img.shields.io/badge/REST%20capabilities-110%2B-purple.svg)](https://github.com/MikkoParkkola/mcp-gateway/tree/main/capabilities)
 [![MCP Protocol](https://img.shields.io/badge/MCP-2025--11--25-green.svg)](https://modelcontextprotocol.io)
@@ -129,7 +129,7 @@ mcp-gateway add -e API_KEY=xxx my-server -- npx my-mcp-server
 
 #### Option C: hand-write `gateway.yaml`
 
-For the full schema reference, see [docs/QUICKSTART.md#configuration](docs/QUICKSTART.md#configuration). Minimal example:
+For the full schema, see the annotated [examples/gateway-full.yaml](examples/gateway-full.yaml), which covers `env_files`, `server`, `auth`, `meta_mcp`, `streaming`, `failsafe`, `cache`, `capabilities`, and `backends`. The remaining top-level sections (`playbooks`, `security`, `webhooks`, `routing_profiles`, `code_mode`, `mtls`, `key_server`, `agent_auth`, `runtime`, `marketplace`, `control_plane`, `cost_governance`) have no prose reference yet; the `Config` struct in [src/config/mod.rs](src/config/mod.rs) is the authoritative list. Minimal example:
 
 ```yaml
 server:
@@ -208,7 +208,7 @@ Modes: `--mode proxy` (HTTP), `--mode stdio` (subprocess), `--mode auto` (probe 
 - **Unlimited tools, discovered on demand.** No more choosing which servers fit the budget. The agent searches (`gateway_search_tools`) and invokes (`gateway_invoke`) tools as it needs them.
 - **Add any REST API in minutes.** Drop in a YAML file or import an OpenAPI spec with `mcp-gateway cap import`. 110+ capabilities ship built in.
 - **Per-user identity to backends.** Multitenant backends can receive the verified end-user identity with no gateway-stored long-lived credential. See [Multitenant identity](#end-user-identity-v31).
-- **Secure by construction.** A tool-poisoning validator scans every backend tool description before it reaches the agent, SHA-256 pinning with rug-pull detection protects each capability, and the OWASP Agentic AI Top 10 is covered 10 out of 10. The whole binary is `#![forbid(unsafe_code)]`, with optional mTLS, message signing, and agent identity.
+- **Secure by construction.** A tool-poisoning validator scans every backend tool description before it reaches the agent, SHA-256 pinning with rug-pull detection protects each capability, and the OWASP Agentic AI Top 10 is covered 10 out of 10. The crate sets `#![deny(unsafe_code)]`, so any unsafe block needs an explicit `#[allow]` opt-in, with optional mTLS, message signing, and agent identity.
 - **Swap your MCP stack without losing your session.** Hot-reload backends and config in about 8ms while the AI stays connected. No restart, no lost context.
 - **Production resilience.** Circuit breakers, retries with backoff, rate limiting, and health checks keep one flaky server from taking down the whole toolchain.
 - **Dual protocol.** MCP plus an A2A (agent-to-agent) transport adapter, so the same gateway routes tool calls and cross-provider agent messages.
@@ -249,6 +249,15 @@ Every MCP tool you connect costs about 150 tokens of context overhead. Connect 2
 | **When one tool breaks** | Cascading failures | Circuit breakers isolate it |
 
 The gateway exposes 14 tools minimum, 16 in the README benchmark scenario, 17 when webhook status is surfaced. The base discovery quartet stays fixed; the rest are operator helpers for stats, cost, playbooks, profile control, disabled-capability visibility, reload, and webhook status.
+
+### Code Mode: two tools instead of the meta-tool set
+
+Setting `code_mode.enabled: true` makes `tools/list` return exactly two tools, `gateway_search` and `gateway_execute`, instead of the meta-tool set. Everything else is reached through those two. Tools named in `meta_mcp.surfaced_tools` are not appended in this mode, so the count stays at two however many backends are connected. Code Mode is off by default.
+
+```yaml
+code_mode:
+  enabled: true
+```
 
 
 ## Security
@@ -452,7 +461,7 @@ Reference: [Anthropic SKILL.md spec](https://docs.claude.com/en/docs/claude-code
 | Document | Contents |
 |----------|----------|
 | [Quick Start](docs/QUICKSTART.md) | Zero to running in 2 minutes |
-| [Configuration Reference](docs/QUICKSTART.md#configuration) | All config options |
+| [Annotated config example](examples/gateway-full.yaml) | Commented `gateway.yaml` covering the most-used config sections |
 | [OAuth Configuration](docs/OAUTH_CONFIG.md) | OAuth 2.0 setup with Slack and Figma examples |
 | [Upgrading to 3.0](docs/UPGRADING-3.0.md) | Per-user OAuth isolation and identity-propagation upgrade path |
 | [Deployment Guide](docs/DEPLOYMENT.md) | Docker, systemd, TLS/mTLS, scaling |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
                          │                                                 │
   AI Client              │  ┌──────────────┐    ┌───────────────────┐      │
   (Claude, Cursor, etc.) │  │  HTTP Router  │───>│    Meta-MCP       │      │
-          |              │  │  (axum)       │    │  12-15 meta-tools:│      │
+          |              │  │  (axum)       │    │  14-17 meta-tools:│      │
           |              │  │               │    │  - list_servers   │      │
    POST /mcp             │  │  /mcp    ─────┼───>│  - list_tools    │      │
    ──────────────────────>  │  /mcp/{id}───┼──┐ │  - search_tools  │      │


### PR DESCRIPTION
Documentation-only. Each claim below was re-checked against the code in this branch before editing.

## What was wrong, and what is now written

**1. `forbid` vs `deny` for unsafe code**
Wrong: README badge "unsafe forbidden" and README:211 "The whole binary is `#![forbid(unsafe_code)]`"; same claim in ARCHITECTURE.md:384 and CLAUDE.md.
Code: `src/lib.rs:25` = `#![deny(unsafe_code)]`, `Cargo.toml:203` = `unsafe_code = "deny"`. `deny` can be suppressed by a local `#[allow]`, and one file does exactly that: `tests/secret_injection_tests.rs:5`. `docs/show-hn.md:38` and `SECURITY.md:40` already said `deny`.
Now: all four say `deny`, and README states that an unsafe block needs an explicit `#[allow]` opt-in.

**2. Dead configuration-reference anchor**
Wrong: README:132 and README:455 both linked `docs/QUICKSTART.md#configuration`. `docs/QUICKSTART.md` has no Configuration heading, so both anchors resolved to nothing.
Code: the authoritative list is the `Config` struct at `src/config/mod.rs:48-105`. `examples/gateway-full.yaml` documents 9 of those sections (`env_files`, `server`, `auth`, `meta_mcp`, `streaming`, `failsafe`, `cache`, `capabilities`, `backends`).
Now: both links point at `examples/gateway-full.yaml`, and README names the sections that have no prose reference yet rather than implying full coverage.

**3. Meta-tool count and build site**
Wrong: ARCHITECTURE.md:42 "up to 9 meta-tools", table listing 9, and "Defined in `src/gateway/meta_mcp_helpers.rs`, function `build_meta_tools()` (line 347)". `docs/ARCHITECTURE.md:13` diagram said 12-15.
Code: `build_meta_tools()` is at `src/gateway/meta_mcp_tool_defs.rs:543`. `src/gateway/meta_mcp_tool_defs_tests.rs:16` asserts 13 with every optional flag off; `:64` asserts 17 with all on. At runtime `src/gateway/meta_mcp/mod.rs:1010` always passes `cost_report = true`, so the floor a client sees is 14. That matches `benchmarks/public_claims.json` (`minimum: 14`, `with_webhook_status: 17`) and README:252.
Now: "14 to 17", the correct file and line, and the eight missing tools added to the table (`gateway_cost_report`, `gateway_set_profile`, `gateway_get_profile`, `gateway_list_disabled_capabilities`, `gateway_list_profiles`, `gateway_set_state`, `gateway_reload_config`, `gateway_reload_capabilities`).

**4. Warm-start recovery**
Wrong: ARCHITECTURE.md state diagram said a failed warm-start returns to Active only by "manual retry via gateway_list_tools(server=X)", and the section header cited `gateway/server.rs:348`, a path that does not exist.
Code: `src/gateway/server/warmstart.rs` retries until the tool cache is populated. `WarmStartPolicy::default` (`:43-51`) sets a 180s fast phase with gaps doubling from 2s to a 30s cap, then a fixed 60s gap. Tests `readiness_errors_are_retried` and `a_backend_that_becomes_reachable_later_is_still_cached` cover it; `permanent_errors_stop_the_loop` covers the case where retries stop, which is when the manual path still applies.
Now: the diagram has a transient-retry edge, the Failed edge says permanent failure, and the section cites `gateway/server/warmstart.rs`.

**5. Code Mode was undocumented**
Uncovered: Code Mode appeared once in README, in an identity table cell, with no explanation.
Code: `src/config/features/code_mode.rs` defines `code_mode.enabled`, default `false`. `src/gateway/meta_mcp/mod.rs:1004-1020` returns `build_code_mode_tools()` when it is set and skips surfaced tools in that branch. `src/gateway/meta_mcp/tests.rs:227-237` asserts `tools/list` returns exactly 2, and the two following tests pin them to `gateway_search` and `gateway_execute`.
Now: a short README section states the behaviour, the config key, and that it is off by default.

## Not changed, deliberately

- README's "14-16 tools" phrasing in diagrams and comparison tables: consistent with `benchmarks/public_claims.json` production scenarios, not drift.
- `docs/design/RFC-0051`, `docs/blog/*`: point-in-time design and blog records, left as written.
- `ARCHITECTURE.md` still cites `gateway/server.rs:48` and `:397` for registration and health check. Those paths are stale too (the file is `src/gateway/server/mod.rs`), but they are outside this drift report and I did not verify replacement line numbers.
- Twelve config sections still have no prose documentation. This PR names them rather than inventing docs for them.

## Verification

- `tests/public_claims_validation.rs:275` requires README to contain "14 tools minimum, 16 in the README benchmark scenario, 17 when webhook status is surfaced" — unchanged by this PR.
- No `BANNED_PUBLIC_PHRASES` entry (`tests/public_claims_validation.rs:152-162`) appears in any file touched here; checked by literal grep.
- Second-opinion gate: `gpt-review` was run twice against this diff and both runs exited without emitting a verdict, dying on a codex MCP transport auth error (`mcp.cloudflare.com` OAuth). No reviewer verdict was obtained, and none is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)