### PR TITLE
docs: record 3.5.0 and the npm distribution channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,8 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 
 ## Current Status
 
-- **v2.10.0** · Rust 1.88+ · Edition 2024 · ~101K LOC · MIT
-- Published on crates.io + Homebrew + Glama + VS Code + Cursor one-click install
+- **v3.5.0** · Rust 1.88+ · Edition 2024 · ~101K LOC · MIT core + PolyForm Noncommercial EE
+- Published on crates.io + Homebrew + npm + ghcr.io container images + Glama + VS Code + Cursor one-click install
 - **Meta-MCP surface**: 14-16 tools in production scenarios (README benchmark scenario)
 - **Capability backends**: 110+ REST capabilities + MCP backends routed via the same surface
 - **Security**: unsafe denied (`#![deny(unsafe_code)]`); dependency-status badge; OWASP Agentic AI 10/10 docs at `docs/OWASP_AGENTIC_AI_COMPLIANCE.md`


### PR DESCRIPTION
The current-status line still read 2.10.0 and omitted two channels that now carry releases.

- version 2.10.0 to 3.5.0
- adds npm and ghcr.io container images to the published-channels list
- states the dual licence explicitly: MIT core, PolyForm Noncommercial for the EE parts

Verified at source before claiming it: crates.io 3.5.0, Homebrew formula 3.5.0, GitHub release v3.5.0 with 12 assets, npm @mikkoparkkola/mcp-gateway 3.5.0 with a signed provenance statement.

This was the only stale version claim in the repository; a full scan found no others.