### PR TITLE
ci(release): publish npm from a GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,12 @@ jobs:
 
   npm-publish:
     needs: release
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    # GitHub-hosted on purpose. npm rejects a provenance bundle signed on a
+    # self-hosted runner ("Unsupported GitHub Actions runner environment:
+    # self-hosted"), so publishing from avrea-* costs the build attestation.
+    # This package is a thin wrapper that needs nothing from that fleet.
+    # https://docs.npmjs.com/generating-provenance-statements
+    runs-on: ubuntu-latest
     permissions:
       id-token: write     # OIDC for npm trusted publishing + provenance attestation
       contents: read


### PR DESCRIPTION
npm rejects a provenance bundle signed on a self-hosted runner, so the v3.5.0 npm publish failed with:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Unsupported GitHub Actions runner environment: "self-hosted".
Only "github-hosted" runners are supported when publishing with provenance.
```

Moves the `npm-publish` job alone to `ubuntu-latest`. Keeping `--provenance` preserves the build attestation, which is the point of the package; the alternative would drop it to make the publish pass. The package is a thin wrapper and needs nothing from the self-hosted fleet. All other jobs are unchanged.

Reviewed by GPT-5.x: SHIP. Reviewed by Kimi: SHIP. Both confirm npm trusted publishing matches on repository plus workflow filename, not on runner.