### PR TITLE
fix(security): report backend names and counts, never configured values

### DIFF
--- a/src/commands/add_remove.rs
+++ b/src/commands/add_remove.rs
@@ -193,17 +193,30 @@ pub fn run_get_command(name: &str, config: &Path) -> ExitCode {
     );
     println!("Enabled:     {}", info.enabled);
 
-    if let Some(cmd) = &info.command {
-        println!("Command:     {cmd}");
+    if let Some(command) = &info.command {
+        println!(
+            "Command:     {} ({} argument(s) redacted)",
+            command.executable, command.argument_count
+        );
     }
     if let Some(url) = &info.url {
         println!("URL:         {url}");
     }
 
+    // Names and presence, never values. This output is routinely pasted into
+    // bug reports and CI logs, which is what made the previous `{k}={v}` a
+    // credential disclosure rather than a cosmetic issue (MIK-7221).
     if !info.env.is_empty() {
         println!("Environment:");
-        for (k, v) in &info.env {
-            println!("  {k}={v}");
+        for key in &info.env {
+            println!("  {key}=<set>");
+        }
+    }
+
+    if !info.headers.is_empty() {
+        println!("Headers:");
+        for key in &info.headers {
+            println!("  {key}=<set>");
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -518,7 +518,10 @@ impl Config {
                     }
                     url::Url::parse(http_url).map_err(|e| {
                         Error::ConfigValidation(format!(
-                            "Backend '{name}' has an invalid http_url '{http_url}': {e}"
+                            // The URL is not echoed: a malformed one still carries its
+                            // userinfo and query, and a validation error is printed on
+                            // startup and in support threads (MIK-7221).
+                            "Backend '{name}' has an invalid http_url: {e}"
                         ))
                     })?;
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -534,7 +534,9 @@ impl Config {
                     }
                     url::Url::parse(a2a_url).map_err(|e| {
                         Error::ConfigValidation(format!(
-                            "Backend '{name}' has an invalid a2a_url '{a2a_url}': {e}"
+                            // Twin of the http_url line above. Fixing one spelling of a
+                            // leak and not the other is how the first fix stops mattering.
+                            "Backend '{name}' has an invalid a2a_url: {e}"
                         ))
                     })?;
                 }

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -21,6 +21,17 @@ use crate::{
 // ── Public data types ─────────────────────────────────────────────────────────
 
 /// Structured summary of a single backend, safe to serialise as JSON.
+///
+/// "Safe" is the point of this type, not a description of it. Every field is a
+/// name, a count or a scrubbed URL; no configured VALUE reaches it. Before
+/// 2026-08-22 this carried `command: Option<String>`, `url: Option<String>` and
+/// `env: HashMap<String, String>` verbatim from the config, so `get` and
+/// `list --json` printed API keys in the clear — reproduced on `0373dca0` with
+/// five canary secrets, all five visible (MIK-7221).
+///
+/// Adding a field that holds a configured value re-opens that. If a caller needs
+/// one, it should read the config directly and take responsibility, rather than
+/// widening a type whose contract is that it can be pasted into a bug report.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackendInfo {
     /// Backend key in the config map.
@@ -31,14 +42,16 @@ pub struct BackendInfo {
     pub transport: String,
     /// Whether the backend is enabled.
     pub enabled: bool,
-    /// Command (stdio only).
+    /// Presence-only command summary (stdio only); arguments are never exposed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub command: Option<String>,
-    /// URL (http only).
+    pub command: Option<BackendCommandInfo>,
+    /// URL (http only), stripped of userinfo, query, and fragment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    /// Environment variables.
-    pub env: HashMap<String, String>,
+    /// Sorted environment-variable names; values are never exposed.
+    pub env: Vec<String>,
+    /// Sorted configured-header names; values are never exposed.
+    pub headers: Vec<String>,
     /// Seconds of idleness after which the gateway stops this backend, or
     /// `None` when it is never stopped.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,6 +61,19 @@ pub struct BackendInfo {
     /// but cannot stop the server. The panel should hide or disable the control
     /// rather than let an operator set something that will be refused.
     pub can_stop_when_idle: bool,
+}
+
+/// Secret-safe summary of a configured stdio command.
+///
+/// A command line is a common hiding place for a credential
+/// (`some-server --api-key sk-…`), so the executable is reported and the
+/// arguments are counted, never shown.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackendCommandInfo {
+    /// Parsed executable token.
+    pub executable: String,
+    /// Number of configured arguments, whose values are redacted.
+    pub argument_count: usize,
 }
 
 /// Partial update applied by [`update_backend`].
@@ -316,16 +342,28 @@ pub fn import_openapi_from_file(
 fn backend_to_info(name: &str, backend: &BackendConfig) -> BackendInfo {
     let (transport_kind, command, url) = match &backend.transport {
         TransportConfig::Stdio { command, .. } => {
-            ("stdio".to_string(), Some(command.clone()), None)
+            ("stdio".to_string(), Some(summarize_command(command)), None)
         }
-        TransportConfig::Http { http_url, .. } => {
-            ("http".to_string(), None, Some(http_url.clone()))
-        }
+        TransportConfig::Http { http_url, .. } => (
+            "http".to_string(),
+            None,
+            Some(sanitize_backend_url(http_url)),
+        ),
         #[cfg(feature = "a2a")]
-        TransportConfig::A2a { a2a_url, .. } => ("a2a".to_string(), None, Some(a2a_url.clone())),
+        TransportConfig::A2a { a2a_url, .. } => {
+            ("a2a".to_string(), None, Some(sanitize_backend_url(a2a_url)))
+        }
     };
 
     let can_stop_when_idle = matches!(backend.transport, TransportConfig::Stdio { .. });
+
+    // Names only, sorted. Sorting is not cosmetic: it makes the output stable
+    // between runs, so a diff of two `list --json` runs shows a configuration
+    // change rather than HashMap iteration order.
+    let mut env: Vec<String> = backend.env.keys().cloned().collect();
+    env.sort();
+    let mut headers: Vec<String> = backend.headers.keys().cloned().collect();
+    headers.sort();
 
     BackendInfo {
         name: name.to_string(),
@@ -336,8 +374,41 @@ fn backend_to_info(name: &str, backend: &BackendConfig) -> BackendInfo {
         can_stop_when_idle,
         command,
         url,
-        env: backend.env.clone(),
+        env,
+        headers,
     }
+}
+
+/// Executable plus argument count. Argument values are never returned.
+fn summarize_command(command: &str) -> BackendCommandInfo {
+    match shlex::split(command) {
+        Some(parts) if !parts.is_empty() => BackendCommandInfo {
+            executable: parts[0].clone(),
+            argument_count: parts.len().saturating_sub(1),
+        },
+        // Unparseable input is reported as such rather than echoed. Echoing the
+        // raw string on the error path is the classic way a redaction is undone:
+        // an attacker-shaped command that fails to lex would print in full.
+        _ => BackendCommandInfo {
+            executable: "<invalid-command>".to_string(),
+            argument_count: 0,
+        },
+    }
+}
+
+/// Strip credentials from a URL: userinfo, query and fragment all carry tokens.
+///
+/// Returns a placeholder rather than the input when parsing fails, for the same
+/// reason as above — the failure path must not become the leak.
+fn sanitize_backend_url(raw: &str) -> String {
+    let Ok(mut url) = url::Url::parse(raw) else {
+        return "<invalid-url>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -612,7 +683,12 @@ mod tests {
 
         let info = &list_backends(&cfg)[0];
         assert_eq!(info.transport, "stdio");
-        assert_eq!(info.command.as_deref(), Some("npx my-server"));
+        // The executable is reported; the arguments are counted, never shown.
+        // This assertion used to read `Some("npx my-server")` — the whole command
+        // string, which is where an `--api-key` would have been (MIK-7221).
+        let command = info.command.as_ref().expect("stdio backend has a command");
+        assert_eq!(command.executable, "npx");
+        assert_eq!(command.argument_count, 1);
         assert!(info.url.is_none());
     }
 
@@ -743,7 +819,14 @@ mod tests {
         assert!(json.contains("\"name\":\"svc\""));
         assert!(json.contains("\"transport\":\"http\""));
         assert!(json.contains("\"enabled\":true"));
-        assert!(json.contains("\"TOKEN\":\"abc\""));
+        // The name is reported, the value never is. This assertion used to read
+        // `json.contains("\"TOKEN\":\"abc\"")` — it asserted the leak, and passed
+        // for as long as the leak existed (MIK-7221).
+        assert!(json.contains("\"TOKEN\""), "the variable NAME is reported");
+        assert!(
+            !json.contains("abc"),
+            "the VALUE must never be serialised: {json}"
+        );
         // command should not appear for http transport
         assert!(!json.contains("\"command\""));
     }

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -23,7 +23,11 @@ use crate::{
 /// Structured summary of a single backend, safe to serialise as JSON.
 ///
 /// "Safe" is the point of this type, not a description of it. Every field is a
-/// name, a count or a scrubbed URL; no configured VALUE reaches it. Before
+/// name, a count or a scrubbed URL — with ONE deliberate exception: `description`
+/// is operator-authored display text and is reproduced verbatim, because a list
+/// of backends without it is unusable. An operator who puts a credential in a
+/// description defeats this type, and no code here can tell that text apart from
+/// the label it is meant to be. Everything else is redacted. Before
 /// 2026-08-22 this carried `command: Option<String>`, `url: Option<String>` and
 /// `env: HashMap<String, String>` verbatim from the config, so `get` and
 /// `list --json` printed API keys in the clear — reproduced on `0373dca0` with

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -49,7 +49,8 @@ pub struct BackendInfo {
     /// Presence-only command summary (stdio only); arguments are never exposed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<BackendCommandInfo>,
-    /// URL (http only), stripped of userinfo, query, and fragment.
+    /// URL (http only), reduced to its ORIGIN. The path goes too — a webhook URL
+    /// carries its whole secret there. See `redact_url_for_diagnostics`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// Sorted environment-variable names; values are never exposed.

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -400,29 +400,14 @@ fn summarize_command(command: &str) -> BackendCommandInfo {
     }
 }
 
-/// Reduce a URL to its origin. Userinfo, query, fragment AND path all carry
-/// tokens — Slack and Discord webhooks put the whole secret in the path — and
-/// this value is printed by `get` and serialised by `list --json`, both of which
-/// end up in bug reports.
+/// Reduce a URL to its origin before it is printed or serialised.
 ///
-/// The operator loses the endpoint path for a backend they configured themselves.
-/// That is a genuine cost, accepted because the output travels: `list --json` is
-/// pasted far more often than it is read locally, and the backend NAME is printed
-/// beside it either way.
-///
-/// Returns a placeholder rather than the input when parsing fails, for the same
-/// reason as above — the failure path must not become the leak.
+/// One line, because the rule and its reasoning live in
+/// [`crate::security::sanitize::redact_url_for_diagnostics`]. The operator loses
+/// the endpoint path for a backend they configured themselves; that cost is
+/// accepted there, once, rather than argued in two places.
 fn sanitize_backend_url(raw: &str) -> String {
-    let Ok(url) = url::Url::parse(raw) else {
-        return "<invalid-url>".to_string();
-    };
-    match url.host_str() {
-        Some(host) => match url.port() {
-            Some(port) => format!("{}://{host}:{port}", url.scheme()),
-            None => format!("{}://{host}", url.scheme()),
-        },
-        None => format!("{}://<no-host>", url.scheme()),
-    }
+    crate::security::sanitize::redact_url_for_diagnostics(raw)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/gateway/ui/backend_ops.rs
+++ b/src/gateway/ui/backend_ops.rs
@@ -396,19 +396,29 @@ fn summarize_command(command: &str) -> BackendCommandInfo {
     }
 }
 
-/// Strip credentials from a URL: userinfo, query and fragment all carry tokens.
+/// Reduce a URL to its origin. Userinfo, query, fragment AND path all carry
+/// tokens — Slack and Discord webhooks put the whole secret in the path — and
+/// this value is printed by `get` and serialised by `list --json`, both of which
+/// end up in bug reports.
+///
+/// The operator loses the endpoint path for a backend they configured themselves.
+/// That is a genuine cost, accepted because the output travels: `list --json` is
+/// pasted far more often than it is read locally, and the backend NAME is printed
+/// beside it either way.
 ///
 /// Returns a placeholder rather than the input when parsing fails, for the same
 /// reason as above — the failure path must not become the leak.
 fn sanitize_backend_url(raw: &str) -> String {
-    let Ok(mut url) = url::Url::parse(raw) else {
+    let Ok(url) = url::Url::parse(raw) else {
         return "<invalid-url>".to_string();
     };
-    let _ = url.set_username("");
-    let _ = url.set_password(None);
-    url.set_query(None);
-    url.set_fragment(None);
-    url.to_string()
+    match url.host_str() {
+        Some(host) => match url.port() {
+            Some(port) => format!("{}://{host}:{port}", url.scheme()),
+            None => format!("{}://{host}", url.scheme()),
+        },
+        None => format!("{}://<no-host>", url.scheme()),
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -665,7 +675,9 @@ mod tests {
 
         let info = &list_backends(&cfg)[0];
         assert_eq!(info.transport, "http");
-        assert_eq!(info.url.as_deref(), Some("https://api.example.com/mcp"));
+        // Origin only. The path is dropped because a webhook-style URL keeps its
+        // whole secret there (MIK-7221).
+        assert_eq!(info.url.as_deref(), Some("https://api.example.com"));
         assert!(info.command.is_none());
     }
 

--- a/src/security/sanitize.rs
+++ b/src/security/sanitize.rs
@@ -568,3 +568,70 @@ mod tests {
         assert!(title.contains("{{system_override}}"));
     }
 }
+
+// ── Diagnostic URL redaction ──────────────────────────────────────────────────
+
+/// Reduce a URL to its origin, for any string a human or a log file will see.
+///
+/// Every part of a URL except the origin can carry a credential:
+///
+/// | part | example |
+/// |---|---|
+/// | userinfo | `https://user:tok@host/` |
+/// | query | `?token=…` |
+/// | fragment | `#access_token=…` |
+/// | **path** | a Slack or Discord webhook, where the secret IS the path |
+///
+/// The conventional "safe URL for logs" keeps the path. That is wrong here: this
+/// output is printed by `get`, serialised by `list --json` and written to the
+/// transport's logs, all of which end up in bug reports (MIK-7221).
+///
+/// **Cost, stated because it is real**: the URL is the sole identifier on several
+/// transport log lines, so two backends on one host now read alike there.
+///
+/// Unparseable input returns a fixed marker rather than being echoed — the error
+/// path is exactly where a redaction usually gets undone.
+///
+/// This lives here, once, because it had two copies. Three independent reviewers
+/// each said the same thing about that, and duplication of a security predicate is
+/// how one copy gets fixed and the other does not.
+#[must_use]
+pub fn redact_url_for_diagnostics(raw: &str) -> String {
+    let Ok(url) = url::Url::parse(raw) else {
+        return "<invalid-url>".to_string();
+    };
+    match url.host_str() {
+        Some(host) => match url.port() {
+            Some(port) => format!("{}://{host}:{port}", url.scheme()),
+            None => format!("{}://{host}", url.scheme()),
+        },
+        // Schemes without a host (file:, data:) have nowhere safe to truncate.
+        None => format!("{}://<no-host>", url.scheme()),
+    }
+}
+
+#[cfg(test)]
+mod redact_url_tests {
+    use super::redact_url_for_diagnostics as redact;
+
+    #[test]
+    fn strips_every_credential_bearing_part() {
+        assert_eq!(
+            redact("https://user:tok@api.example.com/services/SECRET?t=X#f=Y"),
+            "https://api.example.com"
+        );
+        assert_eq!(redact("http://localhost:8080/mcp"), "http://localhost:8080");
+    }
+
+    #[test]
+    fn never_echoes_input_it_cannot_parse() {
+        // The failure path must not become the leak.
+        assert_eq!(redact("not a url ?token=SECRET"), "<invalid-url>");
+        assert!(!redact("not a url ?token=SECRET").contains("SECRET"));
+    }
+
+    #[test]
+    fn hostless_schemes_get_a_marker_not_a_path() {
+        assert_eq!(redact("file:///etc/SECRET"), "file://<no-host>");
+    }
+}

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -36,19 +36,31 @@ use crate::{Error, Result};
 /// Strip credentials from a URL before it reaches a log line or an error string.
 ///
 /// A backend URL routinely carries a token in its userinfo (`https://u:tok@…`),
-/// its query (`?token=…`) or its fragment, and this transport prints the URL on
-/// sixteen paths. Only the origin and path survive; unparseable input becomes a
-/// fixed marker rather than being echoed, because the error path is exactly where
-/// a redaction usually gets undone. (MIK-7221)
+/// its query (`?token=…`), its fragment — or its PATH. Slack and Discord webhooks
+/// put the entire secret in the path, and hosted MCP endpoints sometimes mount a
+/// tenant under one. Keeping the path is the conventional choice and it is wrong
+/// for a value whose contract is "safe to paste into a bug report", so only the
+/// origin survives.
+///
+/// That costs real diagnostic detail: the URL is the sole identifier on these log
+/// lines, so two backends on one host now read alike. Adding the backend name to
+/// the log context would recover it and is worth doing separately; leaking a
+/// webhook token to keep them apart is not the trade to make.
+///
+/// Unparseable input becomes a fixed marker rather than being echoed, because the
+/// error path is exactly where a redaction usually gets undone. (MIK-7221)
 fn sanitize_url_for_diagnostics(raw: &str) -> String {
-    let Ok(mut url) = Url::parse(raw) else {
+    let Ok(url) = Url::parse(raw) else {
         return "<invalid-url>".to_string();
     };
-    let _ = url.set_username("");
-    let _ = url.set_password(None);
-    url.set_query(None);
-    url.set_fragment(None);
-    url.to_string()
+    match url.host_str() {
+        Some(host) => match url.port() {
+            Some(port) => format!("{}://{host}:{port}", url.scheme()),
+            None => format!("{}://{host}", url.scheme()),
+        },
+        // Schemes without a host (file:, data:) have nowhere safe to truncate.
+        None => format!("{}://<no-host>", url.scheme()),
+    }
 }
 
 /// Categorise a reqwest failure without keeping its Display text.

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -33,34 +33,13 @@ use crate::protocol::{
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
-/// Strip credentials from a URL before it reaches a log line or an error string.
+/// Reduce a URL to its origin before it reaches a log line or an error string.
 ///
-/// A backend URL routinely carries a token in its userinfo (`https://u:tok@…`),
-/// its query (`?token=…`), its fragment — or its PATH. Slack and Discord webhooks
-/// put the entire secret in the path, and hosted MCP endpoints sometimes mount a
-/// tenant under one. Keeping the path is the conventional choice and it is wrong
-/// for a value whose contract is "safe to paste into a bug report", so only the
-/// origin survives.
-///
-/// That costs real diagnostic detail: the URL is the sole identifier on these log
-/// lines, so two backends on one host now read alike. Adding the backend name to
-/// the log context would recover it and is worth doing separately; leaking a
-/// webhook token to keep them apart is not the trade to make.
-///
-/// Unparseable input becomes a fixed marker rather than being echoed, because the
-/// error path is exactly where a redaction usually gets undone. (MIK-7221)
+/// One line, because the rule and its reasoning live in
+/// [`crate::security::sanitize::redact_url_for_diagnostics`]. A second copy of a
+/// security predicate is how one gets fixed and the other does not.
 fn sanitize_url_for_diagnostics(raw: &str) -> String {
-    let Ok(url) = Url::parse(raw) else {
-        return "<invalid-url>".to_string();
-    };
-    match url.host_str() {
-        Some(host) => match url.port() {
-            Some(port) => format!("{}://{host}:{port}", url.scheme()),
-            None => format!("{}://{host}", url.scheme()),
-        },
-        // Schemes without a host (file:, data:) have nowhere safe to truncate.
-        None => format!("{}://<no-host>", url.scheme()),
-    }
+    crate::security::sanitize::redact_url_for_diagnostics(raw)
 }
 
 /// Categorise a reqwest failure without keeping its Display text.
@@ -86,10 +65,20 @@ fn safe_request_error(context: &str, error: &reqwest::Error) -> Error {
 /// The body comes from the backend, which is not trusted to keep our secrets out
 /// of its error text, and it can be arbitrarily large. Session expiry is the one
 /// signal callers act on, so it is detected and everything else dropped.
+/// The one spelling of the expiry signal, shared by the writer below and the
+/// reader in [`is_session_expired_error`].
+///
+/// It was a bare string literal in both. They are a pair — the writer turns an
+/// untrusted body into this marker, the reader acts on it — and landing a change
+/// to one without the other silently disabled session recovery while every other
+/// test stayed green. A shared constant does not make them provably consistent,
+/// but it makes them impossible to diverge by typo, which is how they diverged.
+const SESSION_EXPIRED_MARKER: &str = "session expired";
+
 fn safe_http_status_error(status: reqwest::StatusCode, body: &str) -> Error {
     let lower = body.to_ascii_lowercase();
     if body.contains("-32015") || lower.contains("session not found") {
-        Error::Transport(format!("HTTP {status}: session expired"))
+        Error::Transport(format!("HTTP {status}: {SESSION_EXPIRED_MARKER}"))
     } else {
         Error::Transport(format!("HTTP {status}"))
     }
@@ -175,7 +164,7 @@ fn is_session_expired_error(err: &Error) -> bool {
         return false;
     };
     let lower = msg.to_lowercase();
-    lower.contains("session expired") || lower.starts_with("http 404")
+    lower.contains(SESSION_EXPIRED_MARKER) || lower.starts_with("http 404")
 }
 
 /// Detect the session-expiry signature in a *successful-transport* JSON-RPC

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -145,7 +145,9 @@ fn evaluate_redirect(base: &Url, target: &Url, previous_hops: usize) -> Redirect
         return RedirectDecision::Reject(format!(
             "redirect target is cross-origin to the transport base URL; \
              refusing to replay per-user credentials to a different origin \
-             (base={base}, target={target})"
+             (base={}, target={})",
+            sanitize_url_for_diagnostics(base.as_str()),
+            sanitize_url_for_diagnostics(target.as_str())
         ));
     }
     RedirectDecision::Follow
@@ -519,7 +521,12 @@ impl HttpTransport {
                     )));
                 }
             } else {
-                return Err(Error::Protocol(format!("Initialize failed: {error:?}")));
+                // Code only. The message and data are backend-controlled and may
+                // quote back credentials the gateway sent.
+                return Err(Error::Protocol(format!(
+                    "Initialize failed: backend error code {}",
+                    error.code
+                )));
             }
         }
 
@@ -879,7 +886,12 @@ impl HttpTransport {
             debug!("Using existing session ID for caller bucket");
         } else if let Some(session_id) = response.headers().get("mcp-session-id") {
             if let Ok(id) = session_id.to_str() {
-                info!(session_id = %id, url = %sanitize_url_for_diagnostics(message_url.as_str()), "Stored session ID from response");
+                // Presence, not value: an MCP session ID is replayable, so a log
+                // reader who sees one can resume another caller's session.
+                info!(
+                    url = %sanitize_url_for_diagnostics(message_url.as_str()),
+                    "Stored session ID from response"
+                );
                 self.sessions
                     .write()
                     .insert(bucket.to_string(), id.to_string());
@@ -901,10 +913,10 @@ impl HttpTransport {
             }
         } else {
             // Debug: log all headers to find session ID
-            debug!(url = %sanitize_url_for_diagnostics(message_url.as_str()), "No session ID in response. Headers: {:?}",
-                response.headers().iter()
-                    .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("?")))
-                    .collect::<Vec<_>>()
+            // Header NAMES only. Values are backend-controlled and routinely
+            // carry `set-cookie`, `authorization` echoes and bearer material.
+            debug!(url = %sanitize_url_for_diagnostics(message_url.as_str()), "No session ID in response. Header names: {:?}",
+                response.headers().keys().map(header::HeaderName::as_str).collect::<Vec<_>>()
             );
         }
 
@@ -942,7 +954,7 @@ impl HttpTransport {
             response
                 .json()
                 .await
-                .map_err(|e| Error::Transport(format!("Failed to parse response: {e}")))
+                .map_err(|e| safe_request_error("Failed to parse response", &e))
         }
     }
 

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -506,7 +506,10 @@ impl HttpTransport {
                     info!(url = %sanitize_url_for_diagnostics(&self.base_url), version = %negotiated_version, "Successfully negotiated protocol version");
                 } else {
                     return Err(Error::Protocol(format!(
-                        "Protocol version negotiation failed: {error_msg}"
+                        // Code only. `error_msg` is the backend's own text and may
+                        // quote back a credential the gateway sent it.
+                        "Protocol version negotiation failed: backend error code {}",
+                        error.code
                     )));
                 }
             } else {
@@ -597,7 +600,8 @@ impl HttpTransport {
         if let Some(session_id) = session {
             match mode {
                 HeaderMode::Request { method } => {
-                    debug!(session_id = %session_id, method = %method, "Sending request with session ID");
+                    // Presence, not value: a session ID is replayable.
+                    debug!(method = %method, "Sending request with session ID");
                     headers.insert("MCP-Session-Id", session_id.parse().unwrap());
                 }
                 HeaderMode::Notify | HeaderMode::Close => {
@@ -745,7 +749,7 @@ impl HttpTransport {
                                     self.sessions
                                         .write()
                                         .insert(String::new(), value.to_string());
-                                    debug!(session_id = %value, "Extracted session ID");
+                                    debug!("Extracted session ID");
                                 }
                             }
                         }

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -33,6 +33,56 @@ use crate::protocol::{
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
+/// Strip credentials from a URL before it reaches a log line or an error string.
+///
+/// A backend URL routinely carries a token in its userinfo (`https://u:tok@…`),
+/// its query (`?token=…`) or its fragment, and this transport prints the URL on
+/// sixteen paths. Only the origin and path survive; unparseable input becomes a
+/// fixed marker rather than being echoed, because the error path is exactly where
+/// a redaction usually gets undone. (MIK-7221)
+fn sanitize_url_for_diagnostics(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return "<invalid-url>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+/// Categorise a reqwest failure without keeping its Display text.
+///
+/// `reqwest::Error`'s Display embeds the full request URL, so `format!("{e}")`
+/// reintroduces every credential this module is careful to strip. The category
+/// is what a reader needs; the URL is what an attacker needs.
+fn safe_request_error(context: &str, error: &reqwest::Error) -> Error {
+    let category = if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connection failed"
+    } else if error.is_redirect() {
+        "redirect rejected"
+    } else {
+        "request failed"
+    };
+    Error::Transport(format!("{context}: {category}"))
+}
+
+/// Report an HTTP failure status while discarding the response body.
+///
+/// The body comes from the backend, which is not trusted to keep our secrets out
+/// of its error text, and it can be arbitrarily large. Session expiry is the one
+/// signal callers act on, so it is detected and everything else dropped.
+fn safe_http_status_error(status: reqwest::StatusCode, body: &str) -> Error {
+    let lower = body.to_ascii_lowercase();
+    if body.contains("-32015") || lower.contains("session not found") {
+        Error::Transport(format!("HTTP {status}: session expired"))
+    } else {
+        Error::Transport(format!("HTTP {status}"))
+    }
+}
+
 /// Origin equality per WHATWG (scheme + host + effective port). Used to enforce
 /// that an SSE-advertised message endpoint is same-origin as the SSE stream
 /// before any per-user credential is sent to it (SSRF + credential-exfil guard).
@@ -91,10 +141,14 @@ fn evaluate_redirect(base: &Url, target: &Url, previous_hops: usize) -> Redirect
 
 /// Detect the session-expiry signature in a transport error (MIK-5982).
 ///
-/// Matches three observed shapes:
-/// - JSON-RPC `-32015` session errors (rust-mcp-sdk servers, e.g. hebb-serve:
-///   `HTTP 400 Bad Request: {"code":-32015,...,"message":"Bad Request: Session not found"}`)
-/// - any body containing "session not found" (case-insensitive)
+/// Matches the safe markers emitted at the HTTP boundary:
+/// - `session expired`, produced by [`safe_http_status_error`] after an untrusted
+///   body contained JSON-RPC `-32015` or a case-insensitive `session not found`.
+///   The classifier reads that marker rather than the body, because the body no
+///   longer reaches an error string — it may echo our own credentials back at us.
+///   These two functions are a pair: change the marker in one and session recovery
+///   silently stops working, which is what the suite caught when this landed
+///   half-applied (MIK-7221).
 /// - bare `HTTP 404` responses, which the MCP Streamable HTTP spec defines as
 ///   "session terminated or expired" (callers gate this on having had a session)
 ///
@@ -107,7 +161,7 @@ fn is_session_expired_error(err: &Error) -> bool {
         return false;
     };
     let lower = msg.to_lowercase();
-    lower.contains("session not found") || msg.contains("-32015") || lower.starts_with("http 404")
+    lower.contains("session expired") || lower.starts_with("http 404")
 }
 
 /// Detect the session-expiry signature in a *successful-transport* JSON-RPC
@@ -243,7 +297,7 @@ impl HttpTransport {
         // `evaluate_redirect`). An unparseable base cannot function as a
         // transport at all, so failing construction here is correct.
         let base_origin = Url::parse(url)
-            .map_err(|e| Error::Transport(format!("Invalid transport base URL {url:?}: {e}")))?;
+            .map_err(|e| Error::Transport(format!("Invalid transport base URL: {e}")))?;
         let client = Client::builder()
             .timeout(timeout)
             .pool_max_idle_per_host(10)
@@ -337,7 +391,7 @@ impl HttpTransport {
 
                 // If we don't have a valid token, trigger authorization flow
                 if !oauth.has_valid_token() {
-                    info!(url = %base_url_for_task, "OAuth required - initiating authorization flow");
+                    info!(url = %sanitize_url_for_diagnostics(&base_url_for_task), "OAuth required - initiating authorization flow");
                     oauth.authorize().await?;
                 }
 
@@ -370,13 +424,13 @@ impl HttpTransport {
             // Starlette compatibility was the original reason, but it handles both.
             let url = self.base_url.clone();
             *self.message_url.write() = Some(url.clone());
-            info!(url = %url, oauth = self.oauth_client.is_some(), "Streamable HTTP mode - direct POST");
+            info!(url = %sanitize_url_for_diagnostics(&url), oauth = self.oauth_client.is_some(), "Streamable HTTP mode - direct POST");
         } else {
             // SSE mode: GET the SSE endpoint to receive the message endpoint
             let message_endpoint = self.establish_sse_connection().await?;
             let full_message_url = self.resolve_message_url(&message_endpoint)?;
             *self.message_url.write() = Some(full_message_url.clone());
-            info!(sse_url = %self.base_url, message_url = %full_message_url, oauth = self.oauth_client.is_some(), "SSE handshake complete");
+            info!(sse_url = %sanitize_url_for_diagnostics(&self.base_url), message_url = %sanitize_url_for_diagnostics(full_message_url.as_str()), oauth = self.oauth_client.is_some(), "SSE handshake complete");
         }
 
         // Send initialize request via the message endpoint
@@ -412,7 +466,7 @@ impl HttpTransport {
                 // Try to extract supported versions from error message
                 if let Some(negotiated_version) = self.negotiate_protocol_version(error_msg).await {
                     warn!(
-                        url = %self.base_url,
+                        url = %sanitize_url_for_diagnostics(&self.base_url),
                         rejected_version = %version,
                         negotiated_version = %negotiated_version,
                         "Server rejected protocol version, retrying with negotiated version"
@@ -446,7 +500,7 @@ impl HttpTransport {
                     }
 
                     // Success with negotiated version
-                    info!(url = %self.base_url, version = %negotiated_version, "Successfully negotiated protocol version");
+                    info!(url = %sanitize_url_for_diagnostics(&self.base_url), version = %negotiated_version, "Successfully negotiated protocol version");
                 } else {
                     return Err(Error::Protocol(format!(
                         "Protocol version negotiation failed: {error_msg}"
@@ -462,11 +516,11 @@ impl HttpTransport {
         // can still use request/response tools in that case, so notification
         // delivery must not make backend startup fail.
         if let Err(error) = self.notify("notifications/initialized", None).await {
-            debug!(url = %self.base_url, error = %error, "Initialized notification failed (ignored)");
+            debug!(url = %sanitize_url_for_diagnostics(&self.base_url), error = %error, "Initialized notification failed (ignored)");
         }
 
         self.connected.store(true, Ordering::Relaxed);
-        debug!(url = %self.base_url, streamable = %self.streamable_http, "HTTP transport initialized");
+        debug!(url = %sanitize_url_for_diagnostics(&self.base_url), streamable = %self.streamable_http, "HTTP transport initialized");
 
         Ok(())
     }
@@ -518,7 +572,7 @@ impl HttpTransport {
             // a clean auth error, never panic the request path (MIK-6909).
             headers.insert(header::AUTHORIZATION, bearer_header_value(&token)?);
             if matches!(mode, HeaderMode::Sse) {
-                debug!(url = %self.base_url, "SSE connection with OAuth token");
+                debug!(url = %sanitize_url_for_diagnostics(&self.base_url), "SSE connection with OAuth token");
             }
         }
 
@@ -589,7 +643,7 @@ impl HttpTransport {
         let supported_versions = parse_supported_versions_from_error(error_msg)?;
 
         debug!(
-            url = %self.base_url,
+            url = %sanitize_url_for_diagnostics(&self.base_url),
             server_versions = ?supported_versions,
             "Negotiating protocol version"
         );
@@ -598,7 +652,7 @@ impl HttpTransport {
 
         if result.is_none() {
             warn!(
-                url = %self.base_url,
+                url = %sanitize_url_for_diagnostics(&self.base_url),
                 server_versions = ?supported_versions,
                 "No compatible protocol version found"
             );
@@ -613,7 +667,7 @@ impl HttpTransport {
 
         let headers = self.build_mcp_headers(HeaderMode::Sse, None).await?;
 
-        debug!(url = %self.base_url, "Establishing SSE connection");
+        debug!(url = %sanitize_url_for_diagnostics(&self.base_url), "Establishing SSE connection");
 
         let response = self
             .client
@@ -621,7 +675,7 @@ impl HttpTransport {
             .headers(headers)
             .send()
             .await
-            .map_err(|e| Error::Transport(format!("SSE connection failed: {e}")))?;
+            .map_err(|e| safe_request_error("SSE connection failed", &e))?;
 
         let status = response.status();
         if !status.is_success() {
@@ -642,8 +696,8 @@ impl HttpTransport {
         let max_sse_handshake_buffer: usize = 64 * 1024;
 
         while let Some(chunk_result) = stream.next().await {
-            let chunk = chunk_result
-                .map_err(|e| Error::Transport(format!("Failed to read SSE chunk: {e}")))?;
+            let chunk =
+                chunk_result.map_err(|e| safe_request_error("Failed to read SSE chunk", &e))?;
 
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
@@ -802,7 +856,7 @@ impl HttpTransport {
             .json(request)
             .send()
             .await
-            .map_err(|e| Error::Transport(format!("Request failed: {e}")))?;
+            .map_err(|e| safe_request_error("Request failed", &e))?;
 
         // Extract session ID from response headers if this caller's bucket is
         // empty (MIK-6784: store under the caller's identity key, never a shared
@@ -813,7 +867,7 @@ impl HttpTransport {
             debug!("Using existing session ID for caller bucket");
         } else if let Some(session_id) = response.headers().get("mcp-session-id") {
             if let Ok(id) = session_id.to_str() {
-                info!(session_id = %id, url = %message_url, "Stored session ID from response");
+                info!(session_id = %id, url = %sanitize_url_for_diagnostics(message_url.as_str()), "Stored session ID from response");
                 self.sessions
                     .write()
                     .insert(bucket.to_string(), id.to_string());
@@ -835,7 +889,7 @@ impl HttpTransport {
             }
         } else {
             // Debug: log all headers to find session ID
-            debug!(url = %message_url, "No session ID in response. Headers: {:?}",
+            debug!(url = %sanitize_url_for_diagnostics(message_url.as_str()), "No session ID in response. Headers: {:?}",
                 response.headers().iter()
                     .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("?")))
                     .collect::<Vec<_>>()
@@ -845,7 +899,7 @@ impl HttpTransport {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(Error::Transport(format!("HTTP {status}: {body}")));
+            return Err(safe_http_status_error(status, &body));
         }
 
         // Check Content-Type to determine response format
@@ -860,7 +914,7 @@ impl HttpTransport {
             let text = response
                 .text()
                 .await
-                .map_err(|e| Error::Transport(format!("Failed to read SSE response: {e}")))?;
+                .map_err(|e| safe_request_error("Failed to read SSE response", &e))?;
 
             // Find the data line and extract JSON
             for line in text.lines() {
@@ -947,7 +1001,7 @@ impl Transport for HttpTransport {
         };
         if had_session && session_expired {
             warn!(
-                url = %self.base_url,
+                url = %sanitize_url_for_diagnostics(&self.base_url),
                 method = %method,
                 "Backend session expired; re-initializing and retrying once"
             );
@@ -1003,7 +1057,7 @@ impl Transport for HttpTransport {
             .json(&notification)
             .send()
             .await
-            .map_err(|e| Error::Transport(format!("Notification failed: {e}")))?;
+            .map_err(|e| safe_request_error("Notification failed", &e))?;
 
         if !response.status().is_success() {
             // Many HTTP backends (e.g. exa, beeper) do not support MCP
@@ -1011,7 +1065,7 @@ impl Transport for HttpTransport {
             // DEBUG so it does not spam the operator logs.
             debug!(
                 status = %response.status(),
-                url = %message_url,
+                url = %sanitize_url_for_diagnostics(message_url.as_str()),
                 method = method,
                 "Notification not supported by backend (ignored)"
             );
@@ -1056,7 +1110,7 @@ impl Transport for HttpTransport {
                 Err(error) => {
                     warn!(
                         error = %error,
-                        url = %message_url,
+                        url = %sanitize_url_for_diagnostics(message_url.as_str()),
                         "Failed to build full close headers; falling back to session header only"
                     );
                     self.client

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -1539,3 +1539,66 @@ fn bearer_header_value_rejects_invalid_bytes_without_panicking() {
         );
     }
 }
+
+/// One canary, every redaction helper. Each site was found by a reviewer AFTER a
+/// previous round claimed the class was closed — five in round one, three more in
+/// round two, including two session-ID logs and a config line that was the twin
+/// of one already fixed. A per-site fix does not generalise; a sweep does.
+#[test]
+fn no_diagnostic_helper_passes_a_canary_through() {
+    const CANARY: &str = "SENTINEL_TRANSPORT_9f3c";
+
+    // URL redaction: the secret in each position a URL can hide one.
+    for raw in [
+        format!("https://user:{CANARY}@svc.example.com/mcp"),
+        format!("https://svc.example.com/services/{CANARY}"),
+        format!("https://svc.example.com/mcp?token={CANARY}"),
+        format!("https://svc.example.com/mcp#{CANARY}"),
+    ] {
+        let out = sanitize_url_for_diagnostics(&raw);
+        assert!(!out.contains(CANARY), "URL redaction leaked: {out}");
+        assert!(
+            out.starts_with("https://svc.example.com"),
+            "origin lost: {out}"
+        );
+    }
+
+    // Unparseable input must not be echoed — the failure path is where a
+    // redaction usually gets undone.
+    let bad = sanitize_url_for_diagnostics(&format!(":://not a url {CANARY}"));
+    assert!(!bad.contains(CANARY), "invalid-URL path leaked: {bad}");
+
+    // A backend error body is untrusted and may quote our own credentials back.
+    for body in [
+        format!("{{\"error\":\"{CANARY}\"}}"),
+        format!("{{\"code\":-32015,\"message\":\"Session not found {CANARY}\"}}"),
+    ] {
+        let err = safe_http_status_error(reqwest::StatusCode::BAD_REQUEST, &body);
+        assert!(
+            !err.to_string().contains(CANARY),
+            "status error leaked: {err}"
+        );
+    }
+
+    // The expiry marker still survives that redaction, or session recovery breaks.
+    let expired = safe_http_status_error(
+        reqwest::StatusCode::BAD_REQUEST,
+        &format!("{{\"code\":-32015,\"message\":\"Session not found {CANARY}\"}}"),
+    );
+    assert!(
+        is_session_expired_error(&expired),
+        "expiry lost to redaction: {expired}"
+    );
+
+    // A cross-origin redirect rejection names both URLs; neither may carry one.
+    let base = Url::parse("https://svc.example.com/mcp").expect("base");
+    let target = Url::parse(&format!("https://evil.example.com/x?t={CANARY}")).expect("target");
+    if let RedirectDecision::Reject(reason) = evaluate_redirect(&base, &target, 0) {
+        assert!(
+            !reason.contains(CANARY),
+            "redirect rejection leaked: {reason}"
+        );
+    } else {
+        panic!("a cross-origin redirect must be rejected");
+    }
+}

--- a/src/transport/http/tests.rs
+++ b/src/transport/http/tests.rs
@@ -1017,28 +1017,59 @@ async fn request_does_not_reinitialize_without_a_session() {
     // surface as a plain error (nothing to re-initialize).
 
     let err = transport.request("tools/list", None).await.unwrap_err();
-    assert!(err.to_string().contains("Session not found"));
+    // The marker, not the backend's own wording: the body is redacted at the
+    // boundary now, so "Session not found" never reaches an error string.
+    assert!(err.to_string().contains("session expired"), "{err}");
+    assert!(
+        !err.to_string().contains("-32015"),
+        "the untrusted body must not survive into the error: {err}"
+    );
 
     server.abort();
 }
 
 #[test]
 fn session_expired_detection_matches_known_signatures() {
-    // rust-mcp-sdk shape (hebb-serve, observed live 2026-06-11)
-    assert!(is_session_expired_error(&Error::Transport(
-        "HTTP 400 Bad Request: {\"code\":-32015,\"data\":null,\"message\":\"Bad Request: Session not found\"}".to_string()
-    )));
-    // MCP spec: 404 = session terminated/expired
+    // The raw body no longer reaches the classifier: `safe_http_status_error`
+    // converts it at the HTTP boundary, because the body is backend-controlled
+    // and may echo our own credentials. So the contract under test is the PAIR
+    // — the conversion, then the match. Testing either half alone is how this
+    // broke: the redaction landed without the classifier change and session
+    // recovery stopped, silently, with every other test still green (MIK-7221).
+    let raw_rust_mcp_sdk =
+        "{\"code\":-32015,\"data\":null,\"message\":\"Bad Request: Session not found\"}";
+    let converted = safe_http_status_error(reqwest::StatusCode::BAD_REQUEST, raw_rust_mcp_sdk);
+    assert!(
+        !converted.to_string().contains("-32015"),
+        "the untrusted body must not survive into the error: {converted}"
+    );
+    assert!(
+        is_session_expired_error(&converted),
+        "expiry must still be recognised after redaction: {converted}"
+    );
+
+    // The lowercase-only shape, which is the other half of the boundary check.
+    let converted_lower =
+        safe_http_status_error(reqwest::StatusCode::BAD_REQUEST, "session not found, sorry");
+    assert!(is_session_expired_error(&converted_lower));
+
+    // MCP spec: 404 = session terminated/expired. Reaches the classifier directly.
     assert!(is_session_expired_error(&Error::Transport(
         "HTTP 404 Not Found: ".to_string()
     )));
+
+    // A non-expiry body converts to a bare status and must NOT match. Without
+    // this, a conversion that returned the marker unconditionally would pass.
+    let other = safe_http_status_error(reqwest::StatusCode::BAD_REQUEST, "malformed json");
+    assert!(!is_session_expired_error(&other), "{other}");
+
     // Plain transport failure must not match
     assert!(!is_session_expired_error(&Error::Transport(
         "Request failed: connection refused".to_string()
     )));
     // Non-transport errors must not match
     assert!(!is_session_expired_error(&Error::Protocol(
-        "Session not found".to_string()
+        "session expired".to_string()
     )));
 }
 

--- a/tests/cli_secret_redaction.rs
+++ b/tests/cli_secret_redaction.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! End-to-end redaction tests for backend inspection commands.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+const ENV_SECRET: &str = "SENTINEL_CLI_ENV_37a1";
+const HEADER_SECRET: &str = "SENTINEL_CLI_HEADER_84dc";
+const ARG_SECRET: &str = "SENTINEL_CLI_ARG_b515";
+const URL_USER_SECRET: &str = "SENTINEL_CLI_URL_USER_6d9b";
+const URL_QUERY_SECRET: &str = "SENTINEL_CLI_URL_QUERY_efe2";
+const URL_FRAGMENT_SECRET: &str = "SENTINEL_CLI_URL_FRAGMENT_d209";
+
+fn run_gateway(config: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
+        .args(args)
+        .arg("--config")
+        .arg(config)
+        .output()
+        .expect("run mcp-gateway")
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn backend_inspection_commands_never_print_config_secrets() {
+    let dir = tempfile::tempdir().expect("create CLI redaction workspace");
+    let config = dir.path().join("gateway.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            r#"backends:
+  stdio-secret:
+    command: "/usr/bin/example --token '{ARG_SECRET}' --mode safe"
+    env:
+      SAFE_ENV_NAME: "{ENV_SECRET}"
+    headers:
+      Authorization: "{HEADER_SECRET}"
+  http-secret:
+    http_url: "https://user:{URL_USER_SECRET}@svc.example.com/mcp?token={URL_QUERY_SECRET}#{URL_FRAGMENT_SECRET}"
+"#
+        ),
+    )
+    .expect("write CLI redaction config");
+
+    let outputs = [
+        run_gateway(&config, &["get", "stdio-secret"]),
+        run_gateway(&config, &["get", "http-secret"]),
+        run_gateway(&config, &["list", "--json"]),
+    ];
+    for output in &outputs {
+        assert!(
+            output.status.success(),
+            "CLI failed: {}",
+            combined_output(output)
+        );
+    }
+    let combined = outputs.iter().map(combined_output).collect::<String>();
+
+    for sentinel in [
+        ENV_SECRET,
+        HEADER_SECRET,
+        ARG_SECRET,
+        URL_USER_SECRET,
+        URL_QUERY_SECRET,
+        URL_FRAGMENT_SECRET,
+    ] {
+        assert!(
+            !combined.contains(sentinel),
+            "CLI leaked {sentinel}: {combined}"
+        );
+    }
+    assert!(combined.contains("SAFE_ENV_NAME=<set>"));
+    assert!(combined.contains("Authorization=<set>"));
+    assert!(combined.contains("argument(s) redacted"));
+    assert!(combined.contains("https://svc.example.com/mcp"));
+}

--- a/tests/cli_secret_redaction.rs
+++ b/tests/cli_secret_redaction.rs
@@ -11,6 +11,9 @@ const ARG_SECRET: &str = "SENTINEL_CLI_ARG_b515";
 const URL_USER_SECRET: &str = "SENTINEL_CLI_URL_USER_6d9b";
 const URL_QUERY_SECRET: &str = "SENTINEL_CLI_URL_QUERY_efe2";
 const URL_FRAGMENT_SECRET: &str = "SENTINEL_CLI_URL_FRAGMENT_d209";
+/// Webhook-style: the secret IS the path. Slack and Discord both work this way,
+/// and an origin+path sanitiser — the conventional one — leaks it whole.
+const URL_PATH_SECRET: &str = "SENTINEL_CLI_URL_PATH_c0f4";
 
 fn run_gateway(config: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
@@ -44,7 +47,7 @@ fn backend_inspection_commands_never_print_config_secrets() {
     headers:
       Authorization: "{HEADER_SECRET}"
   http-secret:
-    http_url: "https://user:{URL_USER_SECRET}@svc.example.com/mcp?token={URL_QUERY_SECRET}#{URL_FRAGMENT_SECRET}"
+    http_url: "https://user:{URL_USER_SECRET}@svc.example.com/services/{URL_PATH_SECRET}?token={URL_QUERY_SECRET}#{URL_FRAGMENT_SECRET}"
 "#
         ),
     )
@@ -71,6 +74,7 @@ fn backend_inspection_commands_never_print_config_secrets() {
         URL_USER_SECRET,
         URL_QUERY_SECRET,
         URL_FRAGMENT_SECRET,
+        URL_PATH_SECRET,
     ] {
         assert!(
             !combined.contains(sentinel),
@@ -80,5 +84,11 @@ fn backend_inspection_commands_never_print_config_secrets() {
     assert!(combined.contains("SAFE_ENV_NAME=<set>"));
     assert!(combined.contains("Authorization=<set>"));
     assert!(combined.contains("argument(s) redacted"));
-    assert!(combined.contains("https://svc.example.com/mcp"));
+    // The origin is kept so the endpoint is still identifiable; the path is not,
+    // because that is where a webhook secret lives.
+    assert!(combined.contains("https://svc.example.com"));
+    assert!(
+        !combined.contains("/services/"),
+        "the path must not survive: {combined}"
+    );
 }


### PR DESCRIPTION
Closes the diagnostic-output disclosure tracked in MIK-7221.

## What was wrong

`get` and `list --json` summarised a backend by copying its configuration verbatim — the stdio command line, the URL, and every environment value. The HTTP transport did the same across seventeen log sites. All of it is output that gets pasted into bug reports and CI logs.

Reproduced on `0373dca0` before any change, with canary values in a test config: every one appeared in the clear.

## What changed

| | |
|---|---|
| `BackendInfo` | reports a name, a count or an origin; no configured value reaches it |
| stdio command | executable plus argument count — a credential commonly rides in an argument |
| URLs | reduced to scheme, host and port, in both the CLI and the transport's logs |
| reqwest errors | categorised, not formatted: their `Display` embeds the full request URL |
| backend error bodies | discarded, keeping only the session-expiry signal |

**URLs lose their path deliberately.** A push-time review caught that origin-plus-path — the conventional choice — leaks a Slack or Discord webhook whole, since the secret *is* the path. A value documented as safe to paste cannot keep that field.

## Breaking change

`BackendInfo.env` becomes a list of names and `.command` a summary struct, so **`list --json` output changes shape** for anyone parsing it.

## Accepted cost, stated because it is real

The URL is the sole identifier on the transport's log lines, so two backends on one host now read alike. Recovering that means adding the backend name to the log context — worth doing, not this change.

## Tests

3,538 pass, 0 fail. `cargo fmt --check` clean.

Three existing tests asserted the previous behaviour, one of them requiring `"TOKEN":"abc"` to appear in serialised output. Each was rewritten to assert the redaction, and each new assertion was verified to fail when the fix is reverted.

**One regression the suite caught and it is worth recording**: the body-redaction change and the session-expiry classifier are a pair. Landing the first without the second left session recovery silently broken with every other test green. They are now documented as a pair and tested together — the conversion and the match, in one case.

## Out of scope

Six pre-existing `unused_async_trait_impl` clippy errors, identical on pristine `origin/main`, so `cargo clippy -- -D warnings` is red before and after this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)