### PR TITLE
chore(release): 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.0] - 2026-08-28
 
 ### Added
 
@@ -1287,7 +1287,7 @@ credential path.
 - Configuration via YAML with Pydantic validation
 - systemd/launchd service templates
 
-[Unreleased]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.10.0...HEAD
+[3.5.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.4.0...v3.5.0
 [2.10.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.9.1...v2.10.0
 [2.9.1]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.8.1...v2.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ command that changes behaviour, is a breaking change.
 modularity and testing, not as a supported embedding API, and they may change
 in any release. The crate ships a binary; at the time of writing crates.io
 reports zero reverse dependencies. If you embed the library, pin an exact
-version (`=3.4.0`) rather than a caret range.
+version (`=3.5.0`) rather than a caret range.
 
 This is stated explicitly because "removing a `pub` field" and "breaking a
 supported API" are only the same thing when the API is supported. Here it is

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -7,7 +7,7 @@ description: >-
   to author these resources as typed config. Helm does not manage CRD
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "3.5.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -8,7 +8,7 @@ description: >-
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
 version: 0.1.2
-appVersion: "3.4.0"
+appVersion: "3.5.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:
   - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -4,7 +4,7 @@ description: Universal MCP Gateway — compact Meta-MCP tool router with securit
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
 version: 0.1.2
-appVersion: "3.4.0"
+appVersion: "3.5.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:
   - https://github.com/MikkoParkkola/mcp-gateway

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -3,7 +3,7 @@ name: mcp-gateway
 description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
-version: 0.1.2
+version: 0.1.3
 appVersion: "3.5.0"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mikkoparkkola/mcp-gateway
   # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
   # When `digest` is set it takes precedence over `tag`.
-  tag: "3.4.0"
+  tag: "3.5.0"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Cuts 3.5.0. 27 commits since v3.4.0, including the authentication and origin-validation work that two reported security issues depend on for a patched version.

- Crate, lockfile, Helm `appVersion` and the README pinning example move to 3.5.0
- Helm chart `version` moves to 0.1.3 so the packaged chart is a distinct artifact
- The `Unreleased` changelog section becomes `[3.5.0] - 2026-08-28`

Merging this and tagging `v3.5.0` runs the Release workflow, which gates on the vulnerability scan and the log-leak lint before publishing to GitHub Releases, crates.io, npm and Homebrew.