### PR TITLE
ci(release): run publish dry-run against an unreplaced registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,11 @@ jobs:
         run: cargo test --all-features
 
       - name: Verify publish package
+        # The runner image points crates-io at a mirror in its cargo config,
+        # and cargo publish refuses to run while the registry is replaced.
+        # A private CARGO_HOME carries no such config.
+        env:
+          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
         run: cargo publish --locked --dry-run
 
   build:
@@ -273,8 +278,10 @@ jobs:
 
       - name: Sync npm package version to git tag
         working-directory: npm
+        env:
+          TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           echo "Setting npm version to ${VERSION}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
@@ -293,8 +300,10 @@ jobs:
     steps:
       - name: Compute version and download checksums
         id: meta
+        env:
+          TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,9 +251,12 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Publish to crates.io
+        # Same reason as the verify job: a private CARGO_HOME avoids the
+        # runner image's crates-io source replacement.
         run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
 
   npm-publish:
     needs: release


### PR DESCRIPTION
## Problem

The `v3.5.0` release run failed in `verify`, step **Verify publish package**:

```
error: crates-io is replaced with remote registry cache;
##[error]Process completed with exit code 101.
```

`cargo publish` refuses to run while the `crates-io` source is replaced. The
workflow has not changed since `v3.4.0` published successfully on 2026-07-27,
and this repository contains no `.cargo/` directory — the replacement comes
from the runner image's own `$CARGO_HOME/config.toml`. With `build`, `release`,
`publish`, `npm-publish` and `homebrew-update` all gated on `verify`, every
distribution channel except Docker is blocked.

## Change

- `verify` runs the dry-run with `CARGO_HOME` pointed at a per-run temp
  directory, which carries no registry replacement.
- The npm and Homebrew jobs bind `github.event.inputs.tag || github.ref_name`
  through step `env:` instead of interpolating it inside `run:`. Pre-existing;
  fixed here because the workflow lint treats the file as a whole.

## Verification

The release workflow re-runs on the moved `v3.5.0` tag once this lands;
success is `verify` passing and the five downstream jobs publishing.