### PR TITLE
test(meta_mcp): bind #465 timing assertions to the timeouts they test; credit @terafin

### DIFF
--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -3,12 +3,16 @@
 **Work:** mcp-gateway (this repository)
 **Author:** Mikko Parkkola, Finland
 **Date of declaration:** 2026-07-12
+**Last amended:** 2026-09-04 (first outside contribution accepted)
 
 ## Declaration
 
-Mikko Parkkola is the sole human author of mcp-gateway. As of this date there
-are no other human contributors. Where future contributions are accepted, they
-are governed by [`CLA.md`](CLA.md).
+Mikko Parkkola is the principal human author of mcp-gateway and the author of
+its protectable expression as described below. Outside contributions accepted
+into the work are listed under [Contributors](#contributors), together with
+whether that contributor's [`CLA.md`](CLA.md) acceptance is on record. Under
+that agreement a contributor grants the licences this project's licensing
+scheme requires while retaining copyright in their own contribution.
 
 The work is an original work of authorship. Its protectable expression — the
 architecture, module structure, control and data flow, interface design, naming,
@@ -47,6 +51,17 @@ This posture is consistent with the governing framework:
   AI-assisted material is copyrightable. *Thaler v. Perlmutter* (D.C. Cir. 2025)
   bars copyright only for works authored *solely* by AI with human input
   disclaimed — not this work.
+
+## Contributors
+
+Outside contributions accepted into the work. A contributor's acceptance of
+[`CLA.md`](CLA.md) is recorded in the pull request that introduced their first
+contribution; where that record is outstanding, this table says so rather than
+implying it.
+
+| Contributor | Contribution | Pull request | CLA on record |
+|---|---|---|---|
+| [terafin](https://github.com/terafin) | Parallel, timeout-bounded backend fan-out for `prompts/list` and `resources/list`; cancellation-safe cleanup of in-flight transport requests | [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465) | **outstanding** — requested 2026-09-04, after the merge |
 
 ## Third-party material
 

--- a/AUTHORSHIP.md
+++ b/AUTHORSHIP.md
@@ -3,7 +3,7 @@
 **Work:** mcp-gateway (this repository)
 **Author:** Mikko Parkkola, Finland
 **Date of declaration:** 2026-07-12
-**Last amended:** 2026-09-04 (first outside contribution accepted)
+**Last amended:** 2026-09-04 (outside contributions recorded)
 
 ## Declaration
 
@@ -54,13 +54,16 @@ This posture is consistent with the governing framework:
 
 ## Contributors
 
-Outside contributions accepted into the work. A contributor's acceptance of
-[`CLA.md`](CLA.md) is recorded in the pull request that introduced their first
-contribution; where that record is outstanding, this table says so rather than
-implying it.
+Outside contributions accepted into the work, in the order they were merged. A
+contributor's acceptance of [`CLA.md`](CLA.md) is recorded in the pull request
+that introduced their first contribution; where that record is outstanding, or
+where the contribution predates [`CLA.md`](CLA.md) (added 2026-07-11), this
+table says so rather than implying an acceptance that was never given.
 
 | Contributor | Contribution | Pull request | CLA on record |
 |---|---|---|---|
+| Bryan Zick, submitted by [v4de](https://github.com/v4de) | `structuredContent` in responses from tools that declare an `outputSchema`, as the MCP 2025-06-18 spec requires | [#159](https://github.com/MikkoParkkola/mcp-gateway/pull/159) | **not applicable** — merged 2026-04-27, before `CLA.md` existed |
+| [v4de](https://github.com/v4de) | Rust 1.95 clippy, rustfmt and compilation fixes across ~15 sites | [#160](https://github.com/MikkoParkkola/mcp-gateway/pull/160) | **not applicable** — merged 2026-04-28, before `CLA.md` existed |
 | [terafin](https://github.com/terafin) | Parallel, timeout-bounded backend fan-out for `prompts/list` and `resources/list`; cancellation-safe cleanup of in-flight transport requests | [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465) | **outstanding** — requested 2026-09-04, after the merge |
 
 ## Third-party material

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connect timeouts on every (re)connect, and the gateway's late response
   surfaced as an "unknown message ID" error. Backends are now fetched in
   parallel and each fetch is bounded by a short timeout, so a slow or hung
-  backend is skipped instead of blocking the list.
+  backend is skipped instead of blocking the list. Reported and fixed by
+  [@terafin](https://github.com/terafin) from a 56-backend deployment, in
+  [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465).
 - **The aggregation timeout is configurable** via
   `meta_mcp.prompts_resources_fetch_timeout` (default `10s`). Operators with
   unusually slow backends can raise it without a code change.
+  ([@terafin](https://github.com/terafin), [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465))
 - **A cancelled transport request no longer strands its `pending` entry.**
   When an outer timeout drops an in-flight stdio or WebSocket request before
   the transport's own request timeout fires, a RAII guard removes the entry
   from the transport's `pending` map on drop, so a late response finds no
   dangling sender and the map does not grow across reconnect loops.
+  ([@terafin](https://github.com/terafin), [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465))
 
 ## [3.5.0] - 2026-08-28
 

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -2612,8 +2612,8 @@ async fn prompts_list_skips_hung_backend_within_timeout() {
         resp.error
     );
     assert!(
-        elapsed < Duration::from_secs(10),
-        "must skip hung backend quickly, took {:?}",
+        elapsed < Duration::from_secs(2),
+        "must skip the hung backend at the 100ms aggregation timeout, not at the backend's own 5s timeout, took {:?}",
         elapsed
     );
     // Only the gateway meta-prompts remain.
@@ -2642,8 +2642,8 @@ async fn resources_list_skips_hung_backend_within_timeout() {
         resp.error
     );
     assert!(
-        elapsed < Duration::from_secs(10),
-        "must skip hung backend quickly, took {:?}",
+        elapsed < Duration::from_secs(2),
+        "must skip the hung backend at the 100ms aggregation timeout, not at the backend's own 5s timeout, took {:?}",
         elapsed
     );
 }
@@ -2725,8 +2725,8 @@ async fn prompts_list_fast_backend_not_stalled_by_hung_one() {
         resp.error
     );
     assert!(
-        elapsed < Duration::from_secs(10),
-        "fast result must return within a single timeout, took {:?}",
+        elapsed < Duration::from_secs(3),
+        "fast result must return at the 1s aggregation timeout, not at the hung backend's own 5s timeout, took {:?}",
         elapsed
     );
     // Both the gateway meta-prompts AND the fast backend's prompt are present;


### PR DESCRIPTION
Follow-up to #465, which merged before these two items landed.

## Test bounds

An independent review of the #465 diff found that the three timing assertions bound at 10 seconds while the aggregation timeouts they exercise are 100ms and 1s. The backends in those tests carry their own 5-second timeout, so the pre-parallel serial path would also have finished inside 10 seconds — the assertions could not fail for the reason they exist.

They are now 2s and 3s, below that 5-second serial bound and with room for slow CI, and each failure message names the bound it discriminates. No production code changed.

Verified: `cargo test --lib meta_mcp` → 87 passed, 0 failed, in 2.38s.

## Contributor credit

`AUTHORSHIP.md` recorded that the project had no contributors besides the maintainer. That was untrue, so the declaration now points at a `Contributors` section and the three changelog entries name @terafin.

**It had been untrue since April, not since #465.** A review of the first draft of this PR caught the table asserting #465 was the first outside contribution. GitHub's contributor list has five entries: #159 (Bryan Zick, submitted by @v4de, `structuredContent` for tools declaring an `outputSchema`) merged 2026-04-27 and #160 (@v4de, Rust 1.95 lint and compilation fixes) merged 2026-04-28. Both are now in the table, in merge order. Both predate `CLA.md`, which was added 2026-07-11, so their CLA column says `not applicable` rather than `outstanding` — a contribution accepted before the agreement existed was not withheld from it.

**One thing the table records rather than papers over.** This repository is dual-licensed and `CONTRIBUTING.md` asks first-time contributors for a one-line CLA statement in the PR description. #465 has no such line and no sign-off trailer, and it merged without one. The `CLA on record` column says `outstanding` instead of implying an acceptance that did not happen. Asked for on the PR thread; the column flips when it arrives.

## Acceptance criteria

- [x] Each timing assertion fails on the serial path it exists to rule out
- [x] Each failure message names the timeout it discriminates
- [x] `AUTHORSHIP.md` no longer asserts sole authorship
- [x] CLA status stated accurately rather than assumed
- [x] Every outside contribution on `main` appears in the table, not only the most recent
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib meta_mcp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

