### PR TITLE
fix: diagnose unreadable gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ Your agent will install the binary, run the setup wizard, import your existing M
 | **Cargo** | `cargo install mcp-gateway` |
 | **cargo-binstall** | `cargo binstall mcp-gateway` |
 | **Direct binary download (Windows x64)** | Download `mcp-gateway-windows-x86_64.exe` from the [latest release](https://github.com/MikkoParkkola/mcp-gateway/releases/latest) |
-| **Docker** | `docker run -v $(pwd)/gateway.yaml:/config.yaml ghcr.io/mikkoparkkola/mcp-gateway:latest --config /config.yaml` |
+| **Docker** | `docker run -v $(pwd)/gateway.container.yaml:/config.yaml:ro ghcr.io/mikkoparkkola/mcp-gateway:latest --config /config.yaml` |
+
+On Linux, the image runs as UID/GID 1001. Make an owner-only deployment copy
+instead of changing ownership on your working config: `install -m 600
+gateway.yaml gateway.container.yaml && sudo chown 1001:1001
+gateway.container.yaml`. Do not make a credential-bearing config
+world-readable. Docker Desktop handles bind-mount identity differently on
+macOS and Windows.
 
 <details>
 <summary>Direct binary download</summary>

--- a/deploy/single-node/README.md
+++ b/deploy/single-node/README.md
@@ -24,6 +24,13 @@ The Compose template mounts `$PWD/gateway.yaml` as `/config.yaml` and
 relative `capabilities` directory in the local profile resolves to the mounted
 `/capabilities` path.
 
+On Linux, use a dedicated deployment directory rather than changing ownership
+on your working config. The image runs as UID/GID 1001, so prepare the copy with
+`install -m 600 <working-config> gateway.yaml && sudo chown 1001:1001
+gateway.yaml` before starting Compose. Do not make a credential-bearing config
+world-readable. Docker Desktop handles bind-mount identity differently on
+macOS and Windows.
+
 ## Linux systemd
 
 Run these commands in a root shell or through your configuration-management

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -54,14 +54,25 @@ scripts/dev/service-template-smoke.sh
 ```bash
 mcp-gateway init --profile local
 docker build -t mcp-gateway:latest .
+# Linux bind mounts: prepare a dedicated owner-only copy for container UID 1001.
+install -m 600 gateway.yaml gateway.container.yaml
+sudo chown 1001:1001 gateway.container.yaml
 
 docker run -d --name mcp-gateway \
   -p 39400:39400 \
-  -v ./gateway.yaml:/config.yaml:ro \
+  -v ./gateway.container.yaml:/config.yaml:ro \
   -v ./capabilities:/capabilities:ro \
   -e TAVILY_API_KEY=tvly-xxx \
   mcp-gateway:latest
 ```
+
+On Linux, the image runs as UID/GID 1001. Bind-mount an owner-only deployment
+copy that this identity can read; do not change ownership on your working
+config or make a credential-bearing config world-readable. The same
+requirement applies to the Compose example below: create its `gateway.yaml`
+deployment copy with `install -m 600 <working-config> gateway.yaml && sudo chown
+1001:1001 gateway.yaml`. Docker Desktop handles bind-mount identity differently
+on macOS and Windows.
 
 ### Docker Compose
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -258,8 +258,11 @@ scripts/dev/first-run-smoke.sh  # repo checkout: clean init -> routed tool call
 scripts/dev/usability-smoke.sh  # repo checkout: no prompts + safe export + routed tool call
 
 # Container
+# Linux bind mounts: prepare a dedicated owner-only copy for container UID 1001.
+install -m 600 gateway.yaml gateway.container.yaml
+sudo chown 1001:1001 gateway.container.yaml
 docker run --rm -p 39400:39400 \
-  -v "$PWD/gateway.yaml:/config.yaml:ro" \
+  -v "$PWD/gateway.container.yaml:/config.yaml:ro" \
   -v "$PWD/capabilities:/capabilities:ro" \
   ghcr.io/mikkoparkkola/mcp-gateway:latest --config /config.yaml
 scripts/dev/docker-smoke.sh  # repo checkout: container health + routed tool call
@@ -272,6 +275,12 @@ scripts/dev/service-template-smoke.sh  # repo checkout: systemd/launchd path + s
 mcp-gateway doctor --format json
 mcp-gateway tls init-ca --cn "MCP Gateway Root CA" --out ./tls
 ```
+
+On Linux, the image runs as UID/GID 1001, so its bind-mounted deployment copy
+must be readable by that identity. Keep the copy owner-only as shown; do not
+`chmod 644` a config that may contain credentials, and do not change ownership
+on your working config. Docker Desktop handles bind-mount identity differently
+on macOS and Windows.
 
 For a team-shared gateway, keep auth enabled, bind behind TLS or mTLS, and distribute only the generated client entry or managed config profile to users.
 

--- a/docs/design/issue-437-config-readability.md
+++ b/docs/design/issue-437-config-readability.md
@@ -1,0 +1,112 @@
+# Issue 437: actionable config-readability diagnostics
+
+Status: locally validated; remote delivery pending
+
+Issue: <https://github.com/MikkoParkkola/mcp-gateway/issues/437>
+
+## Problem
+
+The official image runs as `gateway` (UID/GID 1001). A Linux bind mount keeps the host file ownership and mode, so a root-owned `0600` `gateway.yaml` exists inside the container but cannot be read by the process. `Config::load` currently checks only `Path::exists`; Figment then reports a generic YAML-file permission error. Under a Docker restart policy, the same non-zero startup failure repeats without telling the operator which security-preserving ownership change is required.
+
+The report also describes `usage.json` and `transitions.json` being replaced by empty arrays. Current-main control flow does not support that as a consequence of the unreadable-config startup itself: both HTTP and stdio return immediately from `Config::load`, before `Gateway::new_with_path` constructs or loads either persistence object. The persistence observation remains important, but it needs an independent failing sequence before changing persistence semantics.
+
+## Scope
+
+FOR:
+
+- identify an unreadable selected config before Figment parsing;
+- name the path, OS error, and current-process ownership requirement;
+- give a secure official-container remediation using UID/GID 1001 without recommending world-readable secrets;
+- preserve fail-loud startup and the existing `Error::Config` public behavior;
+- document the requirement beside every official Docker bind-mount example;
+- add a regression-first Unix test for the actual unreadable-file path.
+
+OUT:
+
+- changing Docker restart policy or hiding the non-zero exit;
+- running as root or weakening the image user;
+- automatically chmod/chowning a host bind mount from inside the container;
+- changing persistence writes without a reproduced persistence failure;
+- Windows ACL interpretation, which has no Unix UID/mode equivalent.
+
+## Evidence and constraints
+
+- `Dockerfile` creates and selects UID/GID 1001.
+- `Config::load` accepts an existing path and lets two Figment extraction passes open it.
+- `run_server` and `run_stdio_server` return before gateway construction when `Config::load` fails.
+- ranker and transition state are loaded only in `Gateway::build_meta_mcp` and saved only after the server run returns.
+- Config files may contain bearer tokens and API keys. `chmod 644`, while sufficient for readability, contradicts the repository's owner-only security policy.
+- GitNexus reports LOW impact for `Config::load`, but its Rust graph lists no incoming callers. Source search finds call sites in serve, doctor, validate, setup, add/remove, config export, reload, and tests; validation therefore covers the shared loader rather than trusting the incomplete graph result.
+
+## Options
+
+### A. Open preflight, then keep Figment authoritative — selected
+
+After resolving the chosen path, attempt `std::fs::File::open`. Map `PermissionDenied` to an actionable `Error::Config`; map other open failures to a path-specific read error. If the open succeeds, retain the existing Figment parsing pipeline unchanged.
+
+Pros:
+
+- classifies the OS error structurally rather than scraping Figment prose;
+- minimal behavioral change and no new dependency;
+- applies consistently to explicit and auto-discovered paths;
+- keeps YAML parsing and environment merging in one existing implementation.
+
+Cons:
+
+- the file can change between preflight and Figment open (diagnostic TOCTOU only);
+- opens the file one extra time at startup.
+
+### B. Read the file once and feed its contents to Figment
+
+Pros: one read and fully controlled read errors.
+
+Rejected because it changes Figment provider construction, path/source reporting, and two-pass env-file extraction; that is a larger parser refactor for a diagnostic defect.
+
+### C. Rewrite Figment errors containing “Permission denied”
+
+Pros: smallest apparent diff.
+
+Rejected because it depends on human prose, OS localization, and upstream formatting. It can misclassify permission errors from referenced env files as the main config.
+
+## Detailed behavior
+
+For a selected config path that cannot be opened:
+
+1. Return `Error::Config` before either Figment extraction.
+2. Include the displayed path and original OS error.
+3. State that the current process must own or be granted read access.
+4. State that the official container runs as UID/GID 1001.
+5. On Unix, recommend creating an owner-only deployment copy with `install -m 600` before applying `chown 1001:1001`, or using an equivalently narrow group/ACL grant.
+6. If a containing directory denies traversal, say that the process also needs directory search (`+x`) access; changing the file alone is insufficient.
+7. Explicitly warn against making a credential-bearing config world-readable.
+
+Missing explicit paths retain the existing “Config file not found” error. Valid and invalid readable YAML retain current behavior. Windows receives a path-specific read/ACL error without Unix ownership commands.
+
+The selected path is the explicit CLI/config argument when present; otherwise it
+is the single default path returned by the existing discovery logic. Discovery
+behavior does not change, and the preflight runs only after that selection.
+
+## Documentation
+
+Update `README.md`, `docs/QUICKSTART.md`, `docs/DEPLOYMENT.md`, and
+`deploy/single-node/README.md` beside their Docker bind-mount examples. Each
+must say that the bind-mounted deployment copy must be readable by UID/GID 1001
+and show an owner-only preparation command. Avoid implying that a local
+developer's primary config must be given away to UID 1001; call it a deployment
+copy.
+
+## Persistence follow-up
+
+Do not close the data-loss portion from source reasoning alone. Request the exact container volume mapping, whether the old state loaded successfully before the restart, shutdown logs, file ownership, and a before/after sequence. Candidate hardening such as suppressing a save after a load failure or atomic replacement belongs in a separate change only after a failing test demonstrates the destructive path.
+
+## Acceptance criteria
+
+- AC1: an unreadable file containing invalid YAML returns the readability error before parsing; the regression asserts that the message includes the selected path and literal `1001`. On Unix, the test skips with an explicit reason when effective UID is root, because root can bypass a `000` mode fixture.
+- AC2: error guidance preserves secret confidentiality and names official-container UID/GID 1001.
+- AC3: missing, readable-valid, and readable-invalid config behavior does not regress.
+- AC4: official Docker bind-mount documentation states the ownership/readability requirement.
+- AC5: no persistence behavior changes without an independent reproduction.
+
+## Rollback
+
+Revert the preflight and documentation commit. No stored data or configuration schema changes are involved.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -191,6 +191,28 @@ impl Config {
             None => Self::fallback_config_path(),
         };
 
+        if let Some(config_path) = resolved.as_deref()
+            && let Err(error) = std::fs::File::open(config_path)
+        {
+            let detail = match error.kind() {
+                #[cfg(unix)]
+                std::io::ErrorKind::PermissionDenied => {
+                    "The current process must own the file or have narrowly scoped read access, and every containing directory must permit traversal. The official container runs as UID/GID 1001; create an owner-only deployment copy before transferring it with `install -m 600 <source> <deployment-copy>` and `chown 1001:1001 <deployment-copy>`, or grant equivalent group/ACL access. Do not make a credential-bearing config world-readable."
+                }
+                #[cfg(not(unix))]
+                std::io::ErrorKind::PermissionDenied => {
+                    "The current process needs read access to the selected config; grant it narrowly through the platform ACL. Do not make a credential-bearing config readable by unrelated users."
+                }
+                _ => {
+                    "The selected config must be readable by the current process and must still exist after path selection."
+                }
+            };
+            return Err(Error::Config(format!(
+                "Cannot read config file {}: {error}. {detail}",
+                config_path.display()
+            )));
+        }
+
         let env_file_config: EnvFileConfig = Self::figment(resolved.as_deref())
             .extract()
             .map_err(|e| Error::Config(e.to_string()))?;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -7,6 +7,71 @@ use std::io::Write;
 
 use super::*;
 
+#[cfg(unix)]
+#[test]
+fn unreadable_invalid_config_reports_secure_container_remediation_before_parsing() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(&path, "this is: [invalid yaml").expect("write invalid config");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000))
+        .expect("remove config read permission");
+
+    // Root and similarly privileged CI users can bypass mode 000. In that
+    // environment this fixture cannot exercise PermissionDenied, so say why
+    // the test is skipped instead of reporting a misleading pass or failure.
+    if std::fs::File::open(&path).is_ok() {
+        eprintln!("skipping unreadable-config regression: effective user can read mode 000");
+        return;
+    }
+
+    let err = Config::load(Some(&path)).expect_err("an unreadable config must fail before parsing");
+    let message = err.to_string();
+    assert!(
+        message.contains(&path.display().to_string()),
+        "the diagnostic must name the selected config path: {message}"
+    );
+    assert!(
+        message.contains("1001"),
+        "the diagnostic must name the official container UID/GID: {message}"
+    );
+    assert!(
+        !message.contains("invalid type") && !message.contains("invalid YAML"),
+        "readability must be diagnosed before the deliberately invalid YAML is parsed: {message}"
+    );
+}
+
+#[test]
+fn missing_explicit_config_keeps_not_found_diagnostic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("missing-gateway.yaml");
+
+    let err = Config::load(Some(&path)).expect_err("a missing explicit config must fail");
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "Configuration error: Config file not found: {}",
+            path.display()
+        )
+    );
+}
+
+#[test]
+fn readable_invalid_config_still_reports_parse_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("gateway.yaml");
+    std::fs::write(&path, "this is: [invalid yaml").expect("write invalid config");
+
+    let err = Config::load(Some(&path)).expect_err("invalid YAML must fail parsing");
+    let message = err.to_string();
+    assert!(
+        message.contains(&path.display().to_string())
+            && !message.contains("Cannot read config file"),
+        "a readable invalid file must retain the parser path: {message}"
+    );
+}
+
 #[test]
 fn test_load_env_files_sets_env_vars() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- fail early with a path-specific, actionable diagnostic when the selected config cannot be opened
- give secure Linux bind-mount guidance for the official UID/GID 1001 image without recommending world-readable secrets
- preserve existing missing-file and readable-YAML behavior
- document the ownership requirement beside official Docker examples

Addresses the confirmed unreadable-config/restart-loop portion of #437.

The reported `usage.json` / `transitions.json` replacement is intentionally not claimed fixed: current startup flow returns before persistence objects are constructed when config loading fails. The design records the exact volume mapping, ownership, shutdown logs, and before/after sequence needed to reproduce that independently.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-features -- -D warnings`
- `cargo test config::tests:: --lib` — 69 passed
- `cargo test --all-features` — all library, binary, integration, and doc-test suites passed (library: 3,724 passed, 2 ignored; doctests: 41 passed, 12 ignored)
- Claude CLI independent design review: APPROVE
- Claude CLI complete patch review: APPROVE

## Declared gap

The Windows ACL-specific message is cfg-gated and compiles in CI's Windows check, but the Unix mode-based regression is intentionally Unix-only; no local Windows runtime test was performed.
