### PR TITLE
fix(MIK-7084): glob L0 gets a score and drops disabled tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`gateway_search` returns L0 by default** (MIK-7084): tool name, one-line purpose, and score. `detail=l1` adds signature, when-to-use, and required params; `detail=l2` returns the full `input_schema`. `include_schema=true` still maps to L2 and is deprecated, not removed. Ranking diagnostics (`ranking` reasons and signals) are omitted unless `explain=true`. `gateway_search_tools` also omits `ranking` unless `explain=true`.
+
 ## [3.5.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The gateway exposes 14 tools minimum, 16 in the README benchmark scenario, 17 wh
 
 ### Code Mode: two tools instead of the meta-tool set
 
-Setting `code_mode.enabled: true` makes `tools/list` return exactly two tools, `gateway_search` and `gateway_execute`, instead of the meta-tool set. Everything else is reached through those two. Tools named in `meta_mcp.surfaced_tools` are not appended in this mode, so the count stays at two however many backends are connected. Code Mode is off by default.
+Setting `code_mode.enabled: true` makes `tools/list` return exactly two tools, `gateway_search` and `gateway_execute`, instead of the meta-tool set. Everything else is reached through those two. Tools named in `meta_mcp.surfaced_tools` are not appended in this mode, so the count stays at two however many backends are connected. Code Mode is off by default. `gateway_search` returns L0 by default (tool name, one-line purpose, score). Pass `detail=l1` or `detail=l2` for more, or `explain=true` for ranking diagnostics. `include_schema=true` is deprecated and maps to L2.
 
 ```yaml
 code_mode:

--- a/docs/adaptive_ranking.md
+++ b/docs/adaptive_ranking.md
@@ -22,13 +22,14 @@ with coarse metadata:
 
 Unsafe, high-risk, policy-denied, unauthorized, unhealthy, and very low-trust
 tools are suppressed before relevance scoring can promote them. Included tools
-carry a `ranking` payload with deterministic reasons and numeric signals so
-users can inspect why a tool was included or downgraded.
+carry a `score`. The `ranking` payload (deterministic reasons and numeric
+signals) is omitted unless the caller sets `explain: true` — scoring
+diagnostics are a debug surface, not a default response field (MIK-7084).
 
 ## Signal Schema
 
-Every included result exposes the coarse `ranking.signals` object. Scores are
-normalized to `0.0..=1.0` unless noted.
+When `explain: true`, every included result exposes the coarse
+`ranking.signals` object. Scores are normalized to `0.0..=1.0` unless noted.
 
 | Signal | Meaning | Default |
 |--------|---------|---------|

--- a/docs/design/mik-7084-search-tier-disclosure.md
+++ b/docs/design/mik-7084-search-tier-disclosure.md
@@ -1,0 +1,25 @@
+# MIK-7084 — tiered `gateway_search` disclosure
+
+FOR: cut unusable ranking telemetry and stop paying invocation-detail
+cost at the selection step. OUT: ranking algorithm, `gateway_search_tools`
+L0/L1/L2 ladder, OpenViking source (concept only).
+
+Ticket ACs `MIK.GW.T1`–`T6` are the spec. Decisions the ticket did not
+name, recorded here because they change the wire:
+
+| decision | choice | rejected |
+|---|---|---|
+| `detail` vs `include_schema` both set | `detail` wins | OR-ing `include_schema=true` up to L2 (surprising when the caller named a tier) |
+| omitted `include_schema` | L0 | keep old default `true` (fights T1) |
+| explicit `include_schema=true` | L2 | ignore it |
+| explicit `include_schema=false` | L0 | a phantom "L1-without-schema" |
+| L0 fields | `tool`, one-line `description`, `score` | `status`, `ranking`, schema |
+| L1 extras | `when_to_use`, `required`, `signature`; `status` if present | full `input_schema` |
+| `explain` default | false; T3 also on `gateway_search_tools` | leave the blob on the older meta-tool |
+| glob path | no `score` (ranker skipped, as today) | fake `1.0` |
+| one-line purpose | first sentence, keywords suffix stripped, max 120 chars | raw 500-char description |
+| `when_to_use` | first paragraph, max 280 chars | copy the full description |
+
+T3 fail-fast (lean `include_schema=false` payload, limit 2): ranking blob
+is ~50–76% of the response depending on description length. Not far
+below the ticket's ~60%. Ladder proceeds.

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1384,3 +1384,7 @@ mod tests;
 #[cfg(test)]
 #[path = "authz_tests.rs"]
 mod authz_tests;
+
+#[cfg(test)]
+#[path = "search_disclosure_e2e.rs"]
+mod search_disclosure_e2e;

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -410,11 +410,9 @@ impl MetaMcp {
             matches = ranked_results_to_code_mode_json(ranked, disclosure.explain, &matches);
         }
 
-        matches.truncate(limit);
-        matches = matches
-            .into_iter()
-            .map(|m| crate::gateway::search_disclosure::project_code_mode_match(m, disclosure))
-            .collect();
+        matches = crate::gateway::search_disclosure::finalize_search_matches(
+            matches, disclosure, use_glob, limit,
+        );
 
         let suggestions = if matches.is_empty() && !use_glob {
             build_suggestions(&query, &all_tags)

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -34,7 +34,6 @@ use super::support::{
 
 #[derive(Clone, Copy)]
 struct CodeModeSearchOptions {
-    include_schema: bool,
     use_glob: bool,
 }
 
@@ -208,8 +207,7 @@ impl MetaMcp {
                 }
                 collect_tool_tags_for_code_mode(&tool, all_tags);
                 if Self::code_mode_tool_matches(&cap.name, &tool, query, options.use_glob) {
-                    let mut entry =
-                        build_code_mode_match_json(&cap.name, &tool, options.include_schema);
+                    let mut entry = build_code_mode_match_json(&cap.name, &tool, true);
                     if cap_killed {
                         entry["status"] = json!("disabled");
                     }
@@ -260,11 +258,7 @@ impl MetaMcp {
                 }
                 for tool in enriched {
                     if Self::code_mode_tool_matches(&backend.name, &tool, query, options.use_glob) {
-                        let mut entry = build_code_mode_match_json(
-                            &backend.name,
-                            &tool,
-                            options.include_schema,
-                        );
+                        let mut entry = build_code_mode_match_json(&backend.name, &tool, true);
                         if backend_killed {
                             entry["status"] = json!("disabled");
                         }
@@ -367,7 +361,9 @@ impl MetaMcp {
     /// Behaves like `search_tools` but:
     /// - Supports glob patterns (`*`, `?`) on tool names in addition to keyword matching.
     /// - Returns tool references in `"server:tool_name"` format (for use with `gateway_execute`).
-    /// - Optionally includes the full `input_schema` for each result (`include_schema`, default `true`).
+    /// - Defaults to L0 (name, one-line purpose, score). `detail=l1|l2` or
+    ///   deprecated `include_schema=true` (maps to L2) selects more. Ranking
+    ///   diagnostics are omitted unless `explain` is true.
     pub(super) async fn code_mode_search(
         &self,
         args: &Value,
@@ -376,14 +372,11 @@ impl MetaMcp {
         let raw_query = extract_required_str(args, "query")?;
         let query = raw_query.to_lowercase();
         let limit = extract_search_limit(args);
-        let include_schema = extract_bool_or(args, "include_schema", true);
+        let disclosure = crate::gateway::search_disclosure::resolve_search_disclosure(args)?;
         let profile = self.active_profile(session_id);
         let use_glob = is_glob_pattern(&query);
         let current_state = self.current_search_state(session_id);
-        let options = CodeModeSearchOptions {
-            include_schema,
-            use_glob,
-        };
+        let options = CodeModeSearchOptions { use_glob };
 
         let mut matches: Vec<Value> = Vec::new();
         let mut all_tags: Vec<String> = Vec::new();
@@ -414,10 +407,14 @@ impl MetaMcp {
                 .filter_map(json_to_code_mode_search_result)
                 .collect();
             let ranked = ranker.rank(search_results, &query);
-            matches = ranked_results_to_code_mode_json(ranked, include_schema, &matches);
+            matches = ranked_results_to_code_mode_json(ranked, disclosure.explain, &matches);
         }
 
         matches.truncate(limit);
+        matches = matches
+            .into_iter()
+            .map(|m| crate::gateway::search_disclosure::project_code_mode_match(m, disclosure))
+            .collect();
 
         let suggestions = if matches.is_empty() && !use_glob {
             build_suggestions(&query, &all_tags)
@@ -729,6 +726,7 @@ impl MetaMcp {
     ) -> Result<Value> {
         let query = extract_required_str(args, "query")?.to_lowercase();
         let limit = extract_search_limit(args);
+        let explain = extract_bool_or(args, "explain", false);
         let profile = self.active_profile(session_id);
         let search_start = std::time::Instant::now();
         let current_state = self.current_search_state(session_id);
@@ -762,7 +760,7 @@ impl MetaMcp {
         if let Some(ref ranker) = self.ranker {
             let search_results: Vec<_> = matches.iter().filter_map(json_to_search_result).collect();
             let ranked = ranker.rank(search_results, &query);
-            matches = ranked_results_to_json(ranked);
+            matches = ranked_results_to_json(ranked, explain);
         }
 
         // Truncate to requested limit AFTER ranking

--- a/src/gateway/meta_mcp/search_disclosure_e2e.rs
+++ b/src/gateway/meta_mcp/search_disclosure_e2e.rs
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! End-to-end `gateway_search` disclosure tests (MIK-7084).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use crate::backend::Backend;
+use crate::backend::BackendRegistry;
+use crate::config::{BackendConfig, FailsafeConfig};
+use crate::gateway::meta_mcp::MetaMcp;
+use crate::protocol::{JsonRpcResponse, RequestId, Tool, ToolsListResult};
+use crate::ranking::SearchRanker;
+use crate::transport::Transport;
+
+struct SearchTestTransport {
+    response: JsonRpcResponse,
+}
+
+#[async_trait::async_trait]
+impl Transport for SearchTestTransport {
+    async fn request(
+        &self,
+        method: &str,
+        _params: Option<Value>,
+    ) -> crate::Result<JsonRpcResponse> {
+        assert_eq!(method, "tools/list");
+        Ok(self.response.clone())
+    }
+
+    async fn notify(&self, _method: &str, _params: Option<Value>) -> crate::Result<()> {
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+fn tool(name: &str, description: &str, schema: Value) -> Tool {
+    Tool {
+        name: name.to_string(),
+        title: None,
+        description: Some(description.to_string()),
+        input_schema: schema,
+        output_schema: None,
+        annotations: None,
+        role: None,
+        projection: None,
+    }
+}
+
+async fn backend_with_tools(name: &str, tools: Vec<Tool>) -> Arc<Backend> {
+    let backend = Arc::new(Backend::new(
+        name,
+        BackendConfig::default(),
+        &FailsafeConfig::default(),
+        Duration::from_secs(300),
+    ));
+    let response = JsonRpcResponse::success_serialized(
+        RequestId::Number(1),
+        ToolsListResult {
+            tools,
+            next_cursor: None,
+        },
+    );
+    let transport: Arc<dyn Transport> = Arc::new(SearchTestTransport { response });
+    backend.set_transport_for_test(transport);
+    backend.get_tools_shared().await.unwrap();
+    backend
+}
+
+fn schema(required: &[&str], properties: &Value) -> Value {
+    json!({"type": "object", "properties": properties, "required": required})
+}
+
+fn linear_tools() -> Vec<Tool> {
+    vec![
+        tool(
+            "create_issue",
+            "Create a Linear issue in a team. Use when filing work. [keywords: linear, issue]",
+            schema(
+                &["title", "team"],
+                &json!({
+                    "title": {"type": "string"},
+                    "team": {"type": "string"},
+                    "description": {"type": "string"},
+                    "priority": {"type": "integer"}
+                }),
+            ),
+        ),
+        tool(
+            "list_issues",
+            "List Linear issues in a team. [keywords: linear, list]",
+            schema(&["team"], &json!({"team": {"type": "string"}})),
+        ),
+    ]
+}
+
+fn catalog_servers() -> Vec<(&'static str, Vec<Tool>)> {
+    vec![
+        ("linear", linear_tools()),
+        (
+            "brave",
+            vec![tool(
+                "web_search",
+                "Search the public web. Prefer this for current events. [keywords: search, web]",
+                schema(
+                    &["query"],
+                    &json!({"query": {"type": "string"}, "count": {"type": "integer"}}),
+                ),
+            )],
+        ),
+        (
+            "gmail",
+            vec![tool(
+                "send_email",
+                "Send an email from the connected Gmail account. [keywords: email, send]",
+                schema(
+                    &["to", "subject", "body"],
+                    &json!({
+                        "to": {"type": "string"},
+                        "subject": {"type": "string"},
+                        "body": {"type": "string"}
+                    }),
+                ),
+            )],
+        ),
+        (
+            "github",
+            vec![tool(
+                "create_pull_request",
+                "Open a GitHub pull request. Use after pushing a branch. [keywords: github, pr]",
+                schema(
+                    &["owner", "repo", "title", "head", "base"],
+                    &json!({
+                        "owner": {"type": "string"},
+                        "repo": {"type": "string"},
+                        "title": {"type": "string"},
+                        "head": {"type": "string"},
+                        "base": {"type": "string"}
+                    }),
+                ),
+            )],
+        ),
+        (
+            "google_calendar",
+            vec![tool(
+                "list_events",
+                "List events on a Google Calendar. [keywords: calendar, events]",
+                schema(
+                    &["calendarId"],
+                    &json!({
+                        "calendarId": {"type": "string"},
+                        "timeMin": {"type": "string"}
+                    }),
+                ),
+            )],
+        ),
+    ]
+}
+
+async fn catalog_meta() -> MetaMcp {
+    let registry = Arc::new(BackendRegistry::new());
+    for (name, tools) in catalog_servers() {
+        let _ = registry.register(backend_with_tools(name, tools).await);
+    }
+    MetaMcp::with_features(
+        registry,
+        None,
+        None,
+        Some(Arc::new(SearchRanker::new())),
+        Duration::from_secs(60),
+    )
+    .with_code_mode(true)
+}
+
+const T5_QUERIES: [&str; 5] = [
+    "linear create issue",
+    "web search",
+    "send email",
+    "github pull request",
+    "calendar events",
+];
+
+#[tokio::test]
+async fn mik_gw_t3_gateway_search_omits_ranking_unless_explain() {
+    let meta = catalog_meta().await;
+    let hidden = meta
+        .code_mode_search(&json!({ "query": "linear create issue", "limit": 2 }), None)
+        .await
+        .unwrap();
+    let shown = meta
+        .code_mode_search(
+            &json!({ "query": "linear create issue", "limit": 2, "explain": true }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(hidden["matches"][0].get("ranking").is_none());
+    assert!(shown["matches"][0].get("ranking").is_some());
+    assert!(shown["matches"][0]["ranking"]["reasons"].is_array());
+}
+
+#[tokio::test]
+async fn mik_gw_t1_default_is_l0() {
+    let meta = catalog_meta().await;
+    let result = meta
+        .code_mode_search(&json!({ "query": "linear create issue", "limit": 1 }), None)
+        .await
+        .unwrap();
+    let hit = &result["matches"][0];
+    let mut keys: Vec<_> = hit.as_object().unwrap().keys().cloned().collect();
+    keys.sort();
+    assert_eq!(keys, ["description", "score", "tool"]);
+    assert!(
+        !hit["description"].as_str().unwrap().contains("[keywords:"),
+        "L0 purpose must not carry keyword tags: {}",
+        hit["description"]
+    );
+}
+
+#[tokio::test]
+async fn mik_gw_t2_detail_and_include_schema_select_tiers() {
+    let meta = catalog_meta().await;
+    let l1 = meta
+        .code_mode_search(
+            &json!({ "query": "linear create issue", "limit": 1, "detail": "l1" }),
+            None,
+        )
+        .await
+        .unwrap();
+    let l1_hit = &l1["matches"][0];
+    assert!(l1_hit.get("input_schema").is_none());
+    assert!(l1_hit.get("signature").is_some());
+    assert!(l1_hit.get("required").is_some());
+    assert!(l1_hit.get("when_to_use").is_some());
+
+    let via_legacy = meta
+        .code_mode_search(
+            &json!({ "query": "linear create issue", "limit": 1, "include_schema": true }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(via_legacy["matches"][0].get("input_schema").is_some());
+
+    let l2 = meta
+        .code_mode_search(
+            &json!({ "query": "linear create issue", "limit": 1, "detail": "l2" }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(l2["matches"][0].get("input_schema").is_some());
+}
+
+#[tokio::test]
+async fn mik_gw_t5_l0_top_tool_matches_legacy_full_for_five_queries() {
+    let meta = catalog_meta().await;
+    for query in T5_QUERIES {
+        let l0 = meta
+            .code_mode_search(&json!({ "query": query, "limit": 3 }), None)
+            .await
+            .unwrap();
+        let legacy = meta
+            .code_mode_search(
+                &json!({
+                    "query": query,
+                    "limit": 3,
+                    "detail": "l2",
+                    "explain": true
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+        let l0_top = l0["matches"][0]["tool"].as_str().unwrap();
+        let legacy_top = legacy["matches"][0]["tool"].as_str().unwrap();
+        assert_eq!(
+            l0_top, legacy_top,
+            "{query}: L0 picked {l0_top}, legacy picked {legacy_top}"
+        );
+        let l0_names: Vec<_> = l0["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["tool"].as_str().unwrap().to_string())
+            .collect();
+        let legacy_names: Vec<_> = legacy["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["tool"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(l0_names, legacy_names, "{query}: order diverged");
+    }
+}
+
+#[tokio::test]
+async fn mik_gw_t2_invalid_detail_fails_fast() {
+    let meta = catalog_meta().await;
+    let err = meta
+        .code_mode_search(&json!({ "query": "linear", "detail": "full" }), None)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("l0|l1|l2"), "{err}");
+}

--- a/src/gateway/meta_mcp/support.rs
+++ b/src/gateway/meta_mcp/support.rs
@@ -114,7 +114,7 @@ pub(super) fn json_to_code_mode_search_result(v: &Value) -> Option<crate::rankin
 /// match JSON by looking up the original entry by its `"tool"` field.
 pub(super) fn ranked_results_to_code_mode_json(
     ranked: Vec<crate::ranking::SearchResult>,
-    _include_schema: bool,
+    explain: bool,
     originals: &[Value],
 ) -> Vec<Value> {
     ranked
@@ -129,14 +129,12 @@ pub(super) fn ranked_results_to_code_mode_json(
                 .map(|mut value| {
                     if let Value::Object(ref mut map) = value {
                         map.insert("score".to_string(), json!(r.score));
-                        map.insert(
-                            "ranking".to_string(),
-                            json!({
-                                "included": r.explanation.included,
-                                "reasons": r.explanation.reasons,
-                                "signals": r.signals
-                            }),
-                        );
+                        if explain {
+                            map.insert(
+                                "ranking".to_string(),
+                                crate::gateway::search_disclosure::ranking_debug_object(&r),
+                            );
+                        }
                     }
                     value
                 })

--- a/src/gateway/meta_mcp_helpers.rs
+++ b/src/gateway/meta_mcp_helpers.rs
@@ -478,21 +478,26 @@ pub(crate) fn build_code_mode_match_json(server: &str, tool: &Tool, include_sche
 }
 
 /// Convert ranked `SearchResult` items to JSON.
-pub(crate) fn ranked_results_to_json(ranked: Vec<SearchResult>) -> Vec<Value> {
+///
+/// Ranking diagnostics are included only when `explain` is true (MIK-7084).
+pub(crate) fn ranked_results_to_json(ranked: Vec<SearchResult>, explain: bool) -> Vec<Value> {
     ranked
         .into_iter()
         .map(|r| {
-            json!({
+            let ranking =
+                explain.then(|| crate::gateway::search_disclosure::ranking_debug_object(&r));
+            let mut value = json!({
                 "server": r.server,
                 "tool": r.tool,
                 "description": r.description,
                 "score": r.score,
-                "ranking": {
-                    "included": r.explanation.included,
-                    "reasons": r.explanation.reasons,
-                    "signals": r.signals
-                }
-            })
+            });
+            if let Some(ranking) = ranking
+                && let Value::Object(ref mut map) = value
+            {
+                map.insert("ranking".to_string(), ranking);
+            }
+            value
         })
         .collect()
 }

--- a/src/gateway/meta_mcp_helpers_chain_tests.rs
+++ b/src/gateway/meta_mcp_helpers_chain_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Mikko Parkkola
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 use super::*;
+use serde_json::json;
 
 // Helper to build a Tool for testing
 fn make_tool(name: &str, description: Option<&str>) -> Tool {
@@ -495,16 +496,36 @@ fn build_code_mode_search_tool_has_limit_parameter() {
 fn build_code_mode_search_tool_has_include_schema_parameter() {
     // GIVEN: code mode search tool definition
     // WHEN: inspecting the input schema
-    // THEN: 'include_schema' boolean parameter with default true is present
+    // THEN: deprecated include_schema is still present, without a true default
     let tool = build_code_mode_search_tool();
     assert_eq!(
         tool.input_schema["properties"]["include_schema"]["type"],
         "boolean"
     );
-    assert_eq!(
-        tool.input_schema["properties"]["include_schema"]["default"],
-        true
+    assert!(
+        tool.input_schema["properties"]["include_schema"]
+            .get("default")
+            .is_none()
     );
+    let desc = tool.input_schema["properties"]["include_schema"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(desc.to_ascii_lowercase().contains("deprecated"), "{desc}");
+}
+
+#[test]
+fn build_code_mode_search_tool_documents_tier_ladder() {
+    let tool = build_code_mode_search_tool();
+    let desc = tool.description.as_deref().unwrap();
+    for needle in ["L0", "l1", "l2", "explain"] {
+        assert!(desc.contains(needle), "missing {needle} in: {desc}");
+    }
+    assert_eq!(
+        tool.input_schema["properties"]["detail"]["enum"],
+        json!(["l0", "l1", "l2"])
+    );
+    assert_eq!(tool.input_schema["properties"]["detail"]["default"], "l0");
+    assert_eq!(tool.input_schema["properties"]["explain"]["default"], false);
 }
 
 #[test]

--- a/src/gateway/meta_mcp_helpers_tests.rs
+++ b/src/gateway/meta_mcp_helpers_tests.rs
@@ -724,7 +724,7 @@ fn ranked_results_to_json_converts_correctly() {
             ..SearchResult::new("s2", "t2", "desc2")
         },
     ];
-    let json_results = ranked_results_to_json(results);
+    let json_results = ranked_results_to_json(results, true);
     assert_eq!(json_results.len(), 2);
     assert_eq!(json_results[0]["server"], "s1");
     assert_eq!(json_results[0]["score"], 0.95);
@@ -733,7 +733,23 @@ fn ranked_results_to_json_converts_correctly() {
 }
 
 #[test]
+fn ranked_results_to_json_omits_ranking_unless_explain() {
+    let results = vec![SearchResult {
+        server: "s1".to_string(),
+        tool: "t1".to_string(),
+        description: "desc1".to_string(),
+        score: 0.95,
+        ..SearchResult::new("s1", "t1", "desc1")
+    }];
+    let hidden = ranked_results_to_json(results.clone(), false);
+    assert!(hidden[0].get("ranking").is_none());
+    assert_eq!(hidden[0]["score"], 0.95);
+    let shown = ranked_results_to_json(results, true);
+    assert_eq!(shown[0]["ranking"]["included"], true);
+}
+
+#[test]
 fn ranked_results_to_json_empty_input() {
-    let json_results = ranked_results_to_json(vec![]);
+    let json_results = ranked_results_to_json(vec![], false);
     assert!(json_results.is_empty());
 }

--- a/src/gateway/meta_mcp_tool_defs.rs
+++ b/src/gateway/meta_mcp_tool_defs.rs
@@ -105,14 +105,20 @@ fn build_search_tools_tool(tool_count: usize, server_count: usize) -> Tool {
         title: Some("Search Tools".to_string()),
         description: Some(format!(
             "Search {tool_count} tools across {server_count} servers by keyword. Returns ranked \
-         matches with full schemas while avoiding the prompt bloat of loading every tool \
-         definition upfront. Supports multi-word queries and synonym expansion."
+         matches (name, description, score) while avoiding the prompt bloat of loading every tool \
+         definition upfront. Ranking diagnostics are omitted unless explain is true. \
+         Supports multi-word queries and synonym expansion."
         )),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "query": { "type": "string", "description": "Search keyword" },
-                "limit": { "type": "integer", "description": "Maximum results (default 10)", "default": 10 }
+                "limit": { "type": "integer", "description": "Maximum results (default 10)", "default": 10 },
+                "explain": {
+                    "type": "boolean",
+                    "description": "Include ranking diagnostics (reasons and signals). Default false.",
+                    "default": false
+                }
             },
             "required": ["query"]
         }),
@@ -619,7 +625,10 @@ pub(crate) fn build_code_mode_search_tool() -> Tool {
         title: Some("Search Tools".to_string()),
         description: Some(
             "Search the gateway tool registry by name, description, or tag. \
-         Returns matching tools with their full schemas. \
+         Default detail is L0: tool name, one-line purpose, and score. \
+         Set detail to l1 for signature, when-to-use, and required params, \
+         or l2 for the full input schema. include_schema=true is deprecated and maps to l2. \
+         Ranking diagnostics are omitted unless explain is true. \
          Supports keyword queries, multi-word queries (any word matches), \
          and glob-style patterns (e.g. \"file_*\", \"*search*\")."
                 .to_string(),
@@ -636,10 +645,20 @@ pub(crate) fn build_code_mode_search_tool() -> Tool {
                     "description": "Maximum number of results to return (default 10, hard-capped at 25)",
                     "default": 10
                 },
+                "detail": {
+                    "type": "string",
+                    "enum": ["l0", "l1", "l2"],
+                    "description": "Response tier: l0 name+purpose+score (default); l1 signature+when-to-use+required params; l2 full input_schema",
+                    "default": "l0"
+                },
                 "include_schema": {
                     "type": "boolean",
-                    "description": "Include the full input schema for each matching tool (default true)",
-                    "default": true
+                    "description": "Deprecated. true maps to detail=l2 (full input schema). Prefer detail."
+                },
+                "explain": {
+                    "type": "boolean",
+                    "description": "Include ranking diagnostics (reasons and signals). Default false.",
+                    "default": false
                 }
             },
             "required": ["query"]

--- a/src/gateway/meta_mcp_tool_defs_tests.rs
+++ b/src/gateway/meta_mcp_tool_defs_tests.rs
@@ -3,6 +3,7 @@
 //! Tests for `meta_mcp_tool_defs` — extracted for LOC compliance.
 
 use super::*;
+use serde_json::json;
 
 // ── build_meta_tools ────────────────────────────────────────────────
 
@@ -342,6 +343,14 @@ fn build_code_mode_search_tool_has_limit_and_schema_params() {
     assert_eq!(tool.input_schema["properties"]["limit"]["type"], "integer");
     assert_eq!(
         tool.input_schema["properties"]["include_schema"]["type"],
+        "boolean"
+    );
+    assert_eq!(
+        tool.input_schema["properties"]["detail"]["enum"],
+        json!(["l0", "l1", "l2"])
+    );
+    assert_eq!(
+        tool.input_schema["properties"]["explain"]["type"],
         "boolean"
     );
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -15,7 +15,7 @@ pub mod oauth;
 pub mod proxy;
 pub mod recovery;
 mod router;
-mod search_disclosure;
+pub(crate) mod search_disclosure;
 mod server;
 pub mod state;
 pub mod streaming;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -15,6 +15,7 @@ pub mod oauth;
 pub mod proxy;
 pub mod recovery;
 mod router;
+mod search_disclosure;
 mod server;
 pub mod state;
 pub mod streaming;

--- a/src/gateway/search_disclosure.rs
+++ b/src/gateway/search_disclosure.rs
@@ -146,6 +146,33 @@ pub(crate) fn project_code_mode_match(value: Value, disclosure: SearchDisclosure
     Value::Object(out)
 }
 
+/// Drop L0-hidden disabled tools, attach a glob score when ranking was skipped,
+/// then project onto the requested tier.
+pub(crate) fn finalize_search_matches(
+    mut matches: Vec<Value>,
+    disclosure: SearchDisclosure,
+    glob: bool,
+    limit: usize,
+) -> Vec<Value> {
+    if disclosure.detail == SearchDetail::L0 {
+        matches.retain(|m| m.get("status").and_then(Value::as_str) != Some("disabled"));
+    }
+    if glob {
+        for m in &mut matches {
+            if m.get("score").is_none()
+                && let Some(obj) = m.as_object_mut()
+            {
+                obj.insert("score".to_string(), json!(1.0));
+            }
+        }
+    }
+    matches.truncate(limit);
+    matches
+        .into_iter()
+        .map(|m| project_code_mode_match(m, disclosure))
+        .collect()
+}
+
 /// First sentence of `description`, keywords suffix stripped, capped.
 pub(crate) fn one_line_purpose(description: &str) -> String {
     let stripped = strip_keyword_suffix(description);

--- a/src/gateway/search_disclosure.rs
+++ b/src/gateway/search_disclosure.rs
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Progressive disclosure for `gateway_search` results (MIK-7084).
+//!
+//! Search is a selection step. Default L0 answers "is this the tool?"
+//! Ranking diagnostics stay a debug surface (`explain: true`).
+
+use serde_json::{Value, json};
+
+use crate::ranking::SearchResult;
+use crate::{Error, Result};
+
+/// Maximum characters for L0 `description` (one-line purpose).
+pub(crate) const ONE_LINE_MAX: usize = 120;
+/// Maximum characters for L1 `when_to_use`.
+pub(crate) const WHEN_TO_USE_MAX: usize = 280;
+
+/// Response tier for `gateway_search`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SearchDetail {
+    /// Name, one-line purpose, score.
+    L0,
+    /// L0 plus signature, when-to-use, required params.
+    L1,
+    /// Full `input_schema` (legacy `include_schema: true`).
+    L2,
+}
+
+/// Parsed disclosure controls for one `gateway_search` call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SearchDisclosure {
+    pub detail: SearchDetail,
+    pub explain: bool,
+}
+
+/// Parse `detail`, `include_schema`, and `explain` from tool arguments.
+///
+/// `detail` wins when both `detail` and `include_schema` are set.
+/// Absent both → L0. Explicit `include_schema: true` → L2.
+pub(crate) fn resolve_search_disclosure(args: &Value) -> Result<SearchDisclosure> {
+    let explain = args
+        .get("explain")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let detail = match args.get("detail") {
+        None | Some(Value::Null) => {
+            if args.get("include_schema").and_then(Value::as_bool) == Some(true) {
+                SearchDetail::L2
+            } else {
+                SearchDetail::L0
+            }
+        }
+        Some(Value::String(s)) => parse_detail(s)?,
+        Some(_) => {
+            return Err(Error::json_rpc(
+                -32602,
+                "detail must be a string (l0|l1|l2)",
+            ));
+        }
+    };
+    Ok(SearchDisclosure { detail, explain })
+}
+
+fn parse_detail(raw: &str) -> Result<SearchDetail> {
+    match raw.to_ascii_lowercase().as_str() {
+        "l0" => Ok(SearchDetail::L0),
+        "l1" => Ok(SearchDetail::L1),
+        "l2" => Ok(SearchDetail::L2),
+        other => Err(Error::json_rpc(
+            -32602,
+            format!("Invalid 'detail' '{other}' (expected l0|l1|l2)"),
+        )),
+    }
+}
+
+/// Ranking diagnostics object. Emitted only when `explain` is true.
+pub(crate) fn ranking_debug_object(result: &SearchResult) -> Value {
+    json!({
+        "included": result.explanation.included,
+        "reasons": result.explanation.reasons,
+        "signals": result.signals,
+    })
+}
+
+/// Project a collected (and possibly ranked) Code Mode match onto a tier.
+///
+/// Unknown extra keys are dropped. `score` is kept when present. `ranking`
+/// is kept only when `explain` is true.
+pub(crate) fn project_code_mode_match(value: Value, disclosure: SearchDisclosure) -> Value {
+    let Value::Object(map) = value else {
+        return value;
+    };
+    let schema = map
+        .get("input_schema")
+        .cloned()
+        .unwrap_or_else(|| json!({"type": "object"}));
+    let raw_desc = map
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let tool = map.get("tool").cloned().unwrap_or(Value::Null);
+    let score = map.get("score").cloned();
+    let ranking = map.get("ranking").cloned();
+    let status = map.get("status").cloned();
+
+    let mut out = serde_json::Map::new();
+    out.insert("tool".to_string(), tool);
+
+    match disclosure.detail {
+        SearchDetail::L0 => {
+            out.insert(
+                "description".to_string(),
+                json!(one_line_purpose(&raw_desc)),
+            );
+        }
+        SearchDetail::L1 => {
+            out.insert(
+                "description".to_string(),
+                json!(one_line_purpose(&raw_desc)),
+            );
+            out.insert("when_to_use".to_string(), json!(when_to_use(&raw_desc)));
+            out.insert("required".to_string(), json!(required_params(&schema)));
+            out.insert("signature".to_string(), json!(schema_signature(&schema)));
+            if let Some(status) = status {
+                out.insert("status".to_string(), status);
+            }
+        }
+        SearchDetail::L2 => {
+            out.insert("description".to_string(), json!(raw_desc));
+            out.insert("input_schema".to_string(), schema);
+            if let Some(status) = status {
+                out.insert("status".to_string(), status);
+            }
+        }
+    }
+
+    if let Some(score) = score {
+        out.insert("score".to_string(), score);
+    }
+    if disclosure.explain
+        && let Some(ranking) = ranking
+    {
+        out.insert("ranking".to_string(), ranking);
+    }
+    Value::Object(out)
+}
+
+/// First sentence of `description`, keywords suffix stripped, capped.
+pub(crate) fn one_line_purpose(description: &str) -> String {
+    let stripped = strip_keyword_suffix(description);
+    clip_chars(first_sentence(stripped), ONE_LINE_MAX)
+}
+
+/// First paragraph of `description`, keywords suffix stripped, capped.
+pub(crate) fn when_to_use(description: &str) -> String {
+    let stripped = strip_keyword_suffix(description);
+    clip_chars(first_paragraph(stripped), WHEN_TO_USE_MAX)
+}
+
+/// `input_schema.required` names, empty when absent or not an array.
+pub(crate) fn required_params(schema: &Value) -> Vec<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Compact param list: `name: type` required, `name?: type` optional.
+pub(crate) fn schema_signature(schema: &Value) -> String {
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return String::new();
+    };
+    let required = required_params(schema);
+    let mut parts = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for name in &required {
+        if let Some(prop) = properties.get(name) {
+            parts.push(format!("{name}: {}", schema_type_name(prop)));
+            seen.insert(name.clone());
+        }
+    }
+    let mut optional: Vec<&String> = properties.keys().filter(|k| !seen.contains(*k)).collect();
+    optional.sort();
+    for name in optional {
+        if let Some(prop) = properties.get(name) {
+            parts.push(format!("{name}?: {}", schema_type_name(prop)));
+        }
+    }
+    parts.join(", ")
+}
+
+fn schema_type_name(schema: &Value) -> String {
+    match schema.get("type") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(Value::as_str)
+            .find(|s| *s != "null")
+            .unwrap_or("any")
+            .to_string(),
+        _ => "any".to_string(),
+    }
+}
+
+fn strip_keyword_suffix(description: &str) -> &str {
+    match description.find("[keywords:") {
+        Some(i) => description[..i].trim_end(),
+        None => description.trim(),
+    }
+}
+
+fn first_sentence(text: &str) -> &str {
+    let text = text.trim();
+    if text.is_empty() {
+        return text;
+    }
+    let line = text.split('\n').next().unwrap_or(text).trim();
+    if let Some(i) = line.find(". ") {
+        return line[..=i].trim_end();
+    }
+    line
+}
+
+fn first_paragraph(text: &str) -> &str {
+    let text = text.trim();
+    match text.find("\n\n") {
+        Some(i) => text[..i].trim(),
+        None => text,
+    }
+}
+
+fn clip_chars(text: &str, max: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    let keep = max.saturating_sub(3);
+    let mut buf = String::new();
+    for (i, c) in trimmed.chars().enumerate() {
+        if i >= keep {
+            break;
+        }
+        buf.push(c);
+    }
+    if let Some(idx) = buf.rfind(' ')
+        && idx >= keep / 2
+    {
+        buf.truncate(idx);
+    }
+    buf.push_str("...");
+    buf
+}
+
+#[cfg(test)]
+#[path = "search_disclosure_tests.rs"]
+mod tests;

--- a/src/gateway/search_disclosure_tests.rs
+++ b/src/gateway/search_disclosure_tests.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Mikko Parkkola
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 use super::{
-    ONE_LINE_MAX, SearchDetail, SearchDisclosure, one_line_purpose, project_code_mode_match,
-    ranking_debug_object, required_params, resolve_search_disclosure, schema_signature,
-    when_to_use,
+    ONE_LINE_MAX, SearchDetail, SearchDisclosure, finalize_search_matches, one_line_purpose,
+    project_code_mode_match, ranking_debug_object, required_params, resolve_search_disclosure,
+    schema_signature, when_to_use,
 };
 use crate::ranking::{RankingExplanation, SearchResult};
 use serde_json::{Value, json};
@@ -542,4 +542,55 @@ fn mik_gw_t5_l0_selects_the_same_tool_as_legacy_full() {
         );
         assert_eq!(l0["tool"], expected);
     }
+}
+
+#[test]
+fn glob_matches_get_a_score_on_l0() {
+    let hits = vec![json!({
+        "tool": "linear:linear_get_issue",
+        "description": "Get a Linear issue.",
+        "input_schema": {"type": "object"}
+    })];
+    let out = finalize_search_matches(
+        hits,
+        SearchDisclosure {
+            detail: SearchDetail::L0,
+            explain: false,
+        },
+        true,
+        5,
+    );
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0]["score"], 1.0);
+    assert!(out[0].get("ranking").is_none());
+    assert!(out[0].get("input_schema").is_none());
+}
+
+#[test]
+fn l0_drops_disabled_glob_candidates() {
+    let hits = vec![
+        json!({
+            "tool": "dead:tool",
+            "description": "Killed.",
+            "status": "disabled",
+            "input_schema": {"type": "object"}
+        }),
+        json!({
+            "tool": "live:tool",
+            "description": "Healthy.",
+            "input_schema": {"type": "object"}
+        }),
+    ];
+    let out = finalize_search_matches(
+        hits,
+        SearchDisclosure {
+            detail: SearchDetail::L0,
+            explain: false,
+        },
+        true,
+        5,
+    );
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0]["tool"], "live:tool");
+    assert_eq!(out[0]["score"], 1.0);
 }

--- a/src/gateway/search_disclosure_tests.rs
+++ b/src/gateway/search_disclosure_tests.rs
@@ -1,0 +1,545 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+use super::{
+    ONE_LINE_MAX, SearchDetail, SearchDisclosure, one_line_purpose, project_code_mode_match,
+    ranking_debug_object, required_params, resolve_search_disclosure, schema_signature,
+    when_to_use,
+};
+use crate::ranking::{RankingExplanation, SearchResult};
+use serde_json::{Value, json};
+
+fn keys_of(value: &Value) -> Vec<String> {
+    value
+        .as_object()
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn fat_linear_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Issue title. Deprecated alias headline is accepted for one release and will be removed; do not send both."
+            },
+            "team": { "type": "string", "description": "Team key or UUID" },
+            "description": { "type": "string", "description": "Markdown body" },
+            "assigneeId": { "type": "string" },
+            "priority": { "type": "integer" },
+            "labelIds": { "type": "array", "items": { "type": "string" } },
+            "parentId": { "type": "string" },
+            "cycleId": { "type": "string" },
+            "projectId": { "type": "string" },
+            "stateId": { "type": "string" },
+            "dueDate": { "type": "string" },
+            "estimate": { "type": "number" },
+            "subscriberIds": { "type": "array", "items": { "type": "string" } },
+            "headline": {
+                "type": "string",
+                "description": "Deprecated. Use title instead. Kept so existing callers that still send headline do not break; remove after 2026-12-01. This paragraph exists to reproduce the deprecation-essay waste measured on the live gateway."
+            }
+        },
+        "required": ["title", "team"]
+    })
+}
+
+fn ranked_match(tool: &str, description: &str, schema: &Value, score: f64) -> Value {
+    let mut result = SearchResult::new("srv", "t", description);
+    result.score = score;
+    result.explanation = RankingExplanation {
+        included: true,
+        reasons: vec![
+            "intent_match".into(),
+            "safety_ok".into(),
+            "grant_ok".into(),
+            "risk_fit".into(),
+            "policy_fit".into(),
+            "permission_fit".into(),
+            "trust_ok".into(),
+            "cost_fit".into(),
+            "latency_fit".into(),
+            "success_rate_fit".into(),
+            "user_preference_fit".into(),
+            "organization_preference_fit".into(),
+        ],
+    };
+    result.signals.relevance = 0.8;
+    json!({
+        "tool": tool,
+        "description": description,
+        "input_schema": schema,
+        "score": score,
+        "ranking": ranking_debug_object(&result)
+    })
+}
+
+fn envelope(query: &str, matches: &[Value]) -> Value {
+    json!({
+        "query": query,
+        "matches": matches,
+        "total": matches.len(),
+        "total_available": matches.len()
+    })
+}
+
+fn utf8_len(value: &Value) -> usize {
+    serde_json::to_vec(value).expect("serialize").len()
+}
+
+// ── MIK.GW.T2 resolve ────────────────────────────────────────────────
+
+#[test]
+fn default_args_resolve_to_l0_without_explain() {
+    let d = resolve_search_disclosure(&json!({ "query": "x" })).unwrap();
+    assert_eq!(d.detail, SearchDetail::L0);
+    assert!(!d.explain);
+}
+
+#[test]
+fn include_schema_true_maps_to_l2() {
+    let d = resolve_search_disclosure(&json!({ "include_schema": true })).unwrap();
+    assert_eq!(d.detail, SearchDetail::L2);
+}
+
+#[test]
+fn include_schema_false_maps_to_l0() {
+    let d = resolve_search_disclosure(&json!({ "include_schema": false })).unwrap();
+    assert_eq!(d.detail, SearchDetail::L0);
+}
+
+#[test]
+fn explicit_detail_wins_over_include_schema() {
+    let d = resolve_search_disclosure(&json!({
+        "detail": "l1",
+        "include_schema": true
+    }))
+    .unwrap();
+    assert_eq!(d.detail, SearchDetail::L1);
+}
+
+#[test]
+fn detail_is_case_insensitive() {
+    assert_eq!(
+        resolve_search_disclosure(&json!({ "detail": "L2" }))
+            .unwrap()
+            .detail,
+        SearchDetail::L2
+    );
+}
+
+#[test]
+fn invalid_detail_is_protocol_error() {
+    let err = resolve_search_disclosure(&json!({ "detail": "full" })).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("l0|l1|l2"), "{msg}");
+}
+
+#[test]
+fn non_string_detail_is_protocol_error() {
+    assert!(resolve_search_disclosure(&json!({ "detail": 2 })).is_err());
+}
+
+#[test]
+fn explain_true_is_opt_in() {
+    let d = resolve_search_disclosure(&json!({ "explain": true })).unwrap();
+    assert!(d.explain);
+    assert_eq!(d.detail, SearchDetail::L0);
+}
+
+// ── MIK.GW.T1 / T2 projection ────────────────────────────────────────
+
+#[test]
+fn l0_keeps_only_tool_description_score() {
+    let src = ranked_match(
+        "linear:create_issue",
+        "Create a Linear issue. Use when filing a ticket. [keywords: linear, issue]",
+        &fat_linear_schema(),
+        12.4,
+    );
+    let out = project_code_mode_match(
+        src,
+        SearchDisclosure {
+            detail: SearchDetail::L0,
+            explain: false,
+        },
+    );
+    let mut keys = keys_of(&out);
+    keys.sort();
+    assert_eq!(keys, ["description", "score", "tool"]);
+    assert_eq!(out["tool"], "linear:create_issue");
+    assert_eq!(out["score"], 12.4);
+    assert_eq!(out["description"], "Create a Linear issue.");
+    assert!(out.get("ranking").is_none());
+    assert!(out.get("input_schema").is_none());
+}
+
+#[test]
+fn l0_omits_disabled_status() {
+    let src = json!({
+        "tool": "x:y",
+        "description": "Does Y.",
+        "score": 1.0,
+        "status": "disabled",
+        "input_schema": {"type": "object"}
+    });
+    let out = project_code_mode_match(
+        src,
+        SearchDisclosure {
+            detail: SearchDetail::L0,
+            explain: false,
+        },
+    );
+    assert!(out.get("status").is_none());
+}
+
+#[test]
+fn l1_adds_signature_when_to_use_required_and_drops_schema() {
+    let src = ranked_match(
+        "linear:create_issue",
+        "Create a Linear issue.\n\nLonger planning notes that belong at L1.",
+        &fat_linear_schema(),
+        9.0,
+    );
+    let out = project_code_mode_match(
+        src,
+        SearchDisclosure {
+            detail: SearchDetail::L1,
+            explain: false,
+        },
+    );
+    assert!(out.get("input_schema").is_none());
+    assert!(out.get("ranking").is_none());
+    assert_eq!(out["required"], json!(["title", "team"]));
+    let sig = out["signature"].as_str().unwrap();
+    assert!(sig.starts_with("title: string, team: string"), "{sig}");
+    assert!(sig.contains("headline?: string"), "{sig}");
+    assert_eq!(out["when_to_use"], "Create a Linear issue.");
+}
+
+#[test]
+fn l2_keeps_input_schema_and_full_description() {
+    let desc = "Create a Linear issue. Use when filing a ticket.";
+    let src = ranked_match("linear:create_issue", desc, &fat_linear_schema(), 9.0);
+    let out = project_code_mode_match(
+        src,
+        SearchDisclosure {
+            detail: SearchDetail::L2,
+            explain: false,
+        },
+    );
+    assert!(out.get("input_schema").is_some());
+    assert_eq!(out["description"], desc);
+    assert!(out.get("ranking").is_none());
+    assert!(out.get("signature").is_none());
+}
+
+#[test]
+fn explain_true_keeps_ranking_at_every_tier() {
+    let src = ranked_match("s:t", "Short purpose.", &fat_linear_schema(), 1.0);
+    for detail in [SearchDetail::L0, SearchDetail::L1, SearchDetail::L2] {
+        let out = project_code_mode_match(
+            src.clone(),
+            SearchDisclosure {
+                detail,
+                explain: true,
+            },
+        );
+        assert!(
+            out.get("ranking").is_some(),
+            "ranking missing at {detail:?}"
+        );
+        assert_eq!(out["ranking"]["included"], true);
+        assert!(out["ranking"]["reasons"].as_array().unwrap().len() >= 12);
+    }
+}
+
+#[test]
+fn l0_description_never_exceeds_one_line_cap() {
+    let long = "A".repeat(400);
+    let src = json!({
+        "tool": "s:t",
+        "description": long,
+        "score": 1.0,
+        "input_schema": {"type": "object"}
+    });
+    let out = project_code_mode_match(
+        src,
+        SearchDisclosure {
+            detail: SearchDetail::L0,
+            explain: false,
+        },
+    );
+    let desc = out["description"].as_str().unwrap();
+    assert!(desc.chars().count() <= ONE_LINE_MAX, "{desc}");
+    assert!(desc.ends_with("..."));
+}
+
+// ── purpose / signature helpers ──────────────────────────────────────
+
+#[test]
+fn one_line_purpose_strips_keywords_and_takes_first_sentence() {
+    assert_eq!(
+        one_line_purpose("Create an issue. Extra prose. [keywords: linear, issue]"),
+        "Create an issue."
+    );
+}
+
+#[test]
+fn when_to_use_stops_at_blank_line() {
+    assert_eq!(
+        when_to_use("File a ticket.\n\nImplementation notes live here."),
+        "File a ticket."
+    );
+}
+
+#[test]
+fn required_params_reads_schema_required() {
+    assert_eq!(
+        required_params(&fat_linear_schema()),
+        vec!["title".to_string(), "team".to_string()]
+    );
+    assert!(required_params(&json!({"type": "object"})).is_empty());
+}
+
+#[test]
+fn schema_signature_marks_optional_params() {
+    let sig = schema_signature(&json!({
+        "type": "object",
+        "properties": {
+            "q": {"type": "string"},
+            "limit": {"type": "integer"}
+        },
+        "required": ["q"]
+    }));
+    assert_eq!(sig, "q: string, limit?: integer");
+}
+
+#[test]
+fn schema_signature_empty_without_properties() {
+    assert_eq!(schema_signature(&json!({"type": "object"})), "");
+}
+
+// ── MIK.GW.T3 measurement on a lean two-hit payload ──────────────────
+
+#[test]
+fn mik_gw_t3_ranking_blob_is_majority_of_lean_payload() {
+    let lean = json!({
+        "tool": "linear:save_issue",
+        "description": "Create a new issue in Linear. Use this when the user wants to file a ticket.",
+        "score": 12.4
+    });
+    let ranked = ranked_match(
+        "linear:save_issue",
+        "Create a new issue in Linear. Use this when the user wants to file a ticket.",
+        &json!({"type": "object"}),
+        12.4,
+    );
+    // Lean Code Mode match has no schema; ranking attached as today.
+    let with_ranking = json!({
+        "tool": ranked["tool"],
+        "description": ranked["description"],
+        "score": ranked["score"],
+        "ranking": ranked["ranking"]
+    });
+    let without = envelope("linear create", &[lean.clone(), lean]);
+    let with = envelope("linear create", &[with_ranking.clone(), with_ranking]);
+    let lean_n = utf8_len(&without);
+    let with_n = utf8_len(&with);
+    let ranking_bytes = with_n.saturating_sub(lean_n);
+    assert!(
+        ranking_bytes.saturating_mul(100) >= with_n.saturating_mul(45),
+        "T3 fail-fast: ranking {ranking_bytes}/{with_n} is far below ~60% (lean={lean_n})"
+    );
+}
+
+// ── MIK.GW.T4 / T5 on fixture catalog ────────────────────────────────
+
+fn catalog_hits() -> Vec<(&'static str, Value)> {
+    vec![
+        (
+            "linear create issue",
+            ranked_match(
+                "linear:create_issue",
+                "Create a Linear issue in a team. Use when filing work. [keywords: linear, issue]",
+                &fat_linear_schema(),
+                14.0,
+            ),
+        ),
+        (
+            "web search",
+            ranked_match(
+                "brave:web_search",
+                "Search the public web. Prefer this for current events. [keywords: search, web]",
+                &json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "count": {"type": "integer"},
+                        "country": {"type": "string"},
+                        "search_lang": {"type": "string"},
+                        "ui_lang": {"type": "string"},
+                        "freshness": {"type": "string"}
+                    },
+                    "required": ["query"]
+                }),
+                13.0,
+            ),
+        ),
+        (
+            "send email",
+            ranked_match(
+                "gmail:send_email",
+                "Send an email from the connected Gmail account. [keywords: email, send]",
+                &json!({
+                    "type": "object",
+                    "properties": {
+                        "to": {"type": "string"},
+                        "subject": {"type": "string"},
+                        "body": {"type": "string"},
+                        "cc": {"type": "string"},
+                        "bcc": {"type": "string"},
+                        "threadId": {"type": "string"},
+                        "attachments": {"type": "array"}
+                    },
+                    "required": ["to", "subject", "body"]
+                }),
+                12.0,
+            ),
+        ),
+        (
+            "github pull request",
+            ranked_match(
+                "github:create_pull_request",
+                "Open a GitHub pull request. Use after pushing a branch. [keywords: github, pr]",
+                &json!({
+                    "type": "object",
+                    "properties": {
+                        "owner": {"type": "string"},
+                        "repo": {"type": "string"},
+                        "title": {"type": "string"},
+                        "head": {"type": "string"},
+                        "base": {"type": "string"},
+                        "body": {"type": "string"},
+                        "draft": {"type": "boolean"},
+                        "maintainer_can_modify": {"type": "boolean"}
+                    },
+                    "required": ["owner", "repo", "title", "head", "base"]
+                }),
+                11.0,
+            ),
+        ),
+        (
+            "calendar events",
+            ranked_match(
+                "google_calendar:list_events",
+                "List events on a Google Calendar. [keywords: calendar, events]",
+                &json!({
+                    "type": "object",
+                    "properties": {
+                        "calendarId": {"type": "string"},
+                        "timeMin": {"type": "string"},
+                        "timeMax": {"type": "string"},
+                        "maxResults": {"type": "integer"},
+                        "q": {"type": "string"},
+                        "singleEvents": {"type": "boolean"},
+                        "orderBy": {"type": "string"}
+                    },
+                    "required": ["calendarId"]
+                }),
+                10.0,
+            ),
+        ),
+    ]
+}
+
+fn project_hits(hits: &[Value], disclosure: SearchDisclosure) -> Vec<Value> {
+    hits.iter()
+        .cloned()
+        .map(|m| project_code_mode_match(m, disclosure))
+        .collect()
+}
+
+#[test]
+fn mik_gw_t4_l0_is_at_most_a_quarter_of_legacy_default() {
+    let catalog = catalog_hits();
+    let mut rows = Vec::new();
+    for (query, hit) in &catalog {
+        let hits = vec![hit.clone()];
+        let legacy_hits = project_hits(
+            &hits,
+            SearchDisclosure {
+                detail: SearchDetail::L2,
+                explain: true,
+            },
+        );
+        let l0_hits = project_hits(
+            &hits,
+            SearchDisclosure {
+                detail: SearchDetail::L0,
+                explain: false,
+            },
+        );
+        let l1_hits = project_hits(
+            &hits,
+            SearchDisclosure {
+                detail: SearchDetail::L1,
+                explain: false,
+            },
+        );
+        let l2_hits = project_hits(
+            &hits,
+            SearchDisclosure {
+                detail: SearchDetail::L2,
+                explain: false,
+            },
+        );
+        let legacy = envelope(query, &legacy_hits);
+        let l0 = envelope(query, &l0_hits);
+        let l1 = envelope(query, &l1_hits);
+        let l2 = envelope(query, &l2_hits);
+        let legacy_n = utf8_len(&legacy);
+        let l0_n = utf8_len(&l0);
+        rows.push((*query, legacy_n, l0_n, utf8_len(&l1), utf8_len(&l2)));
+        assert!(
+            l0_n.saturating_mul(4) <= legacy_n,
+            "{query}: L0 {l0_n} is more than 25% of legacy {legacy_n}"
+        );
+    }
+    eprintln!("MIK.GW.T4 bytes (legacy=L2+explain, tokens~bytes/4)");
+    for (q, legacy, l0, l1, l2) in &rows {
+        eprintln!(
+            "  {q}: legacy={legacy} (~{} tok) l0={l0} (~{} tok) l1={l1} l2={l2} l0/legacy={}%",
+            legacy.div_ceil(4),
+            l0.div_ceil(4),
+            l0.saturating_mul(100) / (*legacy).max(1)
+        );
+    }
+}
+
+#[test]
+fn mik_gw_t5_l0_selects_the_same_tool_as_legacy_full() {
+    for (query, hit) in catalog_hits() {
+        let expected = hit["tool"].as_str().unwrap().to_string();
+        let l0 = project_code_mode_match(
+            hit.clone(),
+            SearchDisclosure {
+                detail: SearchDetail::L0,
+                explain: false,
+            },
+        );
+        let legacy = project_code_mode_match(
+            hit,
+            SearchDisclosure {
+                detail: SearchDetail::L2,
+                explain: true,
+            },
+        );
+        assert_eq!(
+            l0["tool"], legacy["tool"],
+            "{query}: L0 picked {} legacy picked {}",
+            l0["tool"], legacy["tool"]
+        );
+        assert_eq!(l0["tool"], expected);
+    }
+}


### PR DESCRIPTION
## Commits

- feat(search): L0/L1/L2 disclosure and omit ranking unless explain
- feat(MIK-7084): L0/L1/L2 gateway_search disclosure, ranking opt-in
- fix(MIK-7084): glob L0 gets a score and drops disabled tools

## Files

- `CHANGELOG.md`
- `docs/adaptive_ranking.md`
- `docs/design/mik-7084-search-tier-disclosure.md`
- `README.md`
- `src/gateway/meta_mcp_helpers_chain_tests.rs`
- `src/gateway/meta_mcp_helpers_tests.rs`
- `src/gateway/meta_mcp_helpers.rs`
- `src/gateway/meta_mcp_tool_defs_tests.rs`
- `src/gateway/meta_mcp_tool_defs.rs`
- `src/gateway/meta_mcp/mod.rs`
- `src/gateway/meta_mcp/search_disclosure_e2e.rs`
- `src/gateway/meta_mcp/search.rs`
- `src/gateway/meta_mcp/support.rs`
- `src/gateway/mod.rs`
- `src/gateway/search_disclosure_tests.rs`
- `src/gateway/search_disclosure.rs`

## Status

Opened to carry MIK-7084 through the delivery chain. Branch was local-only until now.
Definition-of-Done verdict and the dual-vendor review are still outstanding and are
recorded in this thread before merge.

Tracking: MIK-7084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
