### PR TITLE
ci(release): name the crates.io registry explicitly on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,11 @@ jobs:
         run: cargo test --all-features
 
       - name: Verify publish package
-        # The runner image points crates-io at a mirror in its cargo config,
-        # and cargo publish refuses to run while the registry is replaced.
-        # A private CARGO_HOME carries no such config.
-        env:
-          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
-        run: cargo publish --locked --dry-run
+        # The runner image replaces the crates-io source with a mirror, and
+        # cargo refuses to publish against a replaced source unless the target
+        # registry is named explicitly. The replacement is not carried in
+        # CARGO_HOME, so overriding that does not clear it.
+        run: cargo publish --locked --dry-run --registry crates-io
 
   build:
     needs: verify
@@ -251,12 +250,14 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Publish to crates.io
-        # Same reason as the verify job: a private CARGO_HOME avoids the
-        # runner image's crates-io source replacement.
-        run: cargo publish --locked
+        # Same reason as the verify job: the runner replaces the crates-io
+        # source, so the target registry must be named explicitly. Naming it
+        # can route the token lookup to the per-registry variable, so supply
+        # both spellings rather than risk an auth failure at publish time.
+        run: cargo publish --locked --registry crates-io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
+          CARGO_REGISTRIES_CRATES_IO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   npm-publish:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,11 @@ jobs:
         run: cargo test --all-features
 
       - name: Verify publish package
+        # The runner image points crates-io at a mirror in its cargo config,
+        # and cargo publish refuses to run while the registry is replaced.
+        # A private CARGO_HOME carries no such config.
+        env:
+          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
         run: cargo publish --locked --dry-run
 
   build:
@@ -273,8 +278,10 @@ jobs:
 
       - name: Sync npm package version to git tag
         working-directory: npm
+        env:
+          TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           echo "Setting npm version to ${VERSION}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
@@ -293,8 +300,10 @@ jobs:
     steps:
       - name: Compute version and download checksums
         id: meta
+        env:
+          TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${TAG_REF}"
           VERSION="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
         # cargo refuses to publish against a replaced source unless the target
         # registry is named explicitly. The replacement is not carried in
         # CARGO_HOME, so overriding that does not clear it.
+        # https://doc.rust-lang.org/cargo/reference/source-replacement.html
         run: cargo publish --locked --dry-run --registry crates-io
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,9 +251,12 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Publish to crates.io
+        # Same reason as the verify job: a private CARGO_HOME avoids the
+        # runner image's crates-io source replacement.
         run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_HOME: ${{ runner.temp }}/publish-cargo-home
 
   npm-publish:
     needs: release


### PR DESCRIPTION
The 3.5.0 release run failed in `verify` with:

```
error: crates-io is replaced with remote registry cache;
include `--registry cache` or `--registry crates-io`
```

An earlier attempt pointed `CARGO_HOME` at a private directory on the theory that the replacement came from the runner's cargo config. The follow-up run shows the override applied and the error unchanged, so the replacement is not carried in `CARGO_HOME`.

This takes the remedy cargo's own error names: pass `--registry crates-io` on both the dry-run and the real publish. Naming the registry can route the credential lookup to the per-registry variable, so both token spellings are supplied rather than risk an authentication failure at publish time.

Evidence: run 33208772073, job `verify`, step `Verify publish package`.