### PR TITLE
chore(release): 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-09-04
+
 ### Changed
 
 - **`gateway_search` returns L0 by default** (MIK-7084): tool name, one-line purpose, and score. `detail=l1` adds signature, when-to-use, and required params; `detail=l2` returns the full `input_schema`. `include_schema=true` still maps to L2 and is deprecated, not removed. Ranking diagnostics (`ranking` reasons and signals) are omitted unless `explain=true`. `gateway_search_tools` also omits `ranking` unless `explain=true`.
@@ -32,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the transport's `pending` map on drop, so a late response finds no
   dangling sender and the map does not grow across reconnect loops.
   ([@terafin](https://github.com/terafin), [#465](https://github.com/MikkoParkkola/mcp-gateway/pull/465))
+- **Unreadable gateway config now reports a diagnosis** instead of a generic
+  failure, so a permissions or parse problem is visible at startup.
+  ([#461](https://github.com/MikkoParkkola/mcp-gateway/pull/461))
+- **Sampling POST-backs are bound to the prompted session**, so a late
+  sampling response cannot land on a different client.
+- **Glob L0 ranking drops disabled tools** and still assigns a score, so
+  search results do not advertise tools the operator turned off.
+  ([#470](https://github.com/MikkoParkkola/mcp-gateway/pull/470))
 
 ## [3.5.0] - 2026-08-28
 
@@ -1315,6 +1325,7 @@ credential path.
 - Configuration via YAML with Pydantic validation
 - systemd/launchd service templates
 
+[3.5.1]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.4.0...v3.5.0
 [2.10.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.9.1...v2.10.0
 [2.9.1]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.9.0...v2.9.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 
 ## Current Status
 
-- **v3.5.0** · Rust 1.88+ · Edition 2024 · ~101K LOC · MIT core + PolyForm Noncommercial EE
+- **v3.5.1** · Rust 1.88+ · Edition 2024 · ~101K LOC · MIT core + PolyForm Noncommercial EE
 - Published on crates.io + Homebrew + npm + ghcr.io container images + Glama + VS Code + Cursor one-click install
 - **Meta-MCP surface**: 14-16 tools in production scenarios (README benchmark scenario)
 - **Capability backends**: 110+ REST capabilities + MCP backends routed via the same surface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-gateway"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-gateway"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Mikko Parkkola <mikko.parkkola@iki.fi>"]

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ command that changes behaviour, is a breaking change.
 modularity and testing, not as a supported embedding API, and they may change
 in any release. The crate ships a binary; at the time of writing crates.io
 reports zero reverse dependencies. If you embed the library, pin an exact
-version (`=3.5.0`) rather than a caret range.
+version (`=3.5.1`) rather than a caret range.
 
 This is stated explicitly because "removing a `pub` field" and "breaking a
 supported API" are only the same thing when the API is supported. Here it is

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -8,7 +8,7 @@ description: >-
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
 version: 0.1.3
-appVersion: "3.5.0"
+appVersion: "3.5.1"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:
   - name: Mikko Parkkola

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -4,7 +4,7 @@ description: Universal MCP Gateway — compact Meta-MCP tool router with securit
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
 version: 0.1.3
-appVersion: "3.5.0"
+appVersion: "3.5.1"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:
   - https://github.com/MikkoParkkola/mcp-gateway

--- a/deploy/helm/mcp-gateway/values.yaml
+++ b/deploy/helm/mcp-gateway/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mikkoparkkola/mcp-gateway
   # Prefer a digest for immutable, supply-chain-safe deploys (set by A5/6684).
   # When `digest` is set it takes precedence over `tag`.
-  tag: "3.5.0"
+  tag: "3.5.1"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
Prepare 3.5.1: prompts/resources list no longer stall on a hung backend (#465), unreadable-config diagnosis (#461), sampling bound to session, glob L0 drops disabled tools (#470).

Tag `v3.5.1` after merge. Release workflow publishes GitHub Release, crates.io, npm, Homebrew.

## Test plan
- [ ] CI green
- [ ] After merge, tag v3.5.1 and watch release.yml