### PR TITLE
fix(release): chart version, Unreleased link, and MSRV line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1325,6 +1325,7 @@ credential path.
 - Configuration via YAML with Pydantic validation
 - systemd/launchd service templates
 
+[Unreleased]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.5.1...HEAD
 [3.5.1]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v3.4.0...v3.5.0
 [2.10.0]: https://github.com/MikkoParkkola/mcp-gateway/compare/v2.9.1...v2.10.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ The gateway is a **tool + capability router**, not a general chat-completions / 
 
 ## Current Status
 
-- **v3.5.1** · Rust 1.88+ · Edition 2024 · ~101K LOC · MIT core + PolyForm Noncommercial EE
+- **v3.5.1** · Rust 1.95+ · Edition 2024 · ~101K LOC · MIT core + PolyForm Noncommercial EE
 - Published on crates.io + Homebrew + npm + ghcr.io container images + Glama + VS Code + Cursor one-click install
 - **Meta-MCP surface**: 14-16 tools in production scenarios (README benchmark scenario)
 - **Capability backends**: 110+ REST capabilities + MCP backends routed via the same surface

--- a/deploy/helm/mcp-gateway-crds/Chart.yaml
+++ b/deploy/helm/mcp-gateway-crds/Chart.yaml
@@ -7,7 +7,7 @@ description: >-
   to author these resources as typed config. Helm does not manage CRD
   upgrade/delete lifecycle; see https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "3.5.1"
 home: https://github.com/MikkoParkkola/mcp-gateway
 maintainers:

--- a/deploy/helm/mcp-gateway/Chart.yaml
+++ b/deploy/helm/mcp-gateway/Chart.yaml
@@ -3,7 +3,7 @@ name: mcp-gateway
 description: Universal MCP Gateway — compact Meta-MCP tool router with security posture.
 type: application
 # Chart version tracks the packaging; appVersion tracks the gateway release.
-version: 0.1.3
+version: 0.1.4
 appVersion: "3.5.1"
 home: https://github.com/MikkoParkkola/mcp-gateway
 sources:


### PR DESCRIPTION
## Summary
Follow-up to Copilot review on #476 (already merged as v3.5.1):

- Bump Helm chart `version` 0.1.3 → 0.1.4 on both charts (appVersion already 3.5.1). Same rule as the 3.5.0 release: chart version must change or `helm upgrade` sees no artifact.
- Add `[Unreleased]: ...v3.5.1...HEAD` compare link.
- CLAUDE.md MSRV line now matches `Cargo.toml` rust-version 1.95.

These do not retag v3.5.1. The tagged tree still has chart 0.1.3; this is the next helm package.

## Test plan
- [ ] Chart.yaml versions are 0.1.4 / appVersion 3.5.1
- [ ] CI green