### PR TITLE
fix(MIK-7222): summarize stdio command in remaining logs and errors

### DIFF
--- a/src/a2a/client.rs
+++ b/src/a2a/client.rs
@@ -23,6 +23,7 @@ use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+use crate::security::{diagnostic_url, safe_request_error};
 use crate::{Error, Result};
 
 use super::types::{
@@ -108,13 +109,13 @@ impl A2aClient {
             .get(&url)
             .send()
             .await
-            .map_err(|e| Error::Protocol(format!("Agent Card fetch failed: {e}")))?;
+            .map_err(|e| safe_request_error("Agent Card fetch failed", &e))?;
 
         if !resp.status().is_success() {
             return Err(Error::Protocol(format!(
                 "Agent Card returned HTTP {}: {}",
                 resp.status(),
-                url
+                diagnostic_url(&url)
             )));
         }
 
@@ -209,7 +210,7 @@ impl A2aClient {
             .json(&request)
             .send()
             .await
-            .map_err(|e| Error::Protocol(format!("A2A RPC '{method}' failed: {e}")))?;
+            .map_err(|e| safe_request_error(&format!("A2A RPC '{method}' failed"), &e))?;
 
         if !resp.status().is_success() {
             return Err(Error::Protocol(format!(

--- a/src/a2a/client.rs
+++ b/src/a2a/client.rs
@@ -23,7 +23,7 @@ use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::security::{diagnostic_url, safe_request_error};
+use crate::security::{diagnostic_url, safe_request_error, safe_reqwest_message};
 use crate::{Error, Result};
 
 use super::types::{
@@ -121,7 +121,7 @@ impl A2aClient {
 
         resp.json::<AgentCard>()
             .await
-            .map_err(|e| Error::Protocol(format!("Agent Card parse error: {e}")))
+            .map_err(|e| Error::Protocol(safe_reqwest_message("Agent Card parse error", &e)))
     }
 
     /// Send a text message to the agent and return the resulting task.
@@ -219,9 +219,12 @@ impl A2aClient {
             )));
         }
 
-        resp.json::<A2aResponse>()
-            .await
-            .map_err(|e| Error::Protocol(format!("A2A response parse error for '{method}': {e}")))
+        resp.json::<A2aResponse>().await.map_err(|e| {
+            Error::Protocol(safe_reqwest_message(
+                &format!("A2A response parse error for '{method}'"),
+                &e,
+            ))
+        })
     }
 }
 

--- a/src/commands/cap.rs
+++ b/src/commands/cap.rs
@@ -480,10 +480,16 @@ fn print_discover_empty() {
 
 fn print_discovered_servers(servers: &[mcp_gateway::discovery::DiscoveredServer], format: &str) {
     match format {
-        "json" => println!(
-            "{}",
-            serde_json::to_string_pretty(servers).unwrap_or_default()
-        ),
+        "json" => {
+            let redacted: Vec<_> = servers
+                .iter()
+                .map(mcp_gateway::discovery::DiscoveredServer::diagnostic_value)
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&redacted).unwrap_or_default()
+            );
+        }
         "yaml" => println!("{}", serde_yaml::to_string(servers).unwrap_or_default()),
         _ => {
             println!("Discovered {} MCP server(s):\n", servers.len());
@@ -501,16 +507,22 @@ fn print_server_entry(server: &mcp_gateway::discovery::DiscoveredServer) {
     match &server.transport {
         mcp_gateway::config::TransportConfig::Stdio { command, .. } => {
             println!("   Transport: stdio");
-            println!("   Command: {command}");
+            println!(
+                "   Command: {}",
+                mcp_gateway::security::summarize_stdio_command(command)
+            );
         }
         mcp_gateway::config::TransportConfig::Http { http_url, .. } => {
             println!("   Transport: http");
-            println!("   URL: {http_url}");
+            println!(
+                "   URL: {}",
+                mcp_gateway::security::diagnostic_url(http_url)
+            );
         }
         #[cfg(feature = "a2a")]
         mcp_gateway::config::TransportConfig::A2a { a2a_url, .. } => {
             println!("   Transport: a2a");
-            println!("   URL: {a2a_url}");
+            println!("   URL: {}", mcp_gateway::security::diagnostic_url(a2a_url));
         }
     }
     if let Some(ref path) = server.metadata.config_path {

--- a/src/commands/cap.rs
+++ b/src/commands/cap.rs
@@ -480,17 +480,20 @@ fn print_discover_empty() {
 
 fn print_discovered_servers(servers: &[mcp_gateway::discovery::DiscoveredServer], format: &str) {
     match format {
-        "json" => {
+        "json" | "yaml" => {
             let redacted: Vec<_> = servers
                 .iter()
-                .map(mcp_gateway::discovery::DiscoveredServer::diagnostic_value)
+                .map(mcp_gateway::discovery::DiscoveredServer::redacted_for_diagnostics)
                 .collect();
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&redacted).unwrap_or_default()
-            );
+            if format == "json" {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&redacted).unwrap_or_default()
+                );
+            } else {
+                println!("{}", serde_yaml::to_string(&redacted).unwrap_or_default());
+            }
         }
-        "yaml" => println!("{}", serde_yaml::to_string(servers).unwrap_or_default()),
         _ => {
             println!("Discovered {} MCP server(s):\n", servers.len());
             for server in servers {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -434,9 +434,18 @@ async fn check_http_backend(name: &str, transport: &TransportConfig) -> Option<C
             }
         }
         Err(e) => Some(
-            CheckResult::fail(label, format!("connection failed: {e}"))
-                .with_category("backend_http")
-                .with_hint(format!("Check that the server at {http_url} is running")),
+            CheckResult::fail(
+                label,
+                format!(
+                    "connection failed: {}",
+                    mcp_gateway::security::request_error_category(&e)
+                ),
+            )
+            .with_category("backend_http")
+            .with_hint(format!(
+                "Check that the server at {} is running",
+                mcp_gateway::security::diagnostic_url(http_url)
+            )),
         ),
     }
 }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -88,6 +88,33 @@ impl DiscoveredServer {
             ..Default::default()
         }
     }
+
+    /// Operator-facing JSON: names and origins, never argv or credential-bearing URLs.
+    #[must_use]
+    pub fn diagnostic_value(&self) -> serde_json::Value {
+        use crate::security::{diagnostic_url, summarize_stdio_command};
+        let (transport, command, url) = match &self.transport {
+            TransportConfig::Stdio { command, .. } => {
+                ("stdio", Some(summarize_stdio_command(command)), None)
+            }
+            TransportConfig::Http { http_url, .. } => {
+                ("http", None, Some(diagnostic_url(http_url)))
+            }
+            #[cfg(feature = "a2a")]
+            TransportConfig::A2a { a2a_url, .. } => ("a2a", None, Some(diagnostic_url(a2a_url))),
+        };
+        serde_json::json!({
+            "name": self.name,
+            "description": self.description,
+            "source": format!("{:?}", self.source),
+            "transport": transport,
+            "command": command,
+            "url": url,
+            "config_path": self.metadata.config_path.as_ref().map(|p| p.display().to_string()),
+            "pid": self.metadata.pid,
+            "port": self.metadata.port,
+        })
+    }
 }
 
 /// MCP Auto-Discovery orchestrator

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -89,31 +89,34 @@ impl DiscoveredServer {
         }
     }
 
-    /// Operator-facing JSON: names and origins, never argv or credential-bearing URLs.
+    /// Clone with argv and credential-bearing URLs replaced. Same serde shape
+    /// as the live server, so JSON and YAML discovery output stay compatible.
     #[must_use]
-    pub fn diagnostic_value(&self) -> serde_json::Value {
+    pub fn redacted_for_diagnostics(&self) -> Self {
         use crate::security::{diagnostic_url, summarize_stdio_command};
-        let (transport, command, url) = match &self.transport {
+        let mut redacted = self.clone();
+        match &mut redacted.transport {
             TransportConfig::Stdio { command, .. } => {
-                ("stdio", Some(summarize_stdio_command(command)), None)
+                *command = summarize_stdio_command(command);
             }
             TransportConfig::Http { http_url, .. } => {
-                ("http", None, Some(diagnostic_url(http_url)))
+                *http_url = diagnostic_url(http_url);
             }
             #[cfg(feature = "a2a")]
-            TransportConfig::A2a { a2a_url, .. } => ("a2a", None, Some(diagnostic_url(a2a_url))),
-        };
-        serde_json::json!({
-            "name": self.name,
-            "description": self.description,
-            "source": format!("{:?}", self.source),
-            "transport": transport,
-            "command": command,
-            "url": url,
-            "config_path": self.metadata.config_path.as_ref().map(|p| p.display().to_string()),
-            "pid": self.metadata.pid,
-            "port": self.metadata.port,
-        })
+            TransportConfig::A2a { a2a_url, .. } => {
+                *a2a_url = diagnostic_url(a2a_url);
+            }
+        }
+        if let Some(command) = redacted.metadata.command.as_mut() {
+            *command = summarize_stdio_command(command);
+        }
+        redacted
+    }
+
+    /// Operator-facing JSON: the redacted clone, never argv or secrets.
+    #[must_use]
+    pub fn diagnostic_value(&self) -> serde_json::Value {
+        serde_json::to_value(self.redacted_for_diagnostics()).unwrap_or(serde_json::Value::Null)
     }
 }
 
@@ -198,5 +201,38 @@ impl AutoDiscovery {
 impl Default for AutoDiscovery {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod yaml_redaction_tests {
+    use super::*;
+
+    const CANARY: &str = "SENTINEL_SWEEP_7222";
+
+    #[test]
+    fn yaml_of_redacted_server_keeps_schema_and_drops_canary() {
+        let server = DiscoveredServer {
+            name: "leaky".into(),
+            description: "d".into(),
+            source: DiscoverySource::Environment,
+            transport: TransportConfig::Stdio {
+                command: format!("node --token {CANARY} server.js"),
+                cwd: None,
+                protocol_version: None,
+            },
+            metadata: ServerMetadata {
+                command: Some(format!("node --token {CANARY}")),
+                ..ServerMetadata::default()
+            },
+        };
+        let yaml = serde_yaml::to_string(&server.redacted_for_diagnostics()).expect("yaml");
+        assert!(!yaml.contains(CANARY), "{yaml}");
+        assert!(yaml.contains("command:"), "{yaml}");
+        let raw = serde_yaml::to_string(&server).expect("raw");
+        assert!(
+            raw.contains(CANARY),
+            "fixture is only useful if raw YAML would leak"
+        );
     }
 }

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -20,6 +20,7 @@ use url::Url;
 use super::callback;
 use super::metadata::{self, AuthorizationServerMetadata, ProtectedResourceMetadata};
 use super::storage::{TokenInfo, TokenStorage};
+use crate::security::{request_error_category, safe_oauth_http_error};
 use crate::{Error, Result};
 
 /// Provenance of a `client_id` (MIK-6750 r7, Defect 2).
@@ -406,7 +407,12 @@ impl OAuthClient {
             .form(&params)
             .send()
             .await
-            .map_err(|e| Error::OAuth(format!("Client credentials request failed: {e}")))?;
+            .map_err(|e| {
+                Error::OAuth(format!(
+                    "Client credentials request failed: {}",
+                    request_error_category(&e)
+                ))
+            })?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -416,8 +422,10 @@ impl OAuthClient {
             // re-registers. Fix 1's guard makes this a no-op for
             // configured-secret (static) clients.
             self.purge_client_id_if_invalid(&body);
-            return Err(Error::OAuth(format!(
-                "Client credentials failed: HTTP {status} - {body}"
+            return Err(Error::OAuth(safe_oauth_http_error(
+                "Client credentials failed",
+                status,
+                &body,
             )));
         }
 
@@ -738,7 +746,12 @@ impl OAuthClient {
             .form(&params)
             .send()
             .await
-            .map_err(|e| Error::OAuth(format!("Token request failed: {e}")))?;
+            .map_err(|e| {
+                Error::OAuth(format!(
+                    "Token request failed: {}",
+                    request_error_category(&e)
+                ))
+            })?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -751,8 +764,10 @@ impl OAuthClient {
                 "OAuth token exchange failed"
             );
             self.purge_client_id_if_invalid(&body);
-            return Err(Error::OAuth(format!(
-                "Token exchange failed: HTTP {status} - {body}"
+            return Err(Error::OAuth(safe_oauth_http_error(
+                "Token exchange failed",
+                status,
+                &body,
             )));
         }
 
@@ -800,14 +815,21 @@ impl OAuthClient {
             .form(&params)
             .send()
             .await
-            .map_err(|e| Error::OAuth(format!("Token refresh failed: {e}")))?;
+            .map_err(|e| {
+                Error::OAuth(format!(
+                    "Token refresh failed: {}",
+                    request_error_category(&e)
+                ))
+            })?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             self.purge_client_id_if_invalid(&body);
-            return Err(Error::OAuth(format!(
-                "Token refresh failed: HTTP {status} - {body}"
+            return Err(Error::OAuth(safe_oauth_http_error(
+                "Token refresh failed",
+                status,
+                &body,
             )));
         }
 
@@ -956,13 +978,20 @@ impl OAuthClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| Error::OAuth(format!("Client registration failed: {e}")))?;
+            .map_err(|e| {
+                Error::OAuth(format!(
+                    "Client registration failed: {}",
+                    request_error_category(&e)
+                ))
+            })?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(Error::OAuth(format!(
-                "Client registration failed: HTTP {status} - {body}"
+            return Err(Error::OAuth(safe_oauth_http_error(
+                "Client registration failed",
+                status,
+                &body,
             )));
         }
 

--- a/src/oauth/client/mod.rs
+++ b/src/oauth/client/mod.rs
@@ -20,7 +20,7 @@ use url::Url;
 use super::callback;
 use super::metadata::{self, AuthorizationServerMetadata, ProtectedResourceMetadata};
 use super::storage::{TokenInfo, TokenStorage};
-use crate::security::{request_error_category, safe_oauth_http_error};
+use crate::security::{request_error_category, safe_oauth_http_error, safe_reqwest_message};
 use crate::{Error, Result};
 
 /// Provenance of a `client_id` (MIK-6750 r7, Defect 2).
@@ -429,10 +429,12 @@ impl OAuthClient {
             )));
         }
 
-        let token_response: TokenResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::OAuth(format!("Failed to parse credentials response: {e}")))?;
+        let token_response: TokenResponse = response.json().await.map_err(|e| {
+            Error::OAuth(safe_reqwest_message(
+                "Failed to parse credentials response",
+                &e,
+            ))
+        })?;
 
         let token = TokenInfo::from_response(
             token_response.access_token,
@@ -771,10 +773,9 @@ impl OAuthClient {
             )));
         }
 
-        let token_response: TokenResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::OAuth(format!("Failed to parse token response: {e}")))?;
+        let token_response: TokenResponse = response.json().await.map_err(|e| {
+            Error::OAuth(safe_reqwest_message("Failed to parse token response", &e))
+        })?;
 
         // #143 — structured telemetry: token exchange success event.
         info!(
@@ -833,10 +834,9 @@ impl OAuthClient {
             )));
         }
 
-        let token_response: TokenResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::OAuth(format!("Failed to parse refresh response: {e}")))?;
+        let token_response: TokenResponse = response.json().await.map_err(|e| {
+            Error::OAuth(safe_reqwest_message("Failed to parse refresh response", &e))
+        })?;
 
         let token = TokenInfo::from_response(
             token_response.access_token,
@@ -995,10 +995,12 @@ impl OAuthClient {
             )));
         }
 
-        let reg_response: ClientRegistrationResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::OAuth(format!("Failed to parse registration response: {e}")))?;
+        let reg_response: ClientRegistrationResponse = response.json().await.map_err(|e| {
+            Error::OAuth(safe_reqwest_message(
+                "Failed to parse registration response",
+                &e,
+            ))
+        })?;
 
         info!(client_id = %reg_response.client_id, "Registered OAuth client");
         Ok(reg_response.client_id)

--- a/src/security/http_diagnostics.rs
+++ b/src/security/http_diagnostics.rs
@@ -23,15 +23,23 @@ pub fn request_error_category(error: &reqwest::Error) -> &'static str {
         "connection failed"
     } else if error.is_redirect() {
         "redirect rejected"
+    } else if error.is_decode() {
+        "response parse failed"
     } else {
         "request failed"
     }
 }
 
