### PR TITLE
fix(meta_mcp): parallelize and bound prompts/list and resources/list backend fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaced as an "unknown message ID" error. Backends are now fetched in
   parallel and each fetch is bounded by a short timeout, so a slow or hung
   backend is skipped instead of blocking the list.
+- **The aggregation timeout is configurable** via
+  `meta_mcp.prompts_resources_fetch_timeout` (default `10s`). Operators with
+  unusually slow backends can raise it without a code change.
+- **A cancelled transport request no longer strands its `pending` entry.**
+  When an outer timeout drops an in-flight stdio or WebSocket request before
+  the transport's own request timeout fires, a RAII guard removes the entry
+  from the transport's `pending` map on drop, so a late response finds no
+  dangling sender and the map does not grow across reconnect loops.
 
 ## [3.5.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`gateway_search` returns L0 by default** (MIK-7084): tool name, one-line purpose, and score. `detail=l1` adds signature, when-to-use, and required params; `detail=l2` returns the full `input_schema`. `include_schema=true` still maps to L2 and is deprecated, not removed. Ranking diagnostics (`ranking` reasons and signals) are omitted unless `explain=true`. `gateway_search_tools` also omits `ranking` unless `explain=true`.
+### Fixed
+
+- **`prompts/list` and `resources/list` no longer stall on a slow or hung
+  backend.** Both handlers aggregated every backend sequentially, so a single
+  backend that was slow to answer held the whole request for its full transport
+  timeout (often 120s). On a gateway with 50+ backends this blew past client
+  connect timeouts on every (re)connect, and the gateway's late response
+  surfaced as an "unknown message ID" error. Backends are now fetched in
+  parallel and each fetch is bounded by a short timeout, so a slow or hung
+  backend is skipped instead of blocking the list.
 
 ## [3.5.0] - 2026-08-28
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -892,6 +892,16 @@ pub struct MetaMcpConfig {
     /// Tool cache TTL.
     #[serde(with = "humantime_serde")]
     pub cache_ttl: Duration,
+    /// Per-backend bound on how long `prompts/list` and `resources/list`
+    /// aggregation waits for a single backend before skipping it.
+    ///
+    /// The aggregate fetch runs all backends in parallel (see the meta-MCP
+    /// handlers), so this bounds the whole request by the slowest backend
+    /// rather than the sum of all backends. A backend that exceeds the bound —
+    /// slow OR hung — is skipped for that response; its prompts/resources
+    /// reappear once it recovers. Defaults to 10 seconds.
+    #[serde(default, with = "humantime_serde")]
+    pub prompts_resources_fetch_timeout: Duration,
     /// Backends to warm-start on gateway startup.
     #[serde(default)]
     pub warm_start: Vec<String>,
@@ -919,6 +929,7 @@ impl Default for MetaMcpConfig {
             enabled: true,
             cache_tools: true,
             cache_ttl: Duration::from_secs(300),
+            prompts_resources_fetch_timeout: Duration::from_secs(10),
             warm_start: Vec::new(),
             surfaced_tools: Vec::new(),
             projection_mode: crate::projection::ProjectionMode::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,6 +109,10 @@ fn default_routing_profile() -> String {
     "default".to_string()
 }
 
+fn default_prompts_resources_fetch_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct EnvFileConfig {
@@ -900,7 +904,10 @@ pub struct MetaMcpConfig {
     /// rather than the sum of all backends. A backend that exceeds the bound —
     /// slow OR hung — is skipped for that response; its prompts/resources
     /// reappear once it recovers. Defaults to 10 seconds.
-    #[serde(default, with = "humantime_serde")]
+    #[serde(
+        default = "default_prompts_resources_fetch_timeout",
+        with = "humantime_serde"
+    )]
     pub prompts_resources_fetch_timeout: Duration,
     /// Backends to warm-start on gateway startup.
     #[serde(default)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -350,6 +350,52 @@ meta_mcp:
     assert!(config.meta_mcp.surfaced_tools.is_empty());
 }
 
+// ── meta_mcp.prompts_resources_fetch_timeout (PR #465 aggregation bound) ─────
+
+#[test]
+fn meta_mcp_prompts_resources_fetch_timeout_deserializes_from_yaml() {
+    // GIVEN: a YAML with an explicit aggregation timeout
+    let yaml = r"
+meta_mcp:
+  prompts_resources_fetch_timeout: 5s
+";
+    // WHEN: parsing as Config
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    // THEN: the timeout is read as a humantime Duration
+    assert_eq!(
+        config.meta_mcp.prompts_resources_fetch_timeout,
+        Duration::from_secs(5)
+    );
+}
+
+#[test]
+fn meta_mcp_prompts_resources_fetch_timeout_defaults_to_ten_seconds() {
+    // GIVEN: no prompts_resources_fetch_timeout in config
+    // WHEN: a default config is created
+    let config = Config::default();
+    // THEN: the bound falls back to the documented 10s default
+    assert_eq!(
+        config.meta_mcp.prompts_resources_fetch_timeout,
+        Duration::from_secs(10)
+    );
+}
+
+#[test]
+fn meta_mcp_prompts_resources_fetch_timeout_omitted_in_yaml_keeps_default() {
+    // GIVEN: a YAML with meta_mcp but no aggregation timeout key
+    let yaml = r"
+meta_mcp:
+  cache_ttl: 60s
+";
+    // WHEN: parsing
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    // THEN: the default is applied
+    assert_eq!(
+        config.meta_mcp.prompts_resources_fetch_timeout,
+        Duration::from_secs(10)
+    );
+}
+
 #[test]
 fn surfaced_tool_config_serializes_roundtrip() {
     // GIVEN: a SurfacedToolConfig

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -231,6 +231,10 @@ pub struct MetaMcp {
     /// Pre-built from `surfaced_tools` so `handle_tools_call` only pays one
     /// `HashMap` lookup instead of a linear scan on every call.
     pub(super) surfaced_tools_map: HashMap<String, String>,
+    /// Per-backend timeout for `prompts/list` aggregation.
+    pub(super) prompts_fetch_timeout: std::time::Duration,
+    /// Per-backend timeout for `resources/list` aggregation.
+    pub(super) resources_fetch_timeout: std::time::Duration,
     /// Session-scoped dynamically promoted tools (SEP-1862 / Phase 3).
     ///
     /// Keyed by session ID.  Each entry is a list of `"server:tool"` strings
@@ -391,6 +395,8 @@ impl MetaMcp {
             cost_registry: None,
             surfaced_tools: Vec::new(),
             surfaced_tools_map: HashMap::new(),
+            prompts_fetch_timeout: std::time::Duration::from_secs(10),
+            resources_fetch_timeout: std::time::Duration::from_secs(10),
             #[cfg(feature = "spec-preview")]
             session_promoted: Arc::new(DashMap::new()),
             session_state: SessionStateStore::new(),
@@ -473,6 +479,20 @@ impl MetaMcp {
     #[must_use]
     pub fn with_code_mode(mut self, enabled: bool) -> Self {
         self.code_mode_enabled = enabled;
+        self
+    }
+
+    /// Override the per-backend `prompts/list` fetch timeout (tests).
+    #[must_use]
+    pub fn with_prompts_fetch_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.prompts_fetch_timeout = timeout;
+        self
+    }
+
+    /// Override the per-backend `resources/list` fetch timeout (tests).
+    #[must_use]
+    pub fn with_resources_fetch_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.resources_fetch_timeout = timeout;
         self
     }
 

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -231,10 +231,10 @@ pub struct MetaMcp {
     /// Pre-built from `surfaced_tools` so `handle_tools_call` only pays one
     /// `HashMap` lookup instead of a linear scan on every call.
     pub(super) surfaced_tools_map: HashMap<String, String>,
-    /// Per-backend timeout for `prompts/list` aggregation.
-    pub(super) prompts_fetch_timeout: std::time::Duration,
-    /// Per-backend timeout for `resources/list` aggregation.
-    pub(super) resources_fetch_timeout: std::time::Duration,
+    /// Per-backend bound for `prompts/list` and `resources/list`
+    /// aggregation. Configurable via `meta_mcp.prompts_resources_fetch_timeout`
+    /// (default 10s); overridable per-instance for tests.
+    pub(super) prompts_resources_fetch_timeout: std::time::Duration,
     /// Session-scoped dynamically promoted tools (SEP-1862 / Phase 3).
     ///
     /// Keyed by session ID.  Each entry is a list of `"server:tool"` strings
@@ -395,8 +395,7 @@ impl MetaMcp {
             cost_registry: None,
             surfaced_tools: Vec::new(),
             surfaced_tools_map: HashMap::new(),
-            prompts_fetch_timeout: std::time::Duration::from_secs(10),
-            resources_fetch_timeout: std::time::Duration::from_secs(10),
+            prompts_resources_fetch_timeout: std::time::Duration::from_secs(10),
             #[cfg(feature = "spec-preview")]
             session_promoted: Arc::new(DashMap::new()),
             session_state: SessionStateStore::new(),
@@ -482,17 +481,13 @@ impl MetaMcp {
         self
     }
 
-    /// Override the per-backend `prompts/list` fetch timeout (tests).
+    /// Override the per-backend `prompts/list` and `resources/list` fetch
+    /// timeout. The default comes from
+    /// `meta_mcp.prompts_resources_fetch_timeout` (10s); this lets tests run
+    /// with a shorter bound.
     #[must_use]
-    pub fn with_prompts_fetch_timeout(mut self, timeout: std::time::Duration) -> Self {
-        self.prompts_fetch_timeout = timeout;
-        self
-    }
-
-    /// Override the per-backend `resources/list` fetch timeout (tests).
-    #[must_use]
-    pub fn with_resources_fetch_timeout(mut self, timeout: std::time::Duration) -> Self {
-        self.resources_fetch_timeout = timeout;
+    pub fn with_prompts_resources_fetch_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.prompts_resources_fetch_timeout = timeout;
         self
     }
 

--- a/src/gateway/meta_mcp/protocol.rs
+++ b/src/gateway/meta_mcp/protocol.rs
@@ -158,7 +158,7 @@ impl MetaMcp {
             .filter(|backend| !self.meta_route_isolation_refused(backend))
             .cloned()
             .collect();
-        let timeout = self.prompts_fetch_timeout;
+        let timeout = self.prompts_resources_fetch_timeout;
         let results = join_all(backends.iter().map(|backend| async move {
             match tokio::time::timeout(timeout, backend.get_prompts_shared()).await {
                 Ok(Ok(prompts)) => Ok(prompts.as_ref().clone()),

--- a/src/gateway/meta_mcp/protocol.rs
+++ b/src/gateway/meta_mcp/protocol.rs
@@ -9,6 +9,7 @@
 //! without forwarding to any backend, prepended to every `prompts/list`
 //! response so clients always find them first.
 
+use futures::future::join_all;
 use serde_json::{Value, json};
 use tracing::{debug, warn};
 
@@ -149,14 +150,29 @@ impl MetaMcp {
         // Prepend gateway-owned meta-prompts (served inline, no backend required).
         let mut all_prompts: Vec<Prompt> = gateway_prompts().into();
 
-        for backend in self.backends.all() {
-            if self.meta_route_isolation_refused(&backend) {
-                continue;
+        // Fetch all backends in parallel; skip ones that fail or time out.
+        let backends: Vec<_> = self
+            .backends
+            .all()
+            .iter()
+            .filter(|backend| !self.meta_route_isolation_refused(backend))
+            .cloned()
+            .collect();
+        let timeout = self.prompts_fetch_timeout;
+        let results = join_all(backends.iter().map(|backend| async move {
+            match tokio::time::timeout(timeout, backend.get_prompts_shared()).await {
+                Ok(Ok(prompts)) => Ok(prompts.as_ref().clone()),
+                Ok(Err(e)) => Err(e),
+                Err(_elapsed) => Err(crate::Error::BackendTimeout(backend.name.clone())),
             }
-            match backend.get_prompts_shared().await {
+        }))
+        .await;
+
+        for (backend, prompts) in backends.iter().zip(results) {
+            match prompts {
                 Ok(prompts) => {
-                    for prompt in prompts.iter() {
-                        let mut prompt = prompt.clone();
+                    for prompt in prompts {
+                        let mut prompt = prompt;
                         prompt.name = format!("{}/{}", backend.name, prompt.name);
                         all_prompts.push(prompt);
                     }

--- a/src/gateway/meta_mcp/resources.rs
+++ b/src/gateway/meta_mcp/resources.rs
@@ -19,6 +19,7 @@
 
 use std::sync::Arc;
 
+use futures::future::join_all;
 use serde_json::{Value, json};
 use tracing::warn;
 
@@ -224,13 +225,28 @@ impl MetaMcp {
         // Prepend gateway-owned guides (served inline, no backend required).
         let mut all_resources: Vec<Resource> = guide_resources().into();
 
-        for backend in self.backends.all() {
-            if self.meta_route_isolation_refused(&backend) {
-                continue;
+        // Fetch all backends in parallel; skip ones that fail or time out.
+        let backends: Vec<_> = self
+            .backends
+            .all()
+            .iter()
+            .filter(|backend| !self.meta_route_isolation_refused(backend))
+            .cloned()
+            .collect();
+        let timeout = self.resources_fetch_timeout;
+        let results = join_all(backends.iter().map(|backend| async move {
+            match tokio::time::timeout(timeout, backend.get_resources_shared()).await {
+                Ok(Ok(resources)) => Ok(resources.as_ref().clone()),
+                Ok(Err(e)) => Err(e),
+                Err(_elapsed) => Err(crate::Error::BackendTimeout(backend.name.clone())),
             }
-            match backend.get_resources_shared().await {
+        }))
+        .await;
+
+        for (backend, resources) in backends.iter().zip(results) {
+            match resources {
                 Ok(resources) => {
-                    for resource in resources.iter().cloned() {
+                    for resource in resources {
                         if let Some(clean) = sanitize_resource(resource, &backend.name) {
                             all_resources.push(clean);
                         }

--- a/src/gateway/meta_mcp/resources.rs
+++ b/src/gateway/meta_mcp/resources.rs
@@ -233,7 +233,7 @@ impl MetaMcp {
             .filter(|backend| !self.meta_route_isolation_refused(backend))
             .cloned()
             .collect();
-        let timeout = self.resources_fetch_timeout;
+        let timeout = self.prompts_resources_fetch_timeout;
         let results = join_all(backends.iter().map(|backend| async move {
             match tokio::time::timeout(timeout, backend.get_resources_shared()).await {
                 Ok(Ok(resources)) => Ok(resources.as_ref().clone()),

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -2452,3 +2452,207 @@ async fn global_meta_tool_reaches_an_admin_caller() {
          tool's business: {message}"
     );
 }
+
+// ============================================================================
+// Prompts/resources aggregation: parallel fan-out + per-backend timeout
+// ============================================================================
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A minimal streamable-http MCP backend for testing aggregation.
+///
+/// Responds to `initialize` and to a single configured method (`prompts/list`
+/// or `resources/list`) with a configurable payload and latency. Latency is
+/// applied before responding so a backend that "hangs" is one whose sleep
+/// exceeds the aggregation fetch timeout.
+struct MockMcpBackend {
+    name: String,
+    /// The method this backend answers (`prompts/list` or `resources/list`).
+    method: &'static str,
+    /// JSON array to return for `method`.
+    payload: serde_json::Value,
+    /// Sleep before responding.
+    delay: std::time::Duration,
+}
+
+async fn start_mock(backend: MockMcpBackend) -> String {
+    use axum::extract::State;
+    use axum::routing::post;
+    use axum::Router;
+    use axum::Json;
+
+    #[derive(Clone)]
+    struct S {
+        backend: std::sync::Arc<MockMcpBackend>,
+        seen: std::sync::Arc<AtomicUsize>,
+    }
+
+    let state = S {
+        backend: std::sync::Arc::new(backend),
+        seen: std::sync::Arc::new(AtomicUsize::new(0)),
+    };
+
+    async fn handle(
+        State(s): State<S>,
+        Json(req): Json<serde_json::Value>,
+    ) -> Json<serde_json::Value> {
+        let method = req["method"].as_str().unwrap_or("");
+        let resp = match method {
+            "initialize" => serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": req["id"],
+                "result": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {
+                        "tools": {"listChanged": true},
+                        "prompts": {"listChanged": true},
+                        "resources": {"listChanged": true},
+                    },
+                    "serverInfo": {"name": "mock", "version": "0.1.0"},
+                }
+            }),
+            m if m == s.backend.method => {
+                s.seen.fetch_add(1, Ordering::SeqCst);
+                if !s.backend.delay.is_zero() {
+                    tokio::time::sleep(s.backend.delay).await;
+                }
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req["id"],
+                    "result": { "prompts": s.backend.payload, "resources": s.backend.payload },
+                })
+            }
+            _ => serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": req["id"],
+                "error": { "code": -32601, "message": "Method not found" },
+            }),
+        };
+        Json(resp)
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new().route("/mcp", post(handle)).with_state(state);
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}/mcp")
+}
+
+/// Build a `MetaMcp` whose only backend is a mock at `url`, with a short
+/// aggregation timeout so tests run fast.
+fn meta_with_backend(url: &str, timeout: Duration) -> MetaMcp {
+    use crate::backend::Backend;
+    use crate::config::{BackendConfig, TransportConfig};
+
+    let config = BackendConfig {
+        description: String::new(),
+        enabled: true,
+        transport: TransportConfig::Http {
+            http_url: url.to_string(),
+            streamable_http: true,
+            protocol_version: None,
+        },
+        stop_when_idle_for: None,
+        timeout: Duration::from_secs(5),
+        ..BackendConfig::default()
+    };
+    let backend = Arc::new(Backend::new(
+        "mock",
+        config,
+        &crate::config::FailsafeConfig::default(),
+        Duration::from_secs(60),
+    ));
+    let registry = Arc::new(BackendRegistry::new());
+    let _ = registry.register(backend);
+
+    MetaMcp::new(registry)
+        .with_prompts_fetch_timeout(timeout)
+        .with_resources_fetch_timeout(timeout)
+}
+
+#[tokio::test]
+async fn prompts_list_includes_backend_prompts() {
+    let url = start_mock(MockMcpBackend {
+        name: "mock".to_string(),
+        method: "prompts/list",
+        payload: serde_json::json!([{ "name": "greet", "description": "say hi" }]),
+        delay: Duration::ZERO,
+    })
+    .await;
+    let meta = meta_with_backend(&url, Duration::from_secs(5));
+
+    let resp = meta.handle_prompts_list(RequestId::Number(1), None).await;
+    let prompts = resp.result.unwrap()["prompts"].as_array().unwrap().clone();
+    let names: Vec<&str> = prompts.iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"gateway/gateway-discover"), "meta prompts kept");
+    assert!(names.contains(&"mock/greet"), "backend prompt namespaced");
+}
+
+#[tokio::test]
+async fn prompts_list_skips_hung_backend_within_timeout() {
+    let url = start_mock(MockMcpBackend {
+        name: "mock".to_string(),
+        method: "prompts/list",
+        payload: serde_json::json!([]),
+        delay: Duration::from_secs(60), // far beyond the 100ms test timeout
+    })
+    .await;
+    let meta = meta_with_backend(&url, Duration::from_millis(100));
+
+    let start = std::time::Instant::now();
+    let resp = meta.handle_prompts_list(RequestId::Number(1), None).await;
+    let elapsed = start.elapsed();
+
+    assert!(resp.error.is_none(), "list still succeeds: {:?}", resp.error);
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "must skip hung backend quickly, took {:?}",
+        elapsed
+    );
+    // Only the gateway meta-prompts remain.
+    let result = resp.result.unwrap();
+    let prompts = result["prompts"].as_array().unwrap();
+    assert_eq!(prompts.len(), 2);
+}
+
+#[tokio::test]
+async fn resources_list_skips_hung_backend_within_timeout() {
+    let url = start_mock(MockMcpBackend {
+        name: "mock".to_string(),
+        method: "resources/list",
+        payload: serde_json::json!([]),
+        delay: Duration::from_secs(60),
+    })
+    .await;
+    let meta = meta_with_backend(&url, Duration::from_millis(100));
+
+    let start = std::time::Instant::now();
+    let resp = meta.handle_resources_list(RequestId::Number(1), None).await;
+    let elapsed = start.elapsed();
+
+    assert!(resp.error.is_none(), "list still succeeds: {:?}", resp.error);
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "must skip hung backend quickly, took {:?}",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn resources_list_includes_backend_resources() {
+    let url = start_mock(MockMcpBackend {
+        name: "mock".to_string(),
+        method: "resources/list",
+        payload: serde_json::json!([{ "uri": "mock://a", "name": "A" }]),
+        delay: Duration::ZERO,
+    })
+    .await;
+    let meta = meta_with_backend(&url, Duration::from_secs(5));
+
+    let resp = meta.handle_resources_list(RequestId::Number(1), None).await;
+    let resources = resp.result.unwrap()["resources"].as_array().unwrap().clone();
+    let uris: Vec<&str> = resources.iter().map(|r| r["uri"].as_str().unwrap()).collect();
+    assert!(uris.contains(&"mock://a"), "backend resource included");
+}

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -2466,7 +2466,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// applied before responding so a backend that "hangs" is one whose sleep
 /// exceeds the aggregation fetch timeout.
 struct MockMcpBackend {
-    name: String,
     /// The method this backend answers (`prompts/list` or `resources/list`).
     method: &'static str,
     /// JSON array to return for `method`.
@@ -2476,10 +2475,10 @@ struct MockMcpBackend {
 }
 
 async fn start_mock(backend: MockMcpBackend) -> String {
+    use axum::Json;
+    use axum::Router;
     use axum::extract::State;
     use axum::routing::post;
-    use axum::Router;
-    use axum::Json;
 
     #[derive(Clone)]
     struct S {
@@ -2567,15 +2566,12 @@ fn meta_with_backend(url: &str, timeout: Duration) -> MetaMcp {
     let registry = Arc::new(BackendRegistry::new());
     let _ = registry.register(backend);
 
-    MetaMcp::new(registry)
-        .with_prompts_fetch_timeout(timeout)
-        .with_resources_fetch_timeout(timeout)
+    MetaMcp::new(registry).with_prompts_resources_fetch_timeout(timeout)
 }
 
 #[tokio::test]
 async fn prompts_list_includes_backend_prompts() {
     let url = start_mock(MockMcpBackend {
-        name: "mock".to_string(),
         method: "prompts/list",
         payload: serde_json::json!([{ "name": "greet", "description": "say hi" }]),
         delay: Duration::ZERO,
@@ -2585,15 +2581,20 @@ async fn prompts_list_includes_backend_prompts() {
 
     let resp = meta.handle_prompts_list(RequestId::Number(1), None).await;
     let prompts = resp.result.unwrap()["prompts"].as_array().unwrap().clone();
-    let names: Vec<&str> = prompts.iter().map(|p| p["name"].as_str().unwrap()).collect();
-    assert!(names.contains(&"gateway/gateway-discover"), "meta prompts kept");
+    let names: Vec<&str> = prompts
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"gateway/gateway-discover"),
+        "meta prompts kept"
+    );
     assert!(names.contains(&"mock/greet"), "backend prompt namespaced");
 }
 
 #[tokio::test]
 async fn prompts_list_skips_hung_backend_within_timeout() {
     let url = start_mock(MockMcpBackend {
-        name: "mock".to_string(),
         method: "prompts/list",
         payload: serde_json::json!([]),
         delay: Duration::from_secs(60), // far beyond the 100ms test timeout
@@ -2605,7 +2606,11 @@ async fn prompts_list_skips_hung_backend_within_timeout() {
     let resp = meta.handle_prompts_list(RequestId::Number(1), None).await;
     let elapsed = start.elapsed();
 
-    assert!(resp.error.is_none(), "list still succeeds: {:?}", resp.error);
+    assert!(
+        resp.error.is_none(),
+        "list still succeeds: {:?}",
+        resp.error
+    );
     assert!(
         elapsed < Duration::from_secs(10),
         "must skip hung backend quickly, took {:?}",
@@ -2620,7 +2625,6 @@ async fn prompts_list_skips_hung_backend_within_timeout() {
 #[tokio::test]
 async fn resources_list_skips_hung_backend_within_timeout() {
     let url = start_mock(MockMcpBackend {
-        name: "mock".to_string(),
         method: "resources/list",
         payload: serde_json::json!([]),
         delay: Duration::from_secs(60),
@@ -2632,7 +2636,11 @@ async fn resources_list_skips_hung_backend_within_timeout() {
     let resp = meta.handle_resources_list(RequestId::Number(1), None).await;
     let elapsed = start.elapsed();
 
-    assert!(resp.error.is_none(), "list still succeeds: {:?}", resp.error);
+    assert!(
+        resp.error.is_none(),
+        "list still succeeds: {:?}",
+        resp.error
+    );
     assert!(
         elapsed < Duration::from_secs(10),
         "must skip hung backend quickly, took {:?}",
@@ -2643,7 +2651,6 @@ async fn resources_list_skips_hung_backend_within_timeout() {
 #[tokio::test]
 async fn resources_list_includes_backend_resources() {
     let url = start_mock(MockMcpBackend {
-        name: "mock".to_string(),
         method: "resources/list",
         payload: serde_json::json!([{ "uri": "mock://a", "name": "A" }]),
         delay: Duration::ZERO,
@@ -2652,7 +2659,90 @@ async fn resources_list_includes_backend_resources() {
     let meta = meta_with_backend(&url, Duration::from_secs(5));
 
     let resp = meta.handle_resources_list(RequestId::Number(1), None).await;
-    let resources = resp.result.unwrap()["resources"].as_array().unwrap().clone();
-    let uris: Vec<&str> = resources.iter().map(|r| r["uri"].as_str().unwrap()).collect();
+    let resources = resp.result.unwrap()["resources"]
+        .as_array()
+        .unwrap()
+        .clone();
+    let uris: Vec<&str> = resources
+        .iter()
+        .map(|r| r["uri"].as_str().unwrap())
+        .collect();
     assert!(uris.contains(&"mock://a"), "backend resource included");
+}
+
+/// Fast + hung backends: the fast backend's prompts must be returned within a
+/// single aggregation timeout even though the hung backend never answers.
+#[tokio::test]
+async fn prompts_list_fast_backend_not_stalled_by_hung_one() {
+    let fast = start_mock(MockMcpBackend {
+        method: "prompts/list",
+        payload: serde_json::json!([{ "name": "quick", "description": "fast" }]),
+        delay: Duration::ZERO,
+    })
+    .await;
+    let hung = start_mock(MockMcpBackend {
+        method: "prompts/list",
+        payload: serde_json::json!([]),
+        delay: Duration::from_secs(60),
+    })
+    .await;
+
+    use crate::backend::Backend;
+    use crate::config::{BackendConfig, TransportConfig};
+
+    let registry = Arc::new(BackendRegistry::new());
+    for (name, url) in [("fast", fast), ("hung", hung)] {
+        let config = BackendConfig {
+            description: String::new(),
+            enabled: true,
+            transport: TransportConfig::Http {
+                http_url: url,
+                streamable_http: true,
+                protocol_version: None,
+            },
+            stop_when_idle_for: None,
+            timeout: Duration::from_secs(5),
+            ..BackendConfig::default()
+        };
+        let backend = Arc::new(Backend::new(
+            name,
+            config,
+            &crate::config::FailsafeConfig::default(),
+            Duration::from_secs(60),
+        ));
+        let _ = registry.register(backend);
+    }
+
+    let meta = MetaMcp::new(registry).with_prompts_resources_fetch_timeout(Duration::from_secs(1));
+
+    let start = std::time::Instant::now();
+    let resp = meta.handle_prompts_list(RequestId::Number(1), None).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        resp.error.is_none(),
+        "list still succeeds: {:?}",
+        resp.error
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "fast result must return within a single timeout, took {:?}",
+        elapsed
+    );
+    // Both the gateway meta-prompts AND the fast backend's prompt are present;
+    // the hung backend was skipped within the bound.
+    let result = resp.result.unwrap();
+    let prompts = result["prompts"].as_array().unwrap();
+    let names: Vec<&str> = prompts
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"gateway/gateway-discover"),
+        "meta prompts kept"
+    );
+    assert!(
+        names.contains(&"fast/quick"),
+        "fast backend's prompt returned"
+    );
 }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -515,6 +515,7 @@ impl Gateway {
         .with_projection_mode(self.config.meta_mcp.projection_mode)
         .with_secret_injector(secret_injector)
         .with_surfaced_tools(self.config.meta_mcp.surfaced_tools.clone())
+        .with_prompts_resources_fetch_timeout(self.config.meta_mcp.prompts_resources_fetch_timeout)
         .with_trusted_identity_headers(
             self.config
                 .security

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -11,7 +11,9 @@ pub use self::stdio::StdioTransport;
 pub use self::websocket::McpFrame;
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use serde_json::Value;
+use tokio::sync::oneshot;
 
 use crate::{Result, protocol::JsonRpcResponse};
 
@@ -93,4 +95,42 @@ pub trait Transport: Send + Sync {
 
     /// Close the transport
     async fn close(&self) -> Result<()>;
+}
+
+/// RAII removal of a `pending` entry when its request future is dropped.
+///
+/// [`Transport::request`] implementations register a response `oneshot` sender
+/// in their `pending` map before writing the request, then await the response.
+/// The map entry is normally removed by the reader task when it routes the
+/// matching response, or by the transport's own request timeout. Neither fires
+/// when an OUTER timeout or task abort drops the in-flight request future
+/// first — the entry would otherwise leak in `pending` for the life of the
+/// transport, and a late response would find no matching sender.
+///
+/// The entry is meant to live exactly as long as the request does, so the guard
+/// removes it on drop. On the success path the reader has already removed the
+/// entry, making the removal a harmless no-op.
+pub(crate) struct PendingRequestGuard<'a> {
+    pending: &'a DashMap<String, oneshot::Sender<JsonRpcResponse>>,
+    key: String,
+}
+
+impl<'a> PendingRequestGuard<'a> {
+    /// Wrap a `pending` map entry so it is removed when the guard drops.
+    #[must_use]
+    pub(crate) fn new(
+        pending: &'a DashMap<String, oneshot::Sender<JsonRpcResponse>>,
+        key: &str,
+    ) -> Self {
+        Self {
+            pending,
+            key: key.to_string(),
+        }
+    }
+}
+
+impl Drop for PendingRequestGuard<'_> {
+    fn drop(&mut self) {
+        self.pending.remove(&self.key);
+    }
 }

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -22,7 +22,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::{Mutex, oneshot};
 use tracing::{debug, error, info, warn};
 
-use super::Transport;
+use super::{PendingRequestGuard, Transport};
 use crate::protocol::{
     JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
     is_version_mismatch_error, negotiate_best_version, parse_supported_versions_from_error,
@@ -490,20 +490,21 @@ impl Transport for StdioTransport {
         let message = serde_json::to_string(&request)?;
         let (tx, rx) = oneshot::channel();
         self.pending.insert(id.to_string(), tx);
+        // Removing the entry is the guard's job now: on the success path the
+        // reader task has already routed the response, on an internal timeout
+        // this block removes it explicitly, and on CANCELLATION (an outer
+        // timeout or task abort dropping this future mid-await) the guard's
+        // Drop removes it — without it a stranded entry would leak here for
+        // the transport's lifetime.
+        let _cleanup = PendingRequestGuard::new(&self.pending, &id.to_string());
 
-        if let Err(e) = self.write_message(&message).await {
-            self.pending.remove(&id.to_string());
-            return Err(e);
-        }
+        self.write_message(&message).await?;
 
         // Wait for response with timeout
         match tokio::time::timeout(self.request_timeout, rx).await {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(_)) => Err(Error::Transport("Response channel closed".to_string())),
-            Err(_) => {
-                self.pending.remove(&id.to_string());
-                Err(Error::BackendTimeout("Request timed out".to_string()))
-            }
+            Err(_) => Err(Error::BackendTimeout("Request timed out".to_string())),
         }
     }
 

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -569,6 +569,22 @@ mod tests {
     #[cfg(unix)]
     const EXPLICIT_BACKEND_ENV: &str = "MCP_GATEWAY_TEST_EXPLICIT_BACKEND";
 
+    #[test]
+    fn pending_request_guard_removes_entry_on_drop() {
+        let pending: dashmap::DashMap<String, oneshot::Sender<crate::protocol::JsonRpcResponse>> =
+            dashmap::DashMap::new();
+        let (tx, _rx) = oneshot::channel::<crate::protocol::JsonRpcResponse>();
+        pending.insert("7".to_string(), tx);
+        assert_eq!(pending.len(), 1);
+
+        {
+            let _guard = PendingRequestGuard::new(&pending, "7");
+            assert_eq!(pending.len(), 1, "entry present while guard alive");
+        }
+
+        assert!(pending.is_empty(), "guard drop removes the entry");
+    }
+
     fn make_transport(cmd: &str) -> Arc<StdioTransport> {
         StdioTransport::new(
             cmd,
@@ -740,6 +756,77 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Transport(message)) if message == "Not connected"));
         assert!(t.pending.is_empty());
+    }
+
+    /// Dropping an in-flight `request()` future must not strand its `pending`
+    /// entry. This is the exact cancellation path the aggregation timeout in
+    /// `meta_mcp` exercises: an outer `tokio::time::timeout` (or a task abort)
+    /// drops the request future BEFORE the transport's own request timeout
+    /// fires, so neither the reader task nor the internal timeout removes the
+    /// entry — the RAII `PendingRequestGuard` must. A real child that answers
+    /// `initialize` but never answers `prompts/list` holds the request open so
+    /// the drop happens mid-await.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelled_request_does_not_strand_pending_entry() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let server = workspace.path().join("server.sh");
+        std::fs::write(
+            &server,
+            r#"while IFS= read -r request; do
+    case "$request" in
+        *'"method":"initialize"'*)
+            printf '%s
+' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25"}}'
+            ;;
+        # deliberately answer NOTHING for prompts/list — holds the request open
+    esac
+done
+"#,
+        )
+        .expect("write server");
+
+        let transport = StdioTransport::new(
+            "sh server.sh",
+            HashMap::new(),
+            Some(workspace.path().to_string_lossy().into_owned()),
+            std::time::Duration::from_secs(30), // far beyond the test's abort
+            None,
+        );
+        transport.start().await.expect("start");
+
+        // Run the request on its own task so aborting it is a real cancellation
+        // (an outer `tokio::time::timeout` / task abort dropping the future
+        // mid-await) rather than a test-only `drop` of a pinned future.
+        let request_transport = transport.clone();
+        let request_task =
+            tokio::spawn(async move { request_transport.request("prompts/list", None).await });
+
+        // Wait for the request to register in `pending` — the write has happened
+        // and the child is holding the request open unanswered.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !transport.pending.is_empty() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "precondition: request registered in pending while the child holds it open"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Abort the task mid-await. The child never answers, so the internal 30s
+        // timeout has not fired — the guard's Drop is what must remove the entry.
+        request_task.abort();
+        let _ = request_task.await; // reaps the handle once the task is dropped
+
+        assert!(
+            transport.pending.is_empty(),
+            "a cancelled in-flight request must not strand its pending entry"
+        );
+
+        transport.close().await.expect("close");
     }
 
     #[test]

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -36,7 +36,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
-use super::Transport;
+use super::{PendingRequestGuard, Transport};
 use crate::protocol::{
     JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
 };
@@ -509,24 +509,22 @@ impl Transport for WebSocketTransport {
 
         let (tx, rx) = oneshot::channel();
         self.inner.pending.insert(id.to_string(), tx);
+        // See StdioTransport::request: removing the entry is the guard's job
+        // so a request future dropped by an OUTER timeout or task abort does
+        // not strand its `pending` entry.
+        let _cleanup = PendingRequestGuard::new(&self.inner.pending, &id.to_string());
 
         let msg = McpFrame::Request(request).to_ws_message()?;
-        if let Err(e) = self.send_message(msg).await {
-            self.inner.pending.remove(&id.to_string());
-            return Err(e);
-        }
+        self.send_message(msg).await?;
 
         match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(_)) => Err(Error::Transport(
                 "WebSocket response channel closed".to_string(),
             )),
-            Err(_) => {
-                self.inner.pending.remove(&id.to_string());
-                Err(Error::BackendTimeout(
-                    "WebSocket request timed out".to_string(),
-                ))
-            }
+            Err(_) => Err(Error::BackendTimeout(
+                "WebSocket request timed out".to_string(),
+            )),
         }
     }
 


### PR DESCRIPTION
## Summary

- `prompts/list` and `resources/list` aggregated every backend's prompts/resources by **sequentially awaiting each backend** (`handle_prompts_list` in `src/gateway/meta_mcp/protocol.rs`, `handle_resources_list` in `src/gateway/meta_mcp/resources.rs`).
- On a gateway with 50+ backends, a single slow or hung backend delayed the whole request by its full transport timeout. A client issues `prompts/list` + `resources/list` on every (re)connect; with one slow backend those blew past the client connect timeout, the client aborted, and the gateway's late response surfaced as `Received a response for an unknown message ID`, causing a reconnect loop.
- `tools/list` is unaffected because it is served from cached counts/surfaced tools and never fans out to backends synchronously.
- Fetch each backend's prompts/resources **in parallel** via `futures::future::join_all` (already used in `backend/registry.rs`), so total latency is bounded by the slowest backend rather than the sum of all backends.
- **Bound each backend fetch with `tokio::time::timeout`** (already used across the codebase) so a hung backend is skipped after 10s instead of blocking the whole request for its full transport timeout (often 120s). This is the piece that actually fixes the hang: a single dead backend no longer stalls every reconnect.
- Backends that fail or time out are logged and skipped, preserving existing behavior.

## Real-world validation

Deployed the patched binary against a live gateway with 56 backends. Measured `prompts/list` + `resources/list` through the meta-MCP endpoint:

| scenario | `prompts/list` | `resources/list` |
|---|---|---|
| upstream binary, serial fan-out | **120s+ timeout** | **120s+ timeout** |
| patched (parallel + timeout), one backend disabled | **~2.8s** | **~1.4s** |

The one disabled backend was hung (health probe timed out repeatedly). This is the exact failure the timeout addresses: without the timeout, that hung backend stalls every `prompts/list`/`resources/list` for its full 120s transport timeout; with it, the request completes in seconds.

## Validation

- `cargo check` clean
- `cargo clippy --all-features -- -D warnings` clean
- `cargo test --lib gateway::meta_mcp` — 390 passed
- `cargo test --lib gateway::meta_mcp::protocol` — 12 passed
- `cargo test --lib gateway::meta_mcp::resources` — 9 passed

## Declared gap

A backend whose fetch exceeds the 10s per-backend bound is skipped for that request, so its prompts/resources are absent from that response until it recovers. This is the correct trade-off: availability of the whole list over completeness. A gateway-level cache (mirroring the per-backend `CachedMetadata`) could avoid re-touching a slow backend entirely on warm reconnects; this PR does not add one, staying with the existing per-backend cache convention.

## First contribution

Thanks for a great project :) Finally found a great an aggregator that works for my self hosted stuff!