### PR TITLE
fix(release): publish npm package to npmjs.org, not the runner mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,13 @@ jobs:
         # Trusted publisher is configured on npmjs.com for
         # @mikkoparkkola/mcp-gateway against this workflow. npm CLI auto-detects
         # OIDC via id-token:write — no NODE_AUTH_TOKEN required.
-        run: npm publish --access public --provenance
+        #
+        # The runner image points npm at a mirror in its user-level .npmrc, and
+        # setup-node's registry-url writes the project .npmrc at the repository
+        # root, which npm does not read from this subdirectory. Name the real
+        # registry on the command line so publish targets npmjs.org, which is
+        # also the only registry the trusted publisher can authenticate to.
+        run: npm publish --access public --provenance --registry https://registry.npmjs.org
 
   homebrew-update:
     needs: release


### PR DESCRIPTION
The 3.5.0 release shipped to GitHub Releases, crates.io and Homebrew. The npm job failed with `ENEEDAUTH` against `https://cache.avrea.com:8443/npm/` — the runner image's mirror, not npmjs.org.

Same defect class as the crates.io registry replacement fixed in #456: the runner redirects the package registry, and the publish step has to name the real one.

`setup-node` was already given `registry-url: https://registry.npmjs.org`, but it writes the project `.npmrc` at the repository root and the publish step runs with `working-directory: npm`, which npm does not read it from. Naming the registry on the command line overrides the user-level mirror config, and npmjs.org is the only registry where the trusted publisher and provenance attestation are honoured.

Reviewed by GPT-5.x and Kimi.