+/// Context + category, never `reqwest::Error` Display (that embeds the URL).
+#[must_use]
+pub fn safe_reqwest_message(context: &str, error: &reqwest::Error) -> String {
+    format!("{context}: {}", request_error_category(error))
+}
+
 /// Transport-layer reqwest failure: context + category, never `{e}`.
 #[must_use]
 pub fn safe_request_error(context: &str, error: &reqwest::Error) -> Error {
-    Error::Transport(format!("{context}: {}", request_error_category(error)))
+    Error::Transport(safe_reqwest_message(context, error))
 }
 
 /// HTTP status without an untrusted body, except the session-expiry signal.

--- a/src/security/http_diagnostics.rs
+++ b/src/security/http_diagnostics.rs
@@ -91,10 +91,10 @@ mod tests {
     #[test]
     fn oauth_and_status_drop_body_canary() {
         let body = format!("{{\"access_token\":\"{CANARY}\",\"client_secret\":\"{CANARY}\"}}");
-        let oauth =
+        let redacted =
             safe_oauth_http_error("Client credentials failed", StatusCode::UNAUTHORIZED, &body);
-        assert!(!oauth.contains(CANARY), "{oauth}");
-        assert!(oauth.contains("HTTP 401"), "{oauth}");
+        assert!(!redacted.contains(CANARY));
+        assert!(redacted.contains("HTTP 401"));
         let err = safe_http_status_error(StatusCode::BAD_REQUEST, &body);
         assert!(!err.to_string().contains(CANARY), "{err}");
     }

--- a/src/security/http_diagnostics.rs
+++ b/src/security/http_diagnostics.rs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Shared diagnostic helpers that must not echo credentials.
+//!
+//! MIK-7222: HTTP transport grew `safe_request_error` / `safe_http_status_error`
+//! for PR #439. Other modules still interpolated reqwest Display, OAuth bodies,
+//! and raw stdio command lines. One definition, many callers.
+
+use reqwest::StatusCode;
+
+use crate::Error;
+use crate::security::sanitize::redact_url_for_diagnostics;
+
+/// Marker `is_session_expired_error` reads. Writer and reader must stay a pair.
+pub const SESSION_EXPIRED_MARKER: &str = "session expired";
+
+/// Classify a reqwest failure without keeping its Display (which embeds URLs).
+#[must_use]
+pub fn request_error_category(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connection failed"
+    } else if error.is_redirect() {
+        "redirect rejected"
+    } else {
+        "request failed"
+    }
+}
+
+/// Transport-layer reqwest failure: context + category, never `{e}`.
+#[must_use]
+pub fn safe_request_error(context: &str, error: &reqwest::Error) -> Error {
+    Error::Transport(format!("{context}: {}", request_error_category(error)))
+}
+
+/// HTTP status without an untrusted body, except the session-expiry signal.
+#[must_use]
+pub fn safe_http_status_error(status: StatusCode, body: &str) -> Error {
+    Error::Transport(safe_status_text(status, body))
+}
+
+/// OAuth token-endpoint / registration failure. Status stays; body does not.
+#[must_use]
+pub fn safe_oauth_http_error(context: &str, status: StatusCode, body: &str) -> String {
+    format!("{context}: {}", safe_status_text(status, body))
+}
+
+fn safe_status_text(status: StatusCode, body: &str) -> String {
+    let lower = body.to_ascii_lowercase();
+    if body.contains("-32015") || lower.contains("session not found") {
+        format!("HTTP {status}: {SESSION_EXPIRED_MARKER}")
+    } else {
+        format!("HTTP {status}")
+    }
+}
+
+/// Stdio command for diagnostics: executable name + argument count, never argv.
+#[must_use]
+pub fn summarize_stdio_command(command: &str) -> String {
+    match shlex::split(command) {
+        Some(parts) if !parts.is_empty() => {
+            let n = parts.len().saturating_sub(1);
+            format!("{} ({n} argument(s) redacted)", parts[0])
+        }
+        Some(_) => "empty command".to_string(),
+        None => "invalid quoting (command redacted)".to_string(),
+    }
+}
+
+/// Origin-only URL for logs and doctor hints.
+#[must_use]
+pub fn diagnostic_url(raw: &str) -> String {
+    redact_url_for_diagnostics(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CANARY: &str = "SENTINEL_SWEEP_7222";
+
+    #[test]
+    fn oauth_and_status_drop_body_canary() {
+        let body = format!("{{\"access_token\":\"{CANARY}\",\"client_secret\":\"{CANARY}\"}}");
+        let oauth =
+            safe_oauth_http_error("Client credentials failed", StatusCode::UNAUTHORIZED, &body);
+        assert!(!oauth.contains(CANARY), "{oauth}");
+        assert!(oauth.contains("HTTP 401"), "{oauth}");
+        let err = safe_http_status_error(StatusCode::BAD_REQUEST, &body);
+        assert!(!err.to_string().contains(CANARY), "{err}");
+    }
+
+    #[test]
+    fn session_expiry_marker_survives() {
+        let body = format!("{{\"code\":-32015,\"message\":\"Session not found {CANARY}\"}}");
+        let err = safe_http_status_error(StatusCode::BAD_REQUEST, &body);
+        assert!(err.to_string().contains(SESSION_EXPIRED_MARKER));
+        assert!(!err.to_string().contains(CANARY));
+    }
+
+    #[test]
+    fn stdio_summary_never_echoes_argv() {
+        let cmd = format!("npx --api-key {CANARY} -y server");
+        let out = summarize_stdio_command(&cmd);
+        assert!(!out.contains(CANARY), "{out}");
+        assert!(out.contains("npx"), "{out}");
+        assert!(out.contains("argument(s) redacted"), "{out}");
+        let bad = summarize_stdio_command(&format!("\"unclosed {CANARY}"));
+        assert!(!bad.contains(CANARY), "{bad}");
+        assert_eq!(bad, "invalid quoting (command redacted)");
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -18,6 +18,7 @@ pub mod agent_identity;
 pub mod data_flow;
 #[cfg(feature = "firewall")]
 pub mod firewall;
+pub mod http_diagnostics;
 pub mod message_signing;
 pub mod policy;
 pub mod remote_provenance;
@@ -38,6 +39,10 @@ pub use data_flow::{
     DataFlowRecord, DataFlowTracer, SanitizationRecord, ToolCategory, audit_sanitization,
     hash_argument,
 };
+pub use http_diagnostics::{
+    SESSION_EXPIRED_MARKER, diagnostic_url, request_error_category, safe_http_status_error,
+    safe_oauth_http_error, safe_request_error, summarize_stdio_command,
+};
 pub use policy::{ToolPolicy, ToolPolicyConfig};
 pub use remote_provenance::{
     RemoteServerProvenanceConfig, RemoteServerSignatureAlgorithm, RemoteServerSigningConfig,
@@ -45,7 +50,8 @@ pub use remote_provenance::{
 };
 pub use response_scanner::ResponseScanner;
 pub use sanitize::{
-    SanitizedResourceMeta, sanitize_json_value, sanitize_optional_json, sanitize_resource_metadata,
+    SanitizedResourceMeta, redact_url_for_diagnostics, sanitize_json_value, sanitize_optional_json,
+    sanitize_resource_metadata,
 };
 pub use scope_collision::{detect_collisions, validate_tool_name};
 pub use ssrf::{

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -41,7 +41,7 @@ pub use data_flow::{
 };
 pub use http_diagnostics::{
     SESSION_EXPIRED_MARKER, diagnostic_url, request_error_category, safe_http_status_error,
-    safe_oauth_http_error, safe_request_error, summarize_stdio_command,
+    safe_oauth_http_error, safe_request_error, safe_reqwest_message, summarize_stdio_command,
 };
 pub use policy::{ToolPolicy, ToolPolicyConfig};
 pub use remote_provenance::{

--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -30,58 +30,15 @@ use crate::protocol::{
     JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, RequestId,
     is_version_mismatch_error, negotiate_best_version, parse_supported_versions_from_error,
 };
+use crate::security::http_diagnostics::{
+    SESSION_EXPIRED_MARKER, safe_http_status_error, safe_request_error,
+};
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
 /// Reduce a URL to its origin before it reaches a log line or an error string.
-///
-/// One line, because the rule and its reasoning live in
-/// [`crate::security::sanitize::redact_url_for_diagnostics`]. A second copy of a
-/// security predicate is how one gets fixed and the other does not.
 fn sanitize_url_for_diagnostics(raw: &str) -> String {
     crate::security::sanitize::redact_url_for_diagnostics(raw)
-}
-
-/// Categorise a reqwest failure without keeping its Display text.
-///
-/// `reqwest::Error`'s Display embeds the full request URL, so `format!("{e}")`
-/// reintroduces every credential this module is careful to strip. The category
-/// is what a reader needs; the URL is what an attacker needs.
-fn safe_request_error(context: &str, error: &reqwest::Error) -> Error {
-    let category = if error.is_timeout() {
-        "timeout"
-    } else if error.is_connect() {
-        "connection failed"
-    } else if error.is_redirect() {
-        "redirect rejected"
-    } else {
-        "request failed"
-    };
-    Error::Transport(format!("{context}: {category}"))
-}
-
-/// Report an HTTP failure status while discarding the response body.
-///
-/// The body comes from the backend, which is not trusted to keep our secrets out
-/// of its error text, and it can be arbitrarily large. Session expiry is the one
-/// signal callers act on, so it is detected and everything else dropped.
-/// The one spelling of the expiry signal, shared by the writer below and the
-/// reader in [`is_session_expired_error`].
-///
-/// It was a bare string literal in both. They are a pair — the writer turns an
-/// untrusted body into this marker, the reader acts on it — and landing a change
-/// to one without the other silently disabled session recovery while every other
-/// test stayed green. A shared constant does not make them provably consistent,
-/// but it makes them impossible to diverge by typo, which is how they diverged.
-const SESSION_EXPIRED_MARKER: &str = "session expired";
-
-fn safe_http_status_error(status: reqwest::StatusCode, body: &str) -> Error {
-    let lower = body.to_ascii_lowercase();
-    if body.contains("-32015") || lower.contains("session not found") {
-        Error::Transport(format!("HTTP {status}: {SESSION_EXPIRED_MARKER}"))
-    } else {
-        Error::Transport(format!("HTTP {status}"))
-    }
 }
 
 /// Origin equality per WHATWG (scheme + host + effective port). Used to enforce
@@ -495,10 +452,10 @@ impl HttpTransport {
 
                     let retry_response = self.send_request(&retry_request).await?;
 
-                    if retry_response.error.is_some() {
+                    if let Some(err) = &retry_response.error {
                         return Err(Error::Protocol(format!(
-                            "Initialize failed with negotiated version {}: {:?}",
-                            negotiated_version, retry_response.error
+                            "Initialize failed with negotiated version {}: backend error code {}",
+                            negotiated_version, err.code
                         )));
                     }
 
@@ -735,7 +692,10 @@ impl HttpTransport {
                     let data = data.trim();
 
                     if event_type.as_deref() == Some("endpoint") {
-                        debug!(endpoint = %data, "Received message endpoint from SSE");
+                        debug!(
+                            endpoint = %sanitize_url_for_diagnostics(data),
+                            "Received message endpoint from SSE"
+                        );
 
                         // Extract session_id from the endpoint URL if present.
                         // The SSE handshake is connection-level (not per-caller),

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -132,7 +132,10 @@ impl StdioTransport {
     /// Returns an error if the command cannot be spawned or MCP initialization fails.
     pub async fn start(self: &Arc<Self>) -> Result<()> {
         let parts = shlex::split(&self.command).ok_or_else(|| {
-            Error::Config(format!("Invalid stdio command quoting: {}", self.command))
+            Error::Config(format!(
+                "Invalid stdio command quoting: {}",
+                crate::security::summarize_stdio_command(&self.command)
+            ))
         })?;
         if parts.is_empty() {
             return Err(Error::Config("Empty command".to_string()));

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -125,6 +125,10 @@ impl StdioTransport {
         })
     }
 
+    fn diagnostic_command(&self) -> String {
+        crate::security::summarize_stdio_command(&self.command)
+    }
+
     /// Start the subprocess
     ///
     /// # Errors
@@ -238,7 +242,7 @@ impl StdioTransport {
             debug!("Stdio reader task ended");
         });
 
-        let command = self.command.clone();
+        let command = self.diagnostic_command();
         tokio::spawn(async move {
             let mut reader = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = reader.next_line().await {
@@ -293,7 +297,7 @@ impl StdioTransport {
             .unwrap_or_else(|| PROTOCOL_VERSION.to_string());
 
         debug!(
-            command = %self.command,
+            command = %self.diagnostic_command(),
             version = %version,
             "Sending MCP initialize"
         );
@@ -312,7 +316,7 @@ impl StdioTransport {
 
             return Err(Error::Protocol(format!(
                 "Initialize failed for '{}': {error_msg}",
-                self.command
+                self.diagnostic_command()
             )));
         }
 
@@ -322,13 +326,13 @@ impl StdioTransport {
         {
             if server_version == version {
                 debug!(
-                    command = %self.command,
+                    command = %self.diagnostic_command(),
                     version = %server_version,
                     "Protocol version accepted"
                 );
             } else {
                 info!(
-                    command = %self.command,
+                    command = %self.diagnostic_command(),
                     requested = %version,
                     negotiated = %server_version,
                     "Server negotiated different protocol version"
@@ -352,12 +356,12 @@ impl StdioTransport {
             return Err(Error::Protocol(format!(
                 "Protocol version negotiation failed for '{}': server rejected {rejected_version}, \
                  no compatible version found (server said: {error_msg})",
-                self.command
+                self.diagnostic_command()
             )));
         };
 
         warn!(
-            command = %self.command,
+            command = %self.diagnostic_command(),
             rejected = %rejected_version,
             negotiated = %negotiated,
             "Retrying initialize with negotiated protocol version"
@@ -371,14 +375,15 @@ impl StdioTransport {
         if let Some(ref error) = retry_response.error {
             return Err(Error::Protocol(format!(
                 "Initialize failed for '{}' even with negotiated version {negotiated}: {}",
-                self.command, error.message
+                self.diagnostic_command(),
+                error.message
             )));
         }
 
         *self.protocol_version.write() = Some(negotiated.to_string());
 
         info!(
-            command = %self.command,
+            command = %self.diagnostic_command(),
             version = %negotiated,
             "Successfully negotiated protocol version"
         );
@@ -407,7 +412,7 @@ impl StdioTransport {
 
         let negotiated = self.protocol_version.read().clone();
         info!(
-            command = %self.command,
+            command = %self.diagnostic_command(),
             version = negotiated.as_deref().unwrap_or(PROTOCOL_VERSION),
             "Stdio transport initialized"
         );

--- a/tests/mik_7222_acs.rs
+++ b/tests/mik_7222_acs.rs
@@ -1,0 +1,83 @@
+//! MIK-7222: credential-disclosure sweep. Canary through every diagnostic helper.
+//! If a helper is reverted to echo its input, these fail.
+
+use mcp_gateway::config::TransportConfig;
+use mcp_gateway::discovery::{DiscoveredServer, DiscoverySource, ServerMetadata};
+use mcp_gateway::security::{
+    diagnostic_url, safe_http_status_error, safe_oauth_http_error, summarize_stdio_command,
+};
+use reqwest::StatusCode;
+
+const CANARY: &str = "SENTINEL_SWEEP_7222";
+
+#[test]
+fn sweep1_stdio_quoting_uses_summary_not_argv() {
+    let cmd = format!("npx --api-key {CANARY} -y @scope/pkg");
+    let out = summarize_stdio_command(&cmd);
+    assert!(!out.contains(CANARY), "{out}");
+    assert!(out.starts_with("npx"), "{out}");
+}
+
+#[test]
+fn sweep2_oauth_error_body_is_not_reachable_as_token_json() {
+    // RFC 6749 §5.2 error responses are `error` / `error_description`, not
+    // access_token. Keep P2. The body is still untrusted — a helper that
+    // interpolates it would leak a buggy AS echo of client_secret.
+    let body = format!("{{\"error\":\"invalid_client\",\"client_secret\":\"{CANARY}\"}}");
+    let out = safe_oauth_http_error("Client credentials failed", StatusCode::UNAUTHORIZED, &body);
+    assert!(!out.contains(CANARY), "{out}");
+    assert!(out.contains("HTTP 401"), "{out}");
+}
+
+#[test]
+fn sweep4_discovery_json_redacts_command_and_url() {
+    let server = DiscoveredServer {
+        name: "leaky".into(),
+        description: "d".into(),
+        source: DiscoverySource::Environment,
+        transport: TransportConfig::Stdio {
+            command: format!("node --token {CANARY} server.js"),
+            cwd: None,
+            protocol_version: None,
+        },
+        metadata: ServerMetadata::default(),
+    };
+    let json = server.diagnostic_value().to_string();
+    assert!(!json.contains(CANARY), "{json}");
+    let http = DiscoveredServer {
+        name: "http".into(),
+        description: "d".into(),
+        source: DiscoverySource::Environment,
+        transport: TransportConfig::Http {
+            http_url: format!("https://user:{CANARY}@api.example.com/mcp?t={CANARY}"),
+            streamable_http: false,
+            protocol_version: None,
+        },
+        metadata: ServerMetadata::default(),
+    };
+    let json = http.diagnostic_value().to_string();
+    assert!(!json.contains(CANARY), "{json}");
+    assert!(json.contains("https://api.example.com"), "{json}");
+}
+
+#[test]
+fn sweep5_canary_through_every_helper() {
+    let url = format!("https://user:{CANARY}@svc.example.com/path/{CANARY}?t={CANARY}");
+    assert!(!diagnostic_url(&url).contains(CANARY));
+
+    let body = format!("{{\"access_token\":\"{CANARY}\"}}");
+    assert!(
+        !safe_http_status_error(StatusCode::FORBIDDEN, &body)
+            .to_string()
+            .contains(CANARY)
+    );
+    assert!(!safe_oauth_http_error("x", StatusCode::FORBIDDEN, &body).contains(CANARY));
+    assert!(!summarize_stdio_command(&format!("cmd --secret {CANARY}")).contains(CANARY));
+
+    let expired = safe_http_status_error(
+        StatusCode::BAD_REQUEST,
+        &format!("{{\"code\":-32015,\"message\":\"Session not found {CANARY}\"}}"),
+    );
+    assert!(expired.to_string().contains("session expired"), "{expired}");
+    assert!(!expired.to_string().contains(CANARY));
+}

--- a/tests/mik_7222_acs.rs
+++ b/tests/mik_7222_acs.rs
@@ -4,7 +4,8 @@
 use mcp_gateway::config::TransportConfig;
 use mcp_gateway::discovery::{DiscoveredServer, DiscoverySource, ServerMetadata};
 use mcp_gateway::security::{
-    diagnostic_url, safe_http_status_error, safe_oauth_http_error, summarize_stdio_command,
+    diagnostic_url, request_error_category, safe_http_status_error, safe_oauth_http_error,
+    safe_reqwest_message, summarize_stdio_command,
 };
 use reqwest::StatusCode;
 
@@ -58,6 +59,27 @@ fn sweep4_discovery_json_redacts_command_and_url() {
     let json = http.diagnostic_value().to_string();
     assert!(!json.contains(CANARY), "{json}");
     assert!(json.contains("https://api.example.com"), "{json}");
+    assert!(
+        json.contains("\"http_url\""),
+        "JSON must keep nested TransportConfig keys, got {json}"
+    );
+
+    let yaml_stdio = server.redacted_for_diagnostics();
+    match &yaml_stdio.transport {
+        TransportConfig::Stdio { command, .. } => {
+            assert!(!command.contains(CANARY), "{command}");
+            assert!(command.contains("argument(s) redacted"), "{command}");
+        }
+        other => panic!("expected stdio, got {other:?}"),
+    }
+    let yaml_http = http.redacted_for_diagnostics();
+    match &yaml_http.transport {
+        TransportConfig::Http { http_url, .. } => {
+            assert!(!http_url.contains(CANARY), "{http_url}");
+            assert!(http_url.contains("https://api.example.com"), "{http_url}");
+        }
+        other => panic!("expected http, got {other:?}"),
+    }
 }
 
 #[test]
@@ -80,4 +102,43 @@ fn sweep5_canary_through_every_helper() {
     );
     assert!(expired.to_string().contains("session expired"), "{expired}");
     assert!(!expired.to_string().contains(CANARY));
+}
+
+#[tokio::test]
+async fn sweep_decode_error_must_not_echo_url_credentials() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let body = b"not-json";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        use tokio::io::AsyncWriteExt;
+        let _ = stream.write_all(response.as_bytes()).await;
+        let _ = stream.write_all(body).await;
+    });
+
+    // reqwest lifts userinfo into Basic auth and strips it from Error Display.
+    // Query parameters stay (reqwest 0.13 docs: "an API key as a query parameter").
+    let url = format!("http://127.0.0.1:{}/token?api_key={CANARY}", addr.port());
+    let err = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("send")
+        .json::<serde_json::Value>()
+        .await
+        .expect_err("malformed body must fail decode");
+    assert!(
+        err.to_string().contains(CANARY),
+        "fixture is only useful if Display would leak; got {}",
+        err
+    );
+    let safe = safe_reqwest_message("Failed to parse token response", &err);
+    assert!(!safe.contains(CANARY), "{safe}");
+    assert_eq!(request_error_category(&err), "response parse failed");
 }

--- a/tests/mik_7222_acs.rs
+++ b/tests/mik_7222_acs.rs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //! MIK-7222: credential-disclosure sweep. Canary through every diagnostic helper.
 //! If a helper is reverted to echo its input, these fail.
 
@@ -25,9 +27,10 @@ fn sweep2_oauth_error_body_is_not_reachable_as_token_json() {
     // access_token. Keep P2. The body is still untrusted — a helper that
     // interpolates it would leak a buggy AS echo of client_secret.
     let body = format!("{{\"error\":\"invalid_client\",\"client_secret\":\"{CANARY}\"}}");
-    let out = safe_oauth_http_error("Client credentials failed", StatusCode::UNAUTHORIZED, &body);
-    assert!(!out.contains(CANARY), "{out}");
-    assert!(out.contains("HTTP 401"), "{out}");
+    let redacted =
+        safe_oauth_http_error("Client credentials failed", StatusCode::UNAUTHORIZED, &body);
+    assert!(!redacted.contains(CANARY));
+    assert!(redacted.contains("HTTP 401"));
 }
 
 #[test]


### PR DESCRIPTION
## Commits

- fix(MIK-7222): share HTTP diagnostic helpers and stop echoing secrets
- fix(MIK-7222): redact YAML discovery and reqwest decode Display
- fix(MIK-7222): summarize stdio command in remaining logs and errors

## Files

- `src/a2a/client.rs`
- `src/commands/cap.rs`
- `src/commands/doctor.rs`
- `src/discovery/mod.rs`
- `src/oauth/client/mod.rs`
- `src/security/http_diagnostics.rs`
- `src/security/mod.rs`
- `src/transport/http/mod.rs`
- `src/transport/stdio.rs`
- `tests/mik_7222_acs.rs`

## Status

Opened to carry MIK-7222 through the delivery chain. Branch was local-only until now.
Definition-of-Done verdict and the dual-vendor review are still outstanding and are
recorded in this thread before merge.

Tracking: MIK-7222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
