### PR TITLE
feat(telemetry): measure MCP revision use

### DIFF
--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -111,7 +111,11 @@ registered at zero. Record these fields after deployment:
 
 Use the durable file's start time for the stdio retirement decision, not an
 operator-supplied duration or an in-memory process snapshot. No distribution can
-be claimed until the result comment contains that live evidence.
+be claimed until the result comment contains that live evidence. Evaluate the
+final gate with `production_retirement_decision`: it requires the HTTP baseline
+to match the durable stdio start time and retires only the intersection of the
+HTTP and stdio candidates. A standalone stdio result is not a production
+retirement decision.
 
 **Pre-registered 2% rule: not applied.** The stop criterion forbids narrowing
 on partial data. Decision 2 stays unfrozen. No revision is retired.

--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -54,10 +54,21 @@ Rationale: 2025-06-18 and 2025-11-25 are the two revisions currently in wide cli
 
 ### U1 measurement (MIK-7218) — 2026-08-31
 
-Instrumentation landed in `src/protocol_revision_telemetry.rs`. It records
-`initialize.params.protocolVersion` and `_meta["io.modelcontextprotocol/protocolVersion"]`
-per session, exposes unattributed as its own series, and shadow-logs every
-`tools/list` filter set plus the `cacheScope` the decision table would emit.
+Instrumentation landed in `src/protocol_revision_telemetry.rs`. It counts only
+successful `initialize` dispatches, records both the requested wire revision and
+the revision actually negotiated, and splits the bounded labels by client family
+and HTTP/stdio transport. Missing requested revisions use a separate unattributed
+series. Stdio also emits the same bounded fields as a structured log. `tools/list`
+uses fixed counters for the filter set and the `cacheScope` the decision table
+would emit; it never retains per-request records or session ids.
+
+Read attribution from Prometheus as
+`mcp_protocol_revision_sessions_total / (mcp_protocol_revision_sessions_total +
+mcp_protocol_revision_unattributed_sessions_total)`. The pre-registered 2% share
+uses all initialized sessions, including unattributed sessions, as its denominator;
+this biases the check toward retaining older revisions. Zero-observation entries
+from the gateway's explicit `SUPPORTED_VERSIONS` table remain retirement candidates
+once the attribution floor is met.
 
 **Production window: not elapsed.** Snapshot at instrument time: 0 attributed
 sessions, 0 total. Attribution rate 0.0, below the 80% stop criterion.

--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -52,26 +52,49 @@ Rationale: 2025-06-18 and 2025-11-25 are the two revisions currently in wide cli
 
 **This is a decision, not a fact — it needs the unknown below resolved before it is frozen.**
 
-### U1 measurement (MIK-7218) — 2026-08-31
+### U1 measurement (MIK-7218) — instrumentation prepared 2026-09-04
 
-Instrumentation landed in `src/protocol_revision_telemetry.rs`. It counts only
-successful `initialize` dispatches, records both the requested wire revision and
-the revision actually negotiated, and splits the bounded labels by client family
-and HTTP/stdio transport. Missing requested revisions use a separate unattributed
-series. Stdio also emits the same bounded fields as a structured log. `tools/list`
-uses fixed counters for the filter set and the `cacheScope` the decision table
-would emit; it never retains per-request records or session ids.
+Instrumentation in `src/protocol_revision_telemetry.rs` counts parsed inbound
+requests, the only comparable unit because protocol-level sessions do not exist
+in 2026-07-28. Attribution comes from three sources:
 
-Read attribution from Prometheus as
-`mcp_protocol_revision_sessions_total / (mcp_protocol_revision_sessions_total +
-mcp_protocol_revision_unattributed_sessions_total)`. The pre-registered 2% share
-uses all initialized sessions, including unattributed sessions, as its denominator;
-this biases the check toward retaining older revisions. Zero-observation entries
-from the gateway's explicit `SUPPORTED_VERSIONS` table remain retirement candidates
-once the attribution floor is met.
+- modern per-request `_meta`;
+- the legacy HTTP `MCP-Protocol-Version` header; or
+- bounded, normalized attribution learned at `initialize` for legacy stdio
+  follow-ups.
 
-**Production window: not elapsed.** Snapshot at instrument time: 0 attributed
-sessions, 0 total. Attribution rate 0.0, below the 80% stop criterion.
+Client, revision, and transport labels have fixed families. A missing revision
+lands in a separate unattributed series. `tools/list` uses fixed counters for
+the real filter set and the `cacheScope` the decision table would emit. Raw
+client names never become labels; only hashes for up to 4,096 legacy session IDs
+are retained.
+
+Use one-week counter increases, reduced to scalars, for attribution:
+
+```promql
+sum(increase(mcp_protocol_revision_observations_total[1w]))
+/
+(
+  sum(increase(mcp_protocol_revision_observations_total[1w]))
+  + sum(increase(mcp_protocol_revision_unattributed_observations_total[1w]))
+)
+```
+
+The pre-registered 2% decision is evaluated only after seven elapsed days and
+the 80% attribution floor. For each revision, every unattributed observation is
+added to its count before testing the threshold. This conservative upper bound
+prevents uncertainty from making a revision look safe to remove. Revisions with
+zero observations are still evaluated from the gateway's explicit
+`SUPPORTED_VERSIONS` table.
+
+**Production window: not started.** Record these fields after deployment:
+
+- start timestamp and the timestamp seven full days later;
+- Prometheus counter increases over that exact interval; and
+- process restarts copied from deployment events.
+
+No distribution can be claimed until the result comment contains that live
+evidence.
 
 **Pre-registered 2% rule: not applied.** The stop criterion forbids narrowing
 on partial data. Decision 2 stays unfrozen. No revision is retired.

--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -52,6 +52,19 @@ Rationale: 2025-06-18 and 2025-11-25 are the two revisions currently in wide cli
 
 **This is a decision, not a fact — it needs the unknown below resolved before it is frozen.**
 
+### U1 measurement (MIK-7218) — 2026-08-31
+
+Instrumentation landed in `src/protocol_revision_telemetry.rs`. It records
+`initialize.params.protocolVersion` and `_meta["io.modelcontextprotocol/protocolVersion"]`
+per session, exposes unattributed as its own series, and shadow-logs every
+`tools/list` filter set plus the `cacheScope` the decision table would emit.
+
+**Production window: not elapsed.** Snapshot at instrument time: 0 attributed
+sessions, 0 total. Attribution rate 0.0, below the 80% stop criterion.
+
+**Pre-registered 2% rule: not applied.** The stop criterion forbids narrowing
+on partial data. Decision 2 stays unfrozen. No revision is retired.
+
 ## Unknowns, each with a fail-fast (§P1)
 
 An unknown without a scheduled check is a defect. Five; one resolved, four outstanding:

--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -69,6 +69,15 @@ the real filter set and the `cacheScope` the decision table would emit. Raw
 client names never become labels; only hashes for up to 4,096 legacy session IDs
 are retained.
 
+HTTP deployments expose these counters through Prometheus. Stdio has no metrics
+listener, so it writes a restart-safe aggregate to
+`~/.mcp-gateway/protocol-revision-telemetry/window.json`. The file contains the
+same bounded revision, client, transport, and `tools/list` dimensions. It is
+updated with an owner-only atomic write under a cross-process lock. Each process
+adds only its new observations, so restarting a stdio server does not reset the
+window. A write failure is logged as an incomplete measurement window; it does
+not silently produce retirement evidence.
+
 Use one-week counter increases, reduced to scalars, for attribution:
 
 ```promql
@@ -82,21 +91,27 @@ sum(increase(mcp_protocol_revision_observations_total[1w]))
 
 The pre-registered 2% decision is evaluated only after seven elapsed days and
 the 80% attribution floor. For each revision, every unattributed observation is
-added to its count before testing the threshold. This conservative upper bound
-prevents uncertainty from making a revision look safe to remove. Revisions with
-zero observations are still evaluated from the gateway's explicit
+added to its count before testing the threshold. A present but unrecognized
+revision lands in `other`. At 2% or more, `other` blocks the entire decision;
+below 2%, it is still added to every supported revision's upper-bound count.
+This prevents uncertainty from making a revision look safe to remove. Revisions
+with zero observations are still evaluated from the gateway's explicit
 `SUPPORTED_VERSIONS` table.
 
-**Production window: not started.** Start it from a baseline scrape taken after
-the process has pre-registered every bounded metric series at zero. Record these
-fields after deployment:
+**Production window: not started.** Stop all gateway processes, archive any
+earlier `protocol-revision-telemetry` directory, deploy, and then start the
+gateways. The new durable file's `started_at_unix_seconds` is the stdio baseline;
+take the HTTP baseline scrape after all bounded metric series have been
+registered at zero. Record these fields after deployment:
 
-- start timestamp and the timestamp seven full days later;
+- the durable start timestamp and the timestamp seven full days later;
 - Prometheus counter increases over that exact interval; and
-- process restarts copied from deployment events.
+- process restarts copied from deployment events;
+- the final durable JSON aggregate and its rendered distribution table.
 
-No distribution can be claimed until the result comment contains that live
-evidence.
+Use the durable file's start time for the stdio retirement decision, not an
+operator-supplied duration or an in-memory process snapshot. No distribution can
+be claimed until the result comment contains that live evidence.
 
 **Pre-registered 2% rule: not applied.** The stop criterion forbids narrowing
 on partial data. Decision 2 stays unfrozen. No revision is retired.

--- a/docs/design/RFC-0060-dual-generation-mcp.md
+++ b/docs/design/RFC-0060-dual-generation-mcp.md
@@ -87,7 +87,9 @@ prevents uncertainty from making a revision look safe to remove. Revisions with
 zero observations are still evaluated from the gateway's explicit
 `SUPPORTED_VERSIONS` table.
 
-**Production window: not started.** Record these fields after deployment:
+**Production window: not started.** Start it from a baseline scrape taken after
+the process has pre-registered every bounded metric series at zero. Record these
+fields after deployment:
 
 - start timestamp and the timestamp seven full days later;
 - Prometheus counter increases over that exact interval; and

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1181,7 +1181,12 @@ impl MetaMcp {
         let effective_code_mode = self.code_mode_enabled || url_override;
         if effective_code_mode && !self.code_mode_enabled {
             // URL-activated Code Mode: return the two fixed tools directly.
-            self.shadow_tools_list_assembly(session_id, true);
+            crate::protocol_revision_telemetry::observe_tools_list(
+                crate::protocol_revision_telemetry::ListFilters {
+                    request: true,
+                    ..crate::protocol_revision_telemetry::ListFilters::default()
+                },
+            );
             let tools = build_code_mode_tools();
             let tool_descriptors =
                 project_tool_descriptors_trust_cards("gateway:meta", "mcp-gateway", &tools);

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1057,12 +1057,26 @@ impl MetaMcp {
         self.handle_tools_list_for_session(id, None)
     }
 
+    fn shadow_tools_list_assembly(&self, session_id: Option<&str>, spec_preview_query: bool) {
+        let default = self.profile_registry.default_name();
+        let profile = session_id
+            .is_some_and(|sid| self.session_profiles.get_profile_name(sid, default) != default);
+        crate::protocol_revision_telemetry::observe_tools_list(
+            crate::protocol_revision_telemetry::ListFilters {
+                principal: false,
+                profile,
+                session: session_id.is_some() || self.code_mode_enabled || spec_preview_query,
+            },
+        );
+    }
+
     /// Session-aware variant of `handle_tools_list` used by the router.
     pub fn handle_tools_list_for_session(
         &self,
         id: RequestId,
         session_id: Option<&str>,
     ) -> JsonRpcResponse {
+        self.shadow_tools_list_assembly(session_id, false);
         let tools = if self.code_mode_enabled {
             build_code_mode_tools()
         } else {
@@ -1159,6 +1173,7 @@ impl MetaMcp {
         let effective_code_mode = self.code_mode_enabled || url_override;
         if effective_code_mode && !self.code_mode_enabled {
             // URL-activated Code Mode: return the two fixed tools directly.
+            self.shadow_tools_list_assembly(session_id, true);
             let tools = build_code_mode_tools();
             let tool_descriptors =
                 project_tool_descriptors_trust_cards("gateway:meta", "mcp-gateway", &tools);

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1063,9 +1063,7 @@ impl MetaMcp {
                 crate::protocol_revision_telemetry::ListFilters::default(),
             );
         }
-        let default = self.profile_registry.default_name();
-        let profile = session_id
-            .is_some_and(|sid| self.session_profiles.get_profile_name(sid, default) != default);
+        let profile = self.active_profile(session_id).is_restrictive();
         #[cfg(feature = "spec-preview")]
         let session = !self.promoted_tools_for_session(session_id).is_empty();
         #[cfg(not(feature = "spec-preview"))]

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -974,25 +974,6 @@ impl MetaMcp {
         session_id: Option<&str>,
         header_profile: Option<&str>,
     ) -> JsonRpcResponse {
-        self.handle_initialize_for_transport(
-            id,
-            params,
-            None,
-            session_id,
-            header_profile,
-            crate::protocol_revision_telemetry::Transport::Internal,
-        )
-    }
-
-    pub(crate) fn handle_initialize_for_transport(
-        &self,
-        id: RequestId,
-        params: Option<&Value>,
-        request_meta: Option<&Value>,
-        session_id: Option<&str>,
-        header_profile: Option<&str>,
-        transport: crate::protocol_revision_telemetry::Transport,
-    ) -> JsonRpcResponse {
         let client_version = extract_client_version(params);
         let negotiated_version = negotiate_version(client_version);
         debug!(
@@ -1000,13 +981,6 @@ impl MetaMcp {
             negotiated = negotiated_version,
             "Protocol version negotiation"
         );
-        crate::protocol_revision_telemetry::observe_initialize(
-            params,
-            request_meta,
-            negotiated_version,
-            transport,
-        );
-
         let profile_hint = header_profile.or_else(|| {
             params
                 .and_then(|p| p.get("profile"))
@@ -1082,6 +1056,13 @@ impl MetaMcp {
         session_id: Option<&str>,
         request_variant: bool,
     ) -> crate::protocol_revision_telemetry::ToolsListShadow {
+        // Static Code Mode always returns the same two meta-tools. Routing
+        // profile and promoted-session state do not filter that response.
+        if self.code_mode_enabled {
+            return crate::protocol_revision_telemetry::observe_tools_list(
+                crate::protocol_revision_telemetry::ListFilters::default(),
+            );
+        }
         let default = self.profile_registry.default_name();
         let profile = session_id
             .is_some_and(|sid| self.session_profiles.get_profile_name(sid, default) != default);

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -981,6 +981,11 @@ impl MetaMcp {
             negotiated = negotiated_version,
             "Protocol version negotiation"
         );
+        crate::protocol_revision_telemetry::observe_inbound(
+            session_id.unwrap_or("no-session"),
+            params,
+            None,
+        );
 
         let profile_hint = header_profile.or_else(|| {
             params

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -974,6 +974,25 @@ impl MetaMcp {
         session_id: Option<&str>,
         header_profile: Option<&str>,
     ) -> JsonRpcResponse {
+        self.handle_initialize_for_transport(
+            id,
+            params,
+            None,
+            session_id,
+            header_profile,
+            crate::protocol_revision_telemetry::Transport::Internal,
+        )
+    }
+
+    pub(crate) fn handle_initialize_for_transport(
+        &self,
+        id: RequestId,
+        params: Option<&Value>,
+        request_meta: Option<&Value>,
+        session_id: Option<&str>,
+        header_profile: Option<&str>,
+        transport: crate::protocol_revision_telemetry::Transport,
+    ) -> JsonRpcResponse {
         let client_version = extract_client_version(params);
         let negotiated_version = negotiate_version(client_version);
         debug!(
@@ -981,10 +1000,11 @@ impl MetaMcp {
             negotiated = negotiated_version,
             "Protocol version negotiation"
         );
-        crate::protocol_revision_telemetry::observe_inbound(
-            session_id.unwrap_or("no-session"),
+        crate::protocol_revision_telemetry::observe_initialize(
             params,
-            None,
+            request_meta,
+            negotiated_version,
+            transport,
         );
 
         let profile_hint = header_profile.or_else(|| {
@@ -1057,17 +1077,26 @@ impl MetaMcp {
         self.handle_tools_list_for_session(id, None)
     }
 
-    fn shadow_tools_list_assembly(&self, session_id: Option<&str>, spec_preview_query: bool) {
+    fn shadow_tools_list_assembly(
+        &self,
+        session_id: Option<&str>,
+        request_variant: bool,
+    ) -> crate::protocol_revision_telemetry::ToolsListShadow {
         let default = self.profile_registry.default_name();
         let profile = session_id
             .is_some_and(|sid| self.session_profiles.get_profile_name(sid, default) != default);
+        #[cfg(feature = "spec-preview")]
+        let session = !self.promoted_tools_for_session(session_id).is_empty();
+        #[cfg(not(feature = "spec-preview"))]
+        let session = false;
         crate::protocol_revision_telemetry::observe_tools_list(
             crate::protocol_revision_telemetry::ListFilters {
                 principal: false,
                 profile,
-                session: session_id.is_some() || self.code_mode_enabled || spec_preview_query,
+                session,
+                request: request_variant,
             },
-        );
+        )
     }
 
     /// Session-aware variant of `handle_tools_list` used by the router.

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1056,14 +1056,15 @@ impl MetaMcp {
         session_id: Option<&str>,
         request_variant: bool,
     ) -> crate::protocol_revision_telemetry::ToolsListShadow {
-        // Static Code Mode always returns the same two meta-tools. Routing
-        // profile and promoted-session state do not filter that response.
-        if self.code_mode_enabled {
+        // Static Code Mode returns the same two meta-tools only on the standard
+        // path. A spec-preview query returns filtered backend tools instead.
+        if self.code_mode_enabled && !request_variant {
             return crate::protocol_revision_telemetry::observe_tools_list(
                 crate::protocol_revision_telemetry::ListFilters::default(),
             );
         }
-        let profile = self.active_profile(session_id).is_restrictive();
+        let profile = self.active_profile(session_id).is_restrictive()
+            && (request_variant || !self.surfaced_tools.is_empty());
         #[cfg(feature = "spec-preview")]
         let session = !self.promoted_tools_for_session(session_id).is_empty();
         #[cfg(not(feature = "spec-preview"))]

--- a/src/gateway/meta_mcp/spec_preview.rs
+++ b/src/gateway/meta_mcp/spec_preview.rs
@@ -43,6 +43,7 @@ impl MetaMcp {
             return self.handle_tools_list_for_session(id, session_id);
         }
 
+        self.shadow_tools_list_assembly(session_id, true);
         let profile = self.active_profile(session_id);
         let tools: Vec<Tool> = self.collect_filtered_backend_tools(&query, session_id, &profile);
 

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -168,6 +168,25 @@ fn make_meta_mcp_code_mode() -> MetaMcp {
 }
 
 #[test]
+fn tools_list_wiring_records_real_cache_scope_inputs() {
+    use crate::protocol_revision_telemetry::{ListFilters, global_shadow_count};
+
+    let meta = make_meta_mcp();
+    let unfiltered = ListFilters::default();
+    let before_public = global_shadow_count(unfiltered);
+    meta.handle_tools_list(RequestId::Number(7001));
+    assert!(global_shadow_count(unfiltered) > before_public);
+
+    let request_filtered = ListFilters {
+        request: true,
+        ..ListFilters::default()
+    };
+    let before_private = global_shadow_count(request_filtered);
+    meta.handle_tools_list_with_url_override(RequestId::Number(7002), None, None, true);
+    assert!(global_shadow_count(request_filtered) > before_private);
+}
+
+#[test]
 fn new_matches_featureless_constructor_defaults() {
     let backends = Arc::new(BackendRegistry::new());
     let from_new = MetaMcp::new(Arc::clone(&backends));

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -187,6 +187,27 @@ fn tools_list_wiring_records_real_cache_scope_inputs() {
 }
 
 #[test]
+fn static_code_mode_does_not_claim_profile_or_session_filtering() {
+    use crate::protocol_revision_telemetry::{ListFilters, global_shadow_count};
+
+    let meta = make_meta_mcp_code_mode();
+    meta.session_profiles
+        .set_profile("code-mode-session", "non-default");
+    let unfiltered = ListFilters::default();
+    let incorrectly_filtered = ListFilters {
+        profile: true,
+        ..ListFilters::default()
+    };
+    let before_unfiltered = global_shadow_count(unfiltered);
+    let before_filtered = global_shadow_count(incorrectly_filtered);
+
+    meta.handle_tools_list_for_session(RequestId::Number(7003), Some("code-mode-session"));
+
+    assert!(global_shadow_count(unfiltered) > before_unfiltered);
+    assert_eq!(global_shadow_count(incorrectly_filtered), before_filtered);
+}
+
+#[test]
 fn new_matches_featureless_constructor_defaults() {
     let backends = Arc::new(BackendRegistry::new());
     let from_new = MetaMcp::new(Arc::clone(&backends));

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -188,30 +188,39 @@ fn tools_list_wiring_records_real_cache_scope_inputs() {
 
 #[test]
 fn static_code_mode_does_not_claim_profile_or_session_filtering() {
-    let meta = make_meta_mcp_code_mode();
+    let meta = make_meta_mcp_with_profiles().with_code_mode(true);
     meta.session_profiles
-        .set_profile("code-mode-session", "non-default");
+        .set_profile("code-mode-session", "coding");
     let shadow = meta.shadow_tools_list_assembly(Some("code-mode-session"), false);
 
     assert!(!shadow.profile);
     assert!(!shadow.session);
     assert!(!shadow.request);
+
+    let query_shadow = meta.shadow_tools_list_assembly(Some("code-mode-session"), true);
+    assert!(query_shadow.profile);
+    assert!(query_shadow.request);
 }
 
 #[test]
-fn restrictive_default_profile_is_recorded_as_filtered() {
+fn restrictive_default_profile_without_surfaced_tools_does_not_shape_standard_list() {
     use crate::protocol_revision_telemetry::{ListFilters, global_shadow_count};
 
     let meta = make_meta_mcp_with_profiles();
-    let filtered = ListFilters {
-        profile: true,
-        ..ListFilters::default()
-    };
-    let before = global_shadow_count(filtered);
+    let unfiltered = ListFilters::default();
+    let before = global_shadow_count(unfiltered);
 
     meta.handle_tools_list(RequestId::Number(7004));
 
-    assert!(global_shadow_count(filtered) > before);
+    assert!(global_shadow_count(unfiltered) > before);
+
+    let surfaced = vec![SurfacedToolConfig {
+        server: "brave".to_string(),
+        tool: "brave_search".to_string(),
+    }];
+    let surfaced_meta = make_meta_mcp_with_profiles().with_surfaced_tools(surfaced);
+    let profile_filtered = surfaced_meta.shadow_tools_list_assembly(None, false);
+    assert!(profile_filtered.profile);
 }
 
 #[test]

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -208,6 +208,22 @@ fn static_code_mode_does_not_claim_profile_or_session_filtering() {
 }
 
 #[test]
+fn restrictive_default_profile_is_recorded_as_filtered() {
+    use crate::protocol_revision_telemetry::{ListFilters, global_shadow_count};
+
+    let meta = make_meta_mcp_with_profiles();
+    let filtered = ListFilters {
+        profile: true,
+        ..ListFilters::default()
+    };
+    let before = global_shadow_count(filtered);
+
+    meta.handle_tools_list(RequestId::Number(7004));
+
+    assert!(global_shadow_count(filtered) > before);
+}
+
+#[test]
 fn new_matches_featureless_constructor_defaults() {
     let backends = Arc::new(BackendRegistry::new());
     let from_new = MetaMcp::new(Arc::clone(&backends));

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -188,23 +188,14 @@ fn tools_list_wiring_records_real_cache_scope_inputs() {
 
 #[test]
 fn static_code_mode_does_not_claim_profile_or_session_filtering() {
-    use crate::protocol_revision_telemetry::{ListFilters, global_shadow_count};
-
     let meta = make_meta_mcp_code_mode();
     meta.session_profiles
         .set_profile("code-mode-session", "non-default");
-    let unfiltered = ListFilters::default();
-    let incorrectly_filtered = ListFilters {
-        profile: true,
-        ..ListFilters::default()
-    };
-    let before_unfiltered = global_shadow_count(unfiltered);
-    let before_filtered = global_shadow_count(incorrectly_filtered);
+    let shadow = meta.shadow_tools_list_assembly(Some("code-mode-session"), false);
 
-    meta.handle_tools_list_for_session(RequestId::Number(7003), Some("code-mode-session"));
-
-    assert!(global_shadow_count(unfiltered) > before_unfiltered);
-    assert_eq!(global_shadow_count(incorrectly_filtered), before_filtered);
+    assert!(!shadow.profile);
+    assert!(!shadow.session);
+    assert!(!shadow.request);
 }
 
 #[test]

--- a/src/gateway/router/backend_handlers.rs
+++ b/src/gateway/router/backend_handlers.rs
@@ -482,6 +482,21 @@ pub(super) async fn backend_handler(
         }
     };
 
+    let protocol_header = inbound_headers
+        .get("mcp-protocol-version")
+        .and_then(|value| value.to_str().ok());
+    let session_id = inbound_headers
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok());
+    crate::protocol_revision_telemetry::observe_inbound_request(
+        &json_request,
+        params.as_ref(),
+        &method,
+        protocol_header,
+        session_id,
+        crate::protocol_revision_telemetry::Transport::Http,
+    );
+
     debug!(backend = %name, method = %method, client = ?client.as_ref().map(|c| &c.name), "Backend request");
 
     // Handle notifications - forward to backend but return 202 Accepted.

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -516,13 +516,15 @@ pub(super) async fn meta_mcp_handler(
     }
 
     let inbound_meta = crate::protocol_revision_telemetry::request_meta(&request, params.as_ref());
-    if method != "initialize" {
-        crate::protocol_revision_telemetry::observe_inbound(
-            session_id.as_str(),
-            None,
-            inbound_meta,
-        );
-    }
+    crate::protocol_revision_telemetry::observe_inbound(
+        session_id.as_str(),
+        if method == "initialize" {
+            params.as_ref()
+        } else {
+            None
+        },
+        inbound_meta,
+    );
 
     // For requests, id is guaranteed to exist (checked in parse_request)
     let id = id.expect("id should exist for non-notification requests");
@@ -541,22 +543,12 @@ pub(super) async fn meta_mcp_handler(
             Some(session_id.as_str()),
             header_profile.as_deref(),
         ),
-        "tools/list" => {
-            let profile_bound = header_profile.is_some();
-            crate::protocol_revision_telemetry::observe_tools_list(
-                crate::protocol_revision_telemetry::ListFilters {
-                    principal: client.is_some(),
-                    profile: profile_bound,
-                    session: true,
-                },
-            );
-            state.meta_mcp.handle_tools_list_with_url_override(
-                id,
-                params.as_ref(),
-                Some(session_id.as_str()),
-                code_mode_url_active,
-            )
-        }
+        "tools/list" => state.meta_mcp.handle_tools_list_with_url_override(
+            id,
+            params.as_ref(),
+            Some(session_id.as_str()),
+            code_mode_url_active,
+        ),
         "tools/call" => {
             let (tool_name, arguments) = extract_tools_call_params(params.as_ref());
 

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -516,16 +516,6 @@ pub(super) async fn meta_mcp_handler(
     }
 
     let inbound_meta = crate::protocol_revision_telemetry::request_meta(&request, params.as_ref());
-    crate::protocol_revision_telemetry::observe_inbound(
-        session_id.as_str(),
-        if method == "initialize" {
-            params.as_ref()
-        } else {
-            None
-        },
-        inbound_meta,
-    );
-
     // For requests, id is guaranteed to exist (checked in parse_request)
     let id = id.expect("id should exist for non-notification requests");
 
@@ -537,11 +527,13 @@ pub(super) async fn meta_mcp_handler(
 
     // Route to appropriate handler
     let response = match method.as_str() {
-        "initialize" => state.meta_mcp.handle_initialize(
+        "initialize" => state.meta_mcp.handle_initialize_for_transport(
             id,
             params.as_ref(),
+            inbound_meta,
             Some(session_id.as_str()),
             header_profile.as_deref(),
+            crate::protocol_revision_telemetry::Transport::Http,
         ),
         "tools/list" => state.meta_mcp.handle_tools_list_with_url_override(
             id,

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -515,6 +515,15 @@ pub(super) async fn meta_mcp_handler(
         return build_accepted_response(&session_id);
     }
 
+    let inbound_meta = crate::protocol_revision_telemetry::request_meta(&request, params.as_ref());
+    if method != "initialize" {
+        crate::protocol_revision_telemetry::observe_inbound(
+            session_id.as_str(),
+            None,
+            inbound_meta,
+        );
+    }
+
     // For requests, id is guaranteed to exist (checked in parse_request)
     let id = id.expect("id should exist for non-notification requests");
 
@@ -532,12 +541,22 @@ pub(super) async fn meta_mcp_handler(
             Some(session_id.as_str()),
             header_profile.as_deref(),
         ),
-        "tools/list" => state.meta_mcp.handle_tools_list_with_url_override(
-            id,
-            params.as_ref(),
-            Some(session_id.as_str()),
-            code_mode_url_active,
-        ),
+        "tools/list" => {
+            let profile_bound = header_profile.is_some();
+            crate::protocol_revision_telemetry::observe_tools_list(
+                crate::protocol_revision_telemetry::ListFilters {
+                    principal: client.is_some(),
+                    profile: profile_bound,
+                    session: true,
+                },
+            );
+            state.meta_mcp.handle_tools_list_with_url_override(
+                id,
+                params.as_ref(),
+                Some(session_id.as_str()),
+                code_mode_url_active,
+            )
+        }
         "tools/call" => {
             let (tool_name, arguments) = extract_tools_call_params(params.as_ref());
 

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -507,6 +507,18 @@ pub(super) async fn meta_mcp_handler(
         }
     };
 
+    let protocol_header = headers
+        .get("mcp-protocol-version")
+        .and_then(|value| value.to_str().ok());
+    crate::protocol_revision_telemetry::observe_inbound_request(
+        &request,
+        params.as_ref(),
+        &method,
+        protocol_header,
+        Some(session_id.as_str()),
+        crate::protocol_revision_telemetry::Transport::Http,
+    );
+
     debug!(method = %method, session_id = %session_id, "Meta-MCP request");
 
     // Handle notifications (no id) - return 202 Accepted with empty body
@@ -515,7 +527,6 @@ pub(super) async fn meta_mcp_handler(
         return build_accepted_response(&session_id);
     }
 
-    let inbound_meta = crate::protocol_revision_telemetry::request_meta(&request, params.as_ref());
     // For requests, id is guaranteed to exist (checked in parse_request)
     let id = id.expect("id should exist for non-notification requests");
 
@@ -527,13 +538,11 @@ pub(super) async fn meta_mcp_handler(
 
     // Route to appropriate handler
     let response = match method.as_str() {
-        "initialize" => state.meta_mcp.handle_initialize_for_transport(
+        "initialize" => state.meta_mcp.handle_initialize(
             id,
             params.as_ref(),
-            inbound_meta,
             Some(session_id.as_str()),
             header_profile.as_deref(),
-            crate::protocol_revision_telemetry::Transport::Http,
         ),
         "tools/list" => state.meta_mcp.handle_tools_list_with_url_override(
             id,

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1622,6 +1622,15 @@ impl Gateway {
             Err(response) => return Some(response.to_value_lossy()),
         };
 
+        crate::protocol_revision_telemetry::observe_inbound_request(
+            request,
+            params.as_ref(),
+            &method,
+            None,
+            Some(session_id),
+            crate::protocol_revision_telemetry::Transport::Stdio,
+        );
+
         // Notifications have no id — send no response
         if method.starts_with("notifications/") {
             debug!(notification = %method, "stdio: notification (no response)");
@@ -1634,17 +1643,8 @@ impl Gateway {
             return Some(resp.to_value_lossy());
         };
 
-        let inbound_meta =
-            crate::protocol_revision_telemetry::request_meta(request, params.as_ref());
         let response = match method.as_str() {
-            "initialize" => meta_mcp.handle_initialize_for_transport(
-                id,
-                params.as_ref(),
-                inbound_meta,
-                Some(session_id),
-                None,
-                crate::protocol_revision_telemetry::Transport::Stdio,
-            ),
+            "initialize" => meta_mcp.handle_initialize(id, params.as_ref(), Some(session_id), None),
             "tools/list" => {
                 meta_mcp.handle_tools_list_with_params(id, params.as_ref(), Some(session_id))
             }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1554,12 +1554,13 @@ impl Gateway {
 
             // Handle batch requests (array of JSON-RPC calls)
             if request.is_array() {
-                let responses = Self::dispatch_batch(
+                let responses = Self::dispatch_batch_with_sink(
                     &meta_mcp,
                     &tool_policy,
                     &mtls_policy,
                     request,
                     session_id,
+                    &mut protocol_telemetry_sink,
                 )
                 .await;
                 Self::persist_stdio_protocol_telemetry(&mut protocol_telemetry_sink);
@@ -1571,9 +1572,15 @@ impl Gateway {
             }
 
             // Single request
-            let response_opt =
-                Self::dispatch_single(&meta_mcp, &tool_policy, &mtls_policy, &request, session_id)
-                    .await;
+            let response_opt = Self::dispatch_single_with_sink(
+                &meta_mcp,
+                &tool_policy,
+                &mtls_policy,
+                &request,
+                session_id,
+                protocol_telemetry_sink.as_mut(),
+            )
+            .await;
             Self::persist_stdio_protocol_telemetry(&mut protocol_telemetry_sink);
 
             if let Some(response) = response_opt {
@@ -1639,12 +1646,36 @@ impl Gateway {
     /// Dispatch a single JSON-RPC request through `MetaMcp`.
     ///
     /// Returns `None` for notifications (no response expected per JSON-RPC spec).
+    #[cfg(test)]
     async fn dispatch_single(
         meta_mcp: &Arc<MetaMcp>,
         tool_policy: &Arc<crate::security::ToolPolicy>,
         _mtls_policy: &Arc<crate::mtls::MtlsPolicy>,
         request: &serde_json::Value,
         session_id: &str,
+    ) -> Option<serde_json::Value> {
+        Self::dispatch_single_with_sink(
+            meta_mcp,
+            tool_policy,
+            _mtls_policy,
+            request,
+            session_id,
+            None,
+        )
+        .await
+    }
+
+    /// Dispatch one stdio request, durably recording its inbound observation
+    /// before any handler can await, fail, or terminate the process.
+    async fn dispatch_single_with_sink(
+        meta_mcp: &Arc<MetaMcp>,
+        tool_policy: &Arc<crate::security::ToolPolicy>,
+        _mtls_policy: &Arc<crate::mtls::MtlsPolicy>,
+        request: &serde_json::Value,
+        session_id: &str,
+        protocol_telemetry_sink: Option<
+            &mut crate::protocol_revision_telemetry::DurableTelemetrySink,
+        >,
     ) -> Option<serde_json::Value> {
         use super::router::helpers::{extract_tools_call_params, parse_request};
         use crate::protocol::JsonRpcResponse;
@@ -1662,6 +1693,14 @@ impl Gateway {
             Some(session_id),
             crate::protocol_revision_telemetry::Transport::Stdio,
         );
+        if let Some(sink) = protocol_telemetry_sink
+            && let Err(error) = sink.persist_global()
+        {
+            warn!(
+                %error,
+                "failed to persist inbound stdio protocol-revision observation; measurement window is incomplete"
+            );
+        }
 
         // Notifications have no id — send no response
         if method.starts_with("notifications/") {
@@ -1742,12 +1781,35 @@ impl Gateway {
     }
 
     /// Dispatch a JSON-RPC batch request.
+    #[cfg(test)]
     async fn dispatch_batch(
         meta_mcp: &Arc<MetaMcp>,
         tool_policy: &Arc<crate::security::ToolPolicy>,
         mtls_policy: &Arc<crate::mtls::MtlsPolicy>,
         batch: serde_json::Value,
         session_id: &str,
+    ) -> Vec<serde_json::Value> {
+        let mut sink = None;
+        Self::dispatch_batch_with_sink(
+            meta_mcp,
+            tool_policy,
+            mtls_policy,
+            batch,
+            session_id,
+            &mut sink,
+        )
+        .await
+    }
+
+    async fn dispatch_batch_with_sink(
+        meta_mcp: &Arc<MetaMcp>,
+        tool_policy: &Arc<crate::security::ToolPolicy>,
+        mtls_policy: &Arc<crate::mtls::MtlsPolicy>,
+        batch: serde_json::Value,
+        session_id: &str,
+        protocol_telemetry_sink: &mut Option<
+            crate::protocol_revision_telemetry::DurableTelemetrySink,
+        >,
     ) -> Vec<serde_json::Value> {
         let Some(requests) = batch.as_array() else {
             return vec![
@@ -1765,8 +1827,15 @@ impl Gateway {
 
         let mut responses = Vec::new();
         for req in requests {
-            if let Some(resp) =
-                Self::dispatch_single(meta_mcp, tool_policy, mtls_policy, req, session_id).await
+            if let Some(resp) = Self::dispatch_single_with_sink(
+                meta_mcp,
+                tool_policy,
+                mtls_policy,
+                req,
+                session_id,
+                protocol_telemetry_sink.as_mut(),
+            )
+            .await
             {
                 responses.push(resp);
             }
@@ -2378,7 +2447,7 @@ mod tests {
         );
         Gateway::persist_stdio_protocol_telemetry(&mut sink);
 
-        Gateway::dispatch_single(
+        Gateway::dispatch_single_with_sink(
             &test_meta_mcp(),
             &test_tool_policy(),
             &test_mtls_policy(),
@@ -2392,10 +2461,10 @@ mod tests {
                 }
             }),
             "stdio-durable-window-test",
+            sink.as_mut(),
         )
         .await
         .expect("initialize returns a response");
-        Gateway::persist_stdio_protocol_telemetry(&mut sink);
 
         let window = crate::protocol_revision_telemetry::load_durable_window(data_dir.path())
             .expect("load durable stdio aggregate");

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1636,18 +1636,15 @@ impl Gateway {
 
         let inbound_meta =
             crate::protocol_revision_telemetry::request_meta(request, params.as_ref());
-        crate::protocol_revision_telemetry::observe_inbound(
-            session_id,
-            if method == "initialize" {
-                params.as_ref()
-            } else {
-                None
-            },
-            inbound_meta,
-        );
-
         let response = match method.as_str() {
-            "initialize" => meta_mcp.handle_initialize(id, params.as_ref(), Some(session_id), None),
+            "initialize" => meta_mcp.handle_initialize_for_transport(
+                id,
+                params.as_ref(),
+                inbound_meta,
+                Some(session_id),
+                None,
+                crate::protocol_revision_telemetry::Transport::Stdio,
+            ),
             "tools/list" => {
                 meta_mcp.handle_tools_list_with_params(id, params.as_ref(), Some(session_id))
             }
@@ -2297,6 +2294,59 @@ mod tests {
 
         assert_eq!(response["error"]["code"], -32600);
         assert_eq!(response["error"]["message"], "Missing id");
+    }
+
+    #[tokio::test]
+    async fn stdio_initialize_records_requested_and_negotiated_revisions() {
+        let before = crate::protocol_revision_telemetry::global_snapshot();
+        let response = Gateway::dispatch_single(
+            &test_meta_mcp(),
+            &test_tool_policy(),
+            &test_mtls_policy(),
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 7218,
+                "method": "initialize",
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {"name": "Claude Code"}
+                },
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "clientInfo": {"name": "ignored-by-meta"}
+                }
+            }),
+            "stdio-session-mik-7218",
+        )
+        .await
+        .expect("initialize returns a response");
+
+        assert_eq!(response["result"]["protocolVersion"], "2025-06-18");
+        let after = crate::protocol_revision_telemetry::global_snapshot();
+        assert!(
+            after.by_revision.get("2026-07-28").copied().unwrap_or(0)
+                > before.by_revision.get("2026-07-28").copied().unwrap_or(0)
+        );
+        assert!(
+            after
+                .by_negotiated_revision
+                .get("2025-06-18")
+                .copied()
+                .unwrap_or(0)
+                > before
+                    .by_negotiated_revision
+                    .get("2025-06-18")
+                    .copied()
+                    .unwrap_or(0)
+        );
+        assert!(
+            after.by_transport.get("stdio").copied().unwrap_or(0)
+                > before.by_transport.get("stdio").copied().unwrap_or(0)
+        );
+        assert!(
+            after.by_client.get("claude").copied().unwrap_or(0)
+                > before.by_client.get("claude").copied().unwrap_or(0)
+        );
     }
 
     // ── MIK-7252: stdio authorization ──────────────────────────────────────

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1637,6 +1637,13 @@ impl Gateway {
         let response = match method.as_str() {
             "initialize" => meta_mcp.handle_initialize(id, params.as_ref(), Some(session_id), None),
             "tools/list" => {
+                crate::protocol_revision_telemetry::observe_tools_list(
+                    crate::protocol_revision_telemetry::ListFilters {
+                        principal: false,
+                        profile: false,
+                        session: true,
+                    },
+                );
                 meta_mcp.handle_tools_list_with_params(id, params.as_ref(), Some(session_id))
             }
             "tools/call" => {

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1634,16 +1634,21 @@ impl Gateway {
             return Some(resp.to_value_lossy());
         };
 
+        let inbound_meta =
+            crate::protocol_revision_telemetry::request_meta(request, params.as_ref());
+        crate::protocol_revision_telemetry::observe_inbound(
+            session_id,
+            if method == "initialize" {
+                params.as_ref()
+            } else {
+                None
+            },
+            inbound_meta,
+        );
+
         let response = match method.as_str() {
             "initialize" => meta_mcp.handle_initialize(id, params.as_ref(), Some(session_id), None),
             "tools/list" => {
-                crate::protocol_revision_telemetry::observe_tools_list(
-                    crate::protocol_revision_telemetry::ListFilters {
-                        principal: false,
-                        profile: false,
-                        session: true,
-                    },
-                );
                 meta_mcp.handle_tools_list_with_params(id, params.as_ref(), Some(session_id))
             }
             "tools/call" => {

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -744,7 +744,10 @@ impl Gateway {
 
         // Install Prometheus metrics recorder (no-op when feature is disabled).
         #[cfg(feature = "metrics")]
-        crate::metrics::install();
+        {
+            crate::metrics::install();
+            crate::protocol_revision_telemetry::register_metrics();
+        }
 
         // ── Shared MetaMcp initialisation ────────────────────────────────────
         let BuiltMetaMcp {

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1460,8 +1460,21 @@ impl Gateway {
             meta_mcp,
             tool_policy,
             mtls_policy,
+            data_dir,
             ..
         } = self.build_meta_mcp().await?;
+        let mut protocol_telemetry_sink =
+            match crate::protocol_revision_telemetry::DurableTelemetrySink::open(&data_dir) {
+                Ok(sink) => Some(sink),
+                Err(error) => {
+                    warn!(
+                        %error,
+                        data_dir = %data_dir.display(),
+                        "stdio protocol-revision telemetry is not durable; do not start the measurement window"
+                    );
+                    None
+                }
+            };
 
         if self.config.capabilities.enabled {
             let executor = Arc::new(CapabilityExecutor::new());
@@ -1549,6 +1562,7 @@ impl Gateway {
                     session_id,
                 )
                 .await;
+                Self::persist_stdio_protocol_telemetry(&mut protocol_telemetry_sink);
                 if !responses.is_empty() {
                     let batch_resp = serde_json::Value::Array(responses);
                     Self::write_response(&mut stdout, &batch_resp).await;
@@ -1560,6 +1574,7 @@ impl Gateway {
             let response_opt =
                 Self::dispatch_single(&meta_mcp, &tool_policy, &mtls_policy, &request, session_id)
                     .await;
+            Self::persist_stdio_protocol_telemetry(&mut protocol_telemetry_sink);
 
             if let Some(response) = response_opt {
                 Self::write_response(&mut stdout, &response).await;
@@ -1567,6 +1582,7 @@ impl Gateway {
         }
 
         info!("stdio: EOF reached, shutting down");
+        Self::persist_stdio_protocol_telemetry(&mut protocol_telemetry_sink);
         // Stop sweeping and probing before tearing the backends down. Both tasks
         // hold an Arc on the registry and have no shutdown channel in this mode,
         // so leaving either running keeps the registry alive after run_stdio
@@ -1582,6 +1598,19 @@ impl Gateway {
         warm_start_tasks.cancel().await;
         self.backends.stop_all().await;
         Ok(())
+    }
+
+    fn persist_stdio_protocol_telemetry(
+        sink: &mut Option<crate::protocol_revision_telemetry::DurableTelemetrySink>,
+    ) {
+        if let Some(sink) = sink
+            && let Err(error) = sink.persist_global()
+        {
+            warn!(
+                %error,
+                "failed to persist stdio protocol-revision telemetry; measurement window is incomplete"
+            );
+        }
     }
 
     /// Write a JSON-RPC response to stdout followed by a newline.
@@ -2337,6 +2366,57 @@ mod tests {
         assert!(
             after.by_client.get("claude").copied().unwrap_or(0)
                 > before.by_client.get("claude").copied().unwrap_or(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn stdio_dispatch_persists_operator_readable_protocol_counters() {
+        let data_dir = tempfile::tempdir().expect("temporary data directory");
+        let mut sink = Some(
+            crate::protocol_revision_telemetry::DurableTelemetrySink::open(data_dir.path())
+                .expect("open durable telemetry sink"),
+        );
+        Gateway::persist_stdio_protocol_telemetry(&mut sink);
+
+        Gateway::dispatch_single(
+            &test_meta_mcp(),
+            &test_tool_policy(),
+            &test_mtls_policy(),
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 7219,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "clientInfo": {"name": "Codex"}
+                }
+            }),
+            "stdio-durable-window-test",
+        )
+        .await
+        .expect("initialize returns a response");
+        Gateway::persist_stdio_protocol_telemetry(&mut sink);
+
+        let window = crate::protocol_revision_telemetry::load_durable_window(data_dir.path())
+            .expect("load durable stdio aggregate");
+        assert!(window.snapshot.total >= 1);
+        assert!(
+            window
+                .snapshot
+                .by_transport
+                .get("stdio")
+                .copied()
+                .unwrap_or(0)
+                >= 1
+        );
+        assert!(
+            window
+                .snapshot
+                .by_revision
+                .get("2025-11-25")
+                .copied()
+                .unwrap_or(0)
+                >= 1
         );
     }
 

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -2297,7 +2297,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stdio_initialize_records_requested_and_negotiated_revisions() {
+    async fn stdio_initialize_records_requested_revision() {
         let before = crate::protocol_revision_telemetry::global_snapshot();
         let response = Gateway::dispatch_single(
             &test_meta_mcp(),
@@ -2326,18 +2326,6 @@ mod tests {
         assert!(
             after.by_revision.get("2026-07-28").copied().unwrap_or(0)
                 > before.by_revision.get("2026-07-28").copied().unwrap_or(0)
-        );
-        assert!(
-            after
-                .by_negotiated_revision
-                .get("2025-06-18")
-                .copied()
-                .unwrap_or(0)
-                > before
-                    .by_negotiated_revision
-                    .get("2025-06-18")
-                    .copied()
-                    .unwrap_or(0)
         );
         assert!(
             after.by_transport.get("stdio").copied().unwrap_or(0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod playbook;
 pub mod projection;
 pub mod protocol;
 pub mod protocol_imports;
+pub mod protocol_revision_telemetry;
 pub mod provider;
 pub mod ranking;
 pub mod registry;

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -248,6 +248,7 @@ pub struct DurableTelemetrySink {
     lock_path: PathBuf,
     previous_snapshot: Snapshot,
     previous_shadow: BTreeMap<String, u64>,
+    parent_sync_pending: bool,
 }
 
 impl DurableTelemetrySink {
@@ -264,6 +265,7 @@ impl DurableTelemetrySink {
                 read_window_file(&window_path)?;
             } else {
                 write_window_atomic(&window_path, &DurableWindow::empty(unix_seconds()?))?;
+                sync_parent_directory(&window_path)?;
             }
         }
         Ok(Self {
@@ -271,6 +273,7 @@ impl DurableTelemetrySink {
             lock_path,
             previous_snapshot: Snapshot::default(),
             previous_shadow: empty_shadow_counts(),
+            parent_sync_pending: false,
         })
     }
 
@@ -300,9 +303,23 @@ impl DurableTelemetrySink {
         current_shadow: BTreeMap<String, u64>,
         now: u64,
     ) -> io::Result<()> {
+        self.persist_with_parent_sync(current, current_shadow, now, sync_parent_directory)
+    }
+
+    fn persist_with_parent_sync(
+        &mut self,
+        current: Snapshot,
+        current_shadow: BTreeMap<String, u64>,
+        now: u64,
+        sync_parent: impl FnOnce(&Path) -> io::Result<()>,
+    ) -> io::Result<()> {
         let snapshot_delta = snapshot_delta(&current, &self.previous_snapshot);
         let shadow_delta = map_delta(&current_shadow, &self.previous_shadow);
         if snapshot_delta.total == 0 && shadow_delta.values().all(|count| *count == 0) {
+            if self.parent_sync_pending {
+                sync_parent(&self.window_path)?;
+                self.parent_sync_pending = false;
+            }
             return Ok(());
         }
 
@@ -313,9 +330,11 @@ impl DurableTelemetrySink {
         window.updated_at_unix_seconds = window.updated_at_unix_seconds.max(now);
         validate_window(&window)?;
         write_window_atomic(&self.window_path, &window)?;
-
         self.previous_snapshot = current;
         self.previous_shadow = current_shadow;
+        self.parent_sync_pending = true;
+        sync_parent(&self.window_path)?;
+        self.parent_sync_pending = false;
         Ok(())
     }
 }
@@ -802,10 +821,6 @@ fn unix_seconds() -> io::Result<u64> {
 fn write_window_atomic(path: &Path, window: &DurableWindow) -> io::Result<()> {
     let bytes = serde_json::to_vec_pretty(window)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    #[cfg(unix)]
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "window has no parent"))?;
     let temporary = path.with_extension("json.tmp");
     {
         let mut options = OpenOptions::new();
@@ -818,8 +833,19 @@ fn write_window_atomic(path: &Path, window: &DurableWindow) -> io::Result<()> {
         file.sync_all()?;
     }
     std::fs::rename(&temporary, path)?;
-    #[cfg(unix)]
-    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "window has no parent"))?;
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
@@ -1355,6 +1381,42 @@ mod tests {
                 session: true,
                 request: false,
             }),
+            1
+        );
+    }
+
+    #[test]
+    fn committed_window_is_not_counted_twice_after_parent_sync_failure() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let mut sink = DurableTelemetrySink::open(directory.path()).expect("durable sink");
+        let mut registry = Registry::new();
+        registry.observe_request(Some("2025-11-25"), "codex", Transport::Stdio);
+
+        let error = sink
+            .persist_with_parent_sync(registry.snapshot(), registry.shadow_snapshot(), 1, |_| {
+                Err(io::Error::other("injected parent sync failure"))
+            })
+            .expect_err("parent sync must fail after the rename");
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(sink.parent_sync_pending);
+        assert_eq!(
+            load_durable_window(directory.path())
+                .unwrap()
+                .snapshot
+                .total,
+            1
+        );
+
+        sink.persist_with_parent_sync(registry.snapshot(), registry.shadow_snapshot(), 2, |_| {
+            Ok(())
+        })
+        .expect("retry pending parent sync");
+        assert!(!sink.parent_sync_pending);
+        assert_eq!(
+            load_durable_window(directory.path())
+                .unwrap()
+                .snapshot
+                .total,
             1
         );
     }

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -556,6 +556,18 @@ pub fn request_meta<'a>(request: &'a Value, params: Option<&'a Value>) -> Option
         .or_else(|| params.and_then(|p| p.get("_meta")))
 }
 
+/// Resolve one `_meta` field with root-level precedence and per-field fallback.
+fn request_meta_value<'a>(
+    request: &'a Value,
+    params: Option<&'a Value>,
+    key: &str,
+) -> Option<&'a Value> {
+    request
+        .get("_meta")
+        .and_then(|meta| meta.get(key))
+        .or_else(|| params.and_then(|p| p.get("_meta"))?.get(key))
+}
+
 /// Decision table from RFC-0060: public only for the unfiltered skeleton.
 pub fn cache_scope_decision(filters: ListFilters) -> CacheScope {
     if filters.any() {
@@ -936,12 +948,18 @@ pub fn observe_inbound_request(
     if method.starts_with("notifications/") {
         return;
     }
-    let meta = request_meta(request, params);
     let initialize_params = (method == "initialize").then_some(params).flatten();
-    let explicit_requested = requested_revision(initialize_params, meta)
+    let explicit_requested = request_meta_value(request, params, META_PROTOCOL_VERSION)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| requested_revision(initialize_params, None))
         .or_else(|| protocol_header.map(str::trim).map(str::to_string))
         .filter(|value| !value.is_empty());
-    let explicit_client = client_identity(initialize_params, meta);
+    let explicit_client = client_info_name(request_meta_value(request, params, META_CLIENT_INFO))
+        .or_else(|| client_info_name(initialize_params.and_then(|p| p.get("clientInfo"))))
+        .unwrap_or_else(|| UNATTRIBUTED_CLIENT.to_string());
 
     let mut reg = global()
         .lock()

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -802,6 +802,7 @@ fn unix_seconds() -> io::Result<u64> {
 fn write_window_atomic(path: &Path, window: &DurableWindow) -> io::Result<()> {
     let bytes = serde_json::to_vec_pretty(window)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    #[cfg(unix)]
     let parent = path
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "window has no parent"))?;

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -442,7 +442,9 @@ pub fn observe_inbound_request(
     let mut reg = global()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let previous = reg.session_attribution(session_id);
+    let previous = (transport == Transport::Stdio)
+        .then(|| reg.session_attribution(session_id))
+        .flatten();
     let requested_label = revision_label(explicit_requested.as_deref())
         .or_else(|| previous.and_then(|item| item.requested_revision));
     let client = if explicit_client == UNATTRIBUTED_CLIENT {
@@ -450,7 +452,8 @@ pub fn observe_inbound_request(
     } else {
         client_label(&explicit_client)
     };
-    if method == "initialize"
+    if transport == Transport::Stdio
+        && method == "initialize"
         && let Some(session_id) = session_id
     {
         reg.bind_session(
@@ -733,6 +736,40 @@ mod tests {
             after.by_revision.get("2025-06-18").copied().unwrap_or(0)
                 >= before.by_revision.get("2025-06-18").copied().unwrap_or(0) + 2
         );
+    }
+
+    #[test]
+    fn http_request_without_revision_does_not_reuse_session_attribution() {
+        let session_id = "mik-7218-http-is-request-scoped";
+        let initialize = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "clientInfo": {"name": "Claude Desktop"}
+            }
+        });
+        observe_inbound_request(
+            &initialize,
+            initialize.get("params"),
+            "initialize",
+            None,
+            Some(session_id),
+            Transport::Stdio,
+        );
+        let before = global_snapshot();
+        let request = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
+        observe_inbound_request(
+            &request,
+            None,
+            "tools/list",
+            None,
+            Some(session_id),
+            Transport::Http,
+        );
+        let after = global_snapshot();
+        assert!(after.unattributed > before.unattributed);
     }
 
     #[test]

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -126,7 +126,6 @@ pub struct ToolsListShadow {
 #[derive(Debug, Clone, Copy)]
 struct SessionAttribution {
     requested_revision: Option<&'static str>,
-    negotiated_revision: &'static str,
     client: &'static str,
 }
 
@@ -135,7 +134,6 @@ struct SessionAttribution {
 pub struct Registry {
     /// Requested revisions. Kept as `by_revision` for the pre-registered table.
     by_revision: BTreeMap<String, u64>,
-    by_negotiated_revision: BTreeMap<String, u64>,
     by_client: BTreeMap<String, u64>,
     by_transport: BTreeMap<String, u64>,
     unattributed: u64,
@@ -148,17 +146,15 @@ pub struct Registry {
 /// Snapshot for `/metrics` tests and the Linear table.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Snapshot {
-    /// Sessions whose revision was named on the wire.
+    /// Requests whose revision was named on the wire.
     pub by_revision: BTreeMap<String, u64>,
-    /// Sessions grouped by the revision the gateway actually served.
-    pub by_negotiated_revision: BTreeMap<String, u64>,
-    /// Sessions grouped by client identity (includes `unattributed`).
+    /// Requests grouped by client identity (includes `unattributed`).
     pub by_client: BTreeMap<String, u64>,
-    /// Sessions grouped by the bounded transport label.
+    /// Requests grouped by the bounded transport label.
     pub by_transport: BTreeMap<String, u64>,
-    /// Sessions with no revision on either path. Own series, not a revision key.
+    /// Requests with no revision on either path. Own series, not a revision key.
     pub unattributed: u64,
-    /// All observed sessions, attributed or not.
+    /// All observed requests, attributed or not.
     pub total: u64,
 }
 
@@ -172,7 +168,6 @@ impl Registry {
     pub fn observe_request(
         &mut self,
         requested_revision: Option<&str>,
-        negotiated_revision: &str,
         client: &str,
         transport: Transport,
     ) {
@@ -182,11 +177,6 @@ impl Registry {
         *self
             .by_transport
             .entry(transport.as_str().to_string())
-            .or_insert(0) += 1;
-        let negotiated = revision_label(Some(negotiated_revision)).unwrap_or(OTHER_REVISION);
-        *self
-            .by_negotiated_revision
-            .entry(negotiated.to_string())
             .or_insert(0) += 1;
         match revision_label(requested_revision) {
             Some(rev) => {
@@ -233,7 +223,6 @@ impl Registry {
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
             by_revision: self.by_revision.clone(),
-            by_negotiated_revision: self.by_negotiated_revision.clone(),
             by_client: self.by_client.clone(),
             by_transport: self.by_transport.clone(),
             unattributed: self.unattributed,
@@ -355,7 +344,7 @@ pub fn public_over_filtered(filters: ListFilters, scope: CacheScope) -> bool {
     scope == CacheScope::Public && filters.any()
 }
 
-/// Attributed sessions / total. Empty window is 0.0, not NaN.
+/// Attributed requests / total. Empty window is 0.0, not NaN.
 pub fn attribution_rate(snapshot: &Snapshot) -> f64 {
     if snapshot.total == 0 {
         return 0.0;
@@ -389,7 +378,7 @@ pub fn retire_revisions(snapshot: &Snapshot, elapsed: Duration) -> Vec<String> {
 
 /// Markdown table for the Linear comment. Unattributed is its own row, not a revision.
 pub fn distribution_table(snapshot: &Snapshot) -> String {
-    let mut rows = String::from("| revision | sessions | share |\n| --- | ---: | ---: |\n");
+    let mut rows = String::from("| revision | requests | share |\n| --- | ---: | ---: |\n");
     for (rev, n) in &snapshot.by_revision {
         writeln!(rows, "| {rev} | {n} | {:.1}% |", share(*n, snapshot.total))
             .expect("writing to a String cannot fail");
@@ -461,20 +450,6 @@ pub fn observe_inbound_request(
     } else {
         client_label(&explicit_client)
     };
-    let negotiated_label = if method == "initialize" {
-        let client_version = initialize_params
-            .and_then(|value| value.get("protocolVersion"))
-            .and_then(Value::as_str)
-            .unwrap_or(crate::protocol::PROTOCOL_VERSION);
-        revision_label(Some(crate::protocol::negotiate_version(client_version)))
-            .unwrap_or(OTHER_REVISION)
-    } else {
-        previous
-            .map(|item| item.negotiated_revision)
-            .or(requested_label)
-            .unwrap_or(OTHER_REVISION)
-    };
-
     if method == "initialize"
         && let Some(session_id) = session_id
     {
@@ -482,17 +457,15 @@ pub fn observe_inbound_request(
             session_id,
             SessionAttribution {
                 requested_revision: requested_label,
-                negotiated_revision: negotiated_label,
                 client,
             },
         );
     }
-    reg.observe_request(requested_label, negotiated_label, client, transport);
+    reg.observe_request(requested_label, client, transport);
     drop(reg);
-    emit_session_metrics(requested_label, negotiated_label, client, transport);
+    emit_request_metrics(requested_label, client, transport);
     tracing::info!(
         requested_revision = requested_label.unwrap_or("unattributed"),
-        negotiated_revision = negotiated_label,
         client,
         transport = transport.as_str(),
         "mcp728.u1 inbound request observation"
@@ -549,20 +522,14 @@ pub fn global_shadow_count(filters: ListFilters) -> u64 {
         .shadow_count(filters)
 }
 
-fn emit_session_metrics(
-    requested_revision: Option<&str>,
-    negotiated_revision: &str,
-    client: &str,
-    transport: Transport,
-) {
-    let _ = (requested_revision, negotiated_revision, client, transport);
+fn emit_request_metrics(requested_revision: Option<&str>, client: &str, transport: Transport) {
+    let _ = (requested_revision, client, transport);
     #[cfg(feature = "metrics")]
     {
         if let Some(rev) = requested_revision {
             telemetry_metrics::counter!(
                 "mcp_protocol_revision_observations_total",
                 "requested_revision" => rev.to_string(),
-                "negotiated_revision" => negotiated_revision.to_string(),
                 "client" => client.to_string(),
                 "transport" => transport.as_str()
             )
@@ -570,7 +537,6 @@ fn emit_session_metrics(
         } else {
             telemetry_metrics::counter!(
                 "mcp_protocol_revision_unattributed_observations_total",
-                "negotiated_revision" => negotiated_revision.to_string(),
                 "client" => client.to_string(),
                 "transport" => transport.as_str()
             )
@@ -623,18 +589,12 @@ mod tests {
     #[test]
     fn unattributed_is_its_own_series() {
         let mut reg = Registry::new();
-        reg.observe_request(
-            Some("2025-11-25"),
-            "2025-11-25",
-            "claude-desktop",
-            Transport::Http,
-        );
-        reg.observe_request(None, "2025-11-25", "unknown", Transport::Stdio);
+        reg.observe_request(Some("2025-11-25"), "claude-desktop", Transport::Http);
+        reg.observe_request(None, "unknown", Transport::Stdio);
         let snap = reg.snapshot();
         assert_eq!(snap.total, 2);
         assert_eq!(snap.unattributed, 1);
         assert_eq!(snap.by_revision.get("2025-11-25"), Some(&1));
-        assert_eq!(snap.by_negotiated_revision.get("2025-11-25"), Some(&2));
         assert_eq!(snap.by_client.get("claude"), Some(&1));
         assert_eq!(snap.by_client.get("other"), Some(&1));
         assert_eq!(snap.by_transport.get("http"), Some(&1));
@@ -652,7 +612,6 @@ mod tests {
         for i in 0..100 {
             reg.observe_request(
                 Some(&format!("attacker-revision-{i}")),
-                "attacker-negotiated",
                 &format!("attacker-client-{i}"),
                 Transport::Http,
             );
@@ -660,7 +619,6 @@ mod tests {
         let snapshot = reg.snapshot();
         assert_eq!(snapshot.by_revision.len(), 1);
         assert_eq!(snapshot.by_revision.get(OTHER_REVISION), Some(&100));
-        assert_eq!(snapshot.by_negotiated_revision.len(), 1);
         assert_eq!(snapshot.by_client.len(), 1);
         assert_eq!(snapshot.by_client.get("other"), Some(&100));
     }
@@ -687,8 +645,8 @@ mod tests {
         let empty = Registry::new().snapshot();
         assert!(retire_revisions(&empty, MIN_MEASUREMENT_WINDOW).is_empty());
         let mut low = Registry::new();
-        low.observe_request(Some("2025-06-18"), "2025-06-18", "c", Transport::Http);
-        low.observe_request(None, "2025-11-25", "c", Transport::Http);
+        low.observe_request(Some("2025-06-18"), "c", Transport::Http);
+        low.observe_request(None, "c", Transport::Http);
         // 50% attributed < 80% floor
         assert!(retire_revisions(&low.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
     }
@@ -697,9 +655,9 @@ mod tests {
     fn two_percent_rule_retires_only_below_floor_when_attributed() {
         let mut reg = Registry::new();
         for _ in 0..99 {
-            reg.observe_request(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
+            reg.observe_request(Some("2025-11-25"), "c", Transport::Http);
         }
-        reg.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+        reg.observe_request(Some("2024-11-05"), "c", Transport::Http);
         assert!(retire_revisions(&reg.snapshot(), Duration::from_secs(1)).is_empty());
         let retired = retire_revisions(&reg.snapshot(), MIN_MEASUREMENT_WINDOW);
         assert!(retired.iter().any(|r| r == "2024-11-05"));

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -40,6 +40,16 @@ pub const MEASURED_REVISIONS: &[&str] = &[
 ];
 /// Label for a present but unknown or malformed revision.
 pub const OTHER_REVISION: &str = "other";
+const MEASURED_CLIENTS: &[&str] = &[
+    UNATTRIBUTED_CLIENT,
+    "claude",
+    "codex",
+    "cursor",
+    "vscode",
+    "chatgpt",
+    "other",
+];
+const MEASURED_TRANSPORTS: &[Transport] = &[Transport::Http, Transport::Stdio, Transport::Internal];
 
 /// Inbound transport for a negotiated session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -527,6 +537,70 @@ fn emit_tools_list_metrics(filters: ListFilters, scope: CacheScope) {
         "would_emit_cache_scope" => scope.as_str()
     )
     .increment(1);
+}
+
+/// Register every bounded protocol-revision and list-shadow metric series at zero.
+///
+/// Call this after installing the recorder and before taking the baseline scrape
+/// for a measurement window. Zero registration prevents an unused revision or
+/// client family from disappearing from `increase()` queries.
+pub fn register_metrics() {
+    #[cfg(feature = "metrics")]
+    {
+        for revision in MEASURED_REVISIONS
+            .iter()
+            .copied()
+            .chain(std::iter::once(OTHER_REVISION))
+        {
+            for client in MEASURED_CLIENTS {
+                for transport in MEASURED_TRANSPORTS {
+                    telemetry_metrics::counter!(
+                        "mcp_protocol_revision_observations_total",
+                        "requested_revision" => revision,
+                        "client" => *client,
+                        "transport" => transport.as_str()
+                    )
+                    .increment(0);
+                }
+            }
+        }
+
+        for client in MEASURED_CLIENTS {
+            for transport in MEASURED_TRANSPORTS {
+                telemetry_metrics::counter!(
+                    "mcp_protocol_revision_unattributed_observations_total",
+                    "client" => *client,
+                    "transport" => transport.as_str()
+                )
+                .increment(0);
+            }
+        }
+
+        for principal in [false, true] {
+            for profile in [false, true] {
+                for session in [false, true] {
+                    for request in [false, true] {
+                        let filters = ListFilters {
+                            principal,
+                            profile,
+                            session,
+                            request,
+                        };
+                        let scope = cache_scope_decision(filters);
+                        telemetry_metrics::counter!(
+                            "mcp_tools_list_cache_scope_shadow_total",
+                            "principal" => principal.to_string(),
+                            "profile" => profile.to_string(),
+                            "session" => session.to_string(),
+                            "request" => request.to_string(),
+                            "would_emit_cache_scope" => scope.as_str()
+                        )
+                        .increment(0);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Process snapshot for the measurement table.

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -6,10 +6,11 @@
 //! Telemetry must not: that default would hide the unattributed share the
 //! ticket requires as its own series.
 //!
-//! Session-keyed: the first observation for a session id wins so initialize
-//! plus a later `_meta` stamp cannot double-count.
+//! Only successful `initialize` dispatches are counted. This avoids retaining
+//! session capability tokens and prevents id-less HTTP requests from inflating
+//! the window with synthetic sessions.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::sync::{Mutex, OnceLock};
 
@@ -25,6 +26,39 @@ pub const UNATTRIBUTED_CLIENT: &str = "unattributed";
 pub const ATTRIBUTION_FLOOR: f64 = 0.80;
 /// Pre-registered retire threshold (RFC-0060 Decision 2). Written before data.
 pub const RETIRE_BELOW_SHARE: f64 = 0.02;
+/// Revisions accepted as bounded metric labels. Everything else is `other`.
+pub const MEASURED_REVISIONS: &[&str] = &[
+    "2026-07-28",
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05",
+    "2024-10-07",
+];
+/// Label for a present but unknown or malformed revision.
+pub const OTHER_REVISION: &str = "other";
+
+/// Inbound transport for a negotiated session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    /// Streamable HTTP route.
+    Http,
+    /// Process-local stdio server.
+    Stdio,
+    /// Direct library/test caller without a transport surface.
+    Internal,
+}
+
+impl Transport {
+    /// Stable, finite metric label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Stdio => "stdio",
+            Self::Internal => "internal",
+        }
+    }
+}
 
 /// Filters that make a `tools/list` result session- or tenant-specific.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -35,12 +69,14 @@ pub struct ListFilters {
     pub profile: bool,
     /// Session-scoped assembly ran (promoted tools, session id).
     pub session: bool,
+    /// Request-local query or URL override changed the list.
+    pub request: bool,
 }
 
 impl ListFilters {
     /// True when any filter that forbids `cacheScope=public` is on.
     pub fn any(self) -> bool {
-        self.principal || self.profile || self.session
+        self.principal || self.profile || self.session || self.request
     }
 }
 
@@ -72,19 +108,23 @@ pub struct ToolsListShadow {
     pub profile: bool,
     /// Whether a session filter ran.
     pub session: bool,
+    /// Whether request-local input changed the assembled list.
+    pub request: bool,
     /// Scope the decision table would emit. Not sent to the client in this spike.
     pub would_emit_cache_scope: CacheScope,
 }
 
-/// Process-wide counters plus the session ids already counted.
+/// Process-wide counters. Every key is normalized to a finite label set.
 #[derive(Debug, Default)]
 pub struct Registry {
-    seen_sessions: HashSet<String>,
+    /// Requested revisions. Kept as `by_revision` for the pre-registered table.
     by_revision: BTreeMap<String, u64>,
+    by_negotiated_revision: BTreeMap<String, u64>,
     by_client: BTreeMap<String, u64>,
+    by_transport: BTreeMap<String, u64>,
     unattributed: u64,
     total: u64,
-    shadows: Vec<ToolsListShadow>,
+    shadow_counts: [u64; 16],
 }
 
 /// Snapshot for `/metrics` tests and the Linear table.
@@ -92,8 +132,12 @@ pub struct Registry {
 pub struct Snapshot {
     /// Sessions whose revision was named on the wire.
     pub by_revision: BTreeMap<String, u64>,
+    /// Sessions grouped by the revision the gateway actually served.
+    pub by_negotiated_revision: BTreeMap<String, u64>,
     /// Sessions grouped by client identity (includes `unattributed`).
     pub by_client: BTreeMap<String, u64>,
+    /// Sessions grouped by the bounded transport label.
+    pub by_transport: BTreeMap<String, u64>,
     /// Sessions with no revision on either path. Own series, not a revision key.
     pub unattributed: u64,
     /// All observed sessions, attributed or not.
@@ -106,30 +150,32 @@ impl Registry {
         Self::default()
     }
 
-    /// Record one inbound session. Later observations for the same id are ignored.
+    /// Record one successfully negotiated session.
     pub fn observe_session(
         &mut self,
-        session_id: &str,
-        revision: Option<&str>,
+        requested_revision: Option<&str>,
+        negotiated_revision: &str,
         client: &str,
-    ) -> bool {
-        if !self.seen_sessions.insert(session_id.to_string()) {
-            return false;
-        }
+        transport: Transport,
+    ) {
         self.total += 1;
-        let client = if client.is_empty() {
-            UNATTRIBUTED_CLIENT
-        } else {
-            client
-        };
+        let client = client_label(client);
         *self.by_client.entry(client.to_string()).or_insert(0) += 1;
-        match revision.map(str::trim).filter(|v| !v.is_empty()) {
+        *self
+            .by_transport
+            .entry(transport.as_str().to_string())
+            .or_insert(0) += 1;
+        let negotiated = revision_label(Some(negotiated_revision)).unwrap_or(OTHER_REVISION);
+        *self
+            .by_negotiated_revision
+            .entry(negotiated.to_string())
+            .or_insert(0) += 1;
+        match revision_label(requested_revision) {
             Some(rev) => {
                 *self.by_revision.entry(rev.to_string()).or_insert(0) += 1;
             }
             None => self.unattributed += 1,
         }
-        true
     }
 
     /// Shadow-log one `tools/list` (not session-deduped: every list is a cache decision).
@@ -138,9 +184,10 @@ impl Registry {
             principal: filters.principal,
             profile: filters.profile,
             session: filters.session,
+            request: filters.request,
             would_emit_cache_scope: cache_scope_decision(filters),
         };
-        self.shadows.push(shadow.clone());
+        self.shadow_counts[shadow_index(filters)] += 1;
         shadow
     }
 
@@ -148,15 +195,17 @@ impl Registry {
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
             by_revision: self.by_revision.clone(),
+            by_negotiated_revision: self.by_negotiated_revision.clone(),
             by_client: self.by_client.clone(),
+            by_transport: self.by_transport.clone(),
             unattributed: self.unattributed,
             total: self.total,
         }
     }
 
-    /// Shadow log, oldest first.
-    pub fn shadows(&self) -> &[ToolsListShadow] {
-        &self.shadows
+    /// Count for one of the finite `tools/list` filter combinations.
+    pub fn shadow_count(&self, filters: ListFilters) -> u64 {
+        self.shadow_counts[shadow_index(filters)]
     }
 
     #[cfg(test)]
@@ -164,6 +213,13 @@ impl Registry {
     fn reset(&mut self) {
         *self = Self::default();
     }
+}
+
+fn shadow_index(filters: ListFilters) -> usize {
+    usize::from(filters.principal)
+        | (usize::from(filters.profile) << 1)
+        | (usize::from(filters.session) << 2)
+        | (usize::from(filters.request) << 3)
 }
 
 /// Revision the client asked for. `_meta` wins when both are present.
@@ -178,7 +234,7 @@ pub fn requested_revision(
         .or_else(|| {
             initialize_params.and_then(|p| p.get("protocolVersion")?.as_str().map(str::to_string))
         })
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.trim().is_empty())
 }
 
 /// Client name from initialize `clientInfo` or 2026 `_meta` clientInfo.
@@ -198,7 +254,40 @@ fn client_info_name(value: Option<&Value>) -> Option<String> {
 }
 
 fn meta_string(meta: Option<&Value>, key: &str) -> Option<String> {
-    meta?.get(key)?.as_str().map(str::to_string)
+    meta?
+        .get(key)?
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn revision_label(revision: Option<&str>) -> Option<&'static str> {
+    let revision = revision.map(str::trim).filter(|v| !v.is_empty())?;
+    MEASURED_REVISIONS
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == revision)
+        .or(Some(OTHER_REVISION))
+}
+
+fn client_label(client: &str) -> &'static str {
+    let client = client.trim().to_ascii_lowercase();
+    if client.is_empty() || client == UNATTRIBUTED_CLIENT {
+        UNATTRIBUTED_CLIENT
+    } else if client.contains("claude") {
+        "claude"
+    } else if client.contains("codex") {
+        "codex"
+    } else if client.contains("cursor") {
+        "cursor"
+    } else if client.contains("vscode") || client.contains("visual studio code") {
+        "vscode"
+    } else if client.contains("chatgpt") {
+        "chatgpt"
+    } else {
+        "other"
+    }
 }
 
 /// `_meta` may sit on the JSON-RPC request root or on `params`.
@@ -237,11 +326,13 @@ pub fn retire_revisions(snapshot: &Snapshot) -> Vec<String> {
     if snapshot.total == 0 || attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
         return Vec::new();
     }
-    snapshot
-        .by_revision
+    crate::protocol::SUPPORTED_VERSIONS
         .iter()
-        .filter(|(_, n)| ratio(**n, snapshot.total) < RETIRE_BELOW_SHARE)
-        .map(|(rev, _)| rev.clone())
+        .filter(|rev| {
+            let count = snapshot.by_revision.get(**rev).copied().unwrap_or(0);
+            ratio(count, snapshot.total) < RETIRE_BELOW_SHARE
+        })
+        .map(|rev| (*rev).to_string())
         .collect()
 }
 
@@ -284,22 +375,31 @@ fn global() -> &'static Mutex<Registry> {
     REGISTRY.get_or_init(|| Mutex::new(Registry::new()))
 }
 
-/// Record one inbound session on the process registry.
-pub fn observe_inbound(
-    session_id: &str,
+/// Record one successful initialize on the process registry.
+pub fn observe_initialize(
     initialize_params: Option<&Value>,
     request_meta: Option<&Value>,
+    negotiated_revision: &str,
+    transport: Transport,
 ) {
-    let revision = requested_revision(initialize_params, request_meta);
-    let client = client_identity(initialize_params, request_meta);
+    let requested = requested_revision(initialize_params, request_meta);
+    let raw_client = client_identity(initialize_params, request_meta);
+    let requested_label = revision_label(requested.as_deref());
+    let negotiated_label = revision_label(Some(negotiated_revision)).unwrap_or(OTHER_REVISION);
+    let client = client_label(&raw_client);
     let mut reg = global()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let recorded = reg.observe_session(session_id, revision.as_deref(), &client);
+    reg.observe_session(requested.as_deref(), negotiated_revision, client, transport);
     drop(reg);
-    if recorded {
-        emit_session_metrics(revision.as_deref(), &client);
-    }
+    emit_session_metrics(requested_label, negotiated_label, client, transport);
+    tracing::info!(
+        requested_revision = requested_label.unwrap_or("unattributed"),
+        negotiated_revision = negotiated_label,
+        client,
+        transport = transport.as_str(),
+        "mcp728.u1 negotiated session"
+    );
 }
 
 /// Shadow-log one `tools/list` on the process registry.
@@ -309,15 +409,31 @@ pub fn observe_tools_list(filters: ListFilters) -> ToolsListShadow {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let shadow = reg.shadow_tools_list(filters);
     drop(reg);
+    emit_tools_list_metrics(filters, shadow.would_emit_cache_scope);
     tracing::info!(
         principal = shadow.principal,
         profile = shadow.profile,
         session = shadow.session,
+        request = shadow.request,
         would_emit_cache_scope = shadow.would_emit_cache_scope.as_str(),
         public_over_filtered = public_over_filtered(filters, shadow.would_emit_cache_scope),
         "mcp728.u1 tools/list cacheScope shadow"
     );
     shadow
+}
+
+fn emit_tools_list_metrics(filters: ListFilters, scope: CacheScope) {
+    let _ = (filters, scope);
+    #[cfg(feature = "metrics")]
+    telemetry_metrics::counter!(
+        "mcp_tools_list_cache_scope_shadow_total",
+        "principal" => filters.principal.to_string(),
+        "profile" => filters.profile.to_string(),
+        "session" => filters.session.to_string(),
+        "request" => filters.request.to_string(),
+        "would_emit_cache_scope" => scope.as_str()
+    )
+    .increment(1);
 }
 
 /// Process snapshot for the measurement table.
@@ -328,30 +444,38 @@ pub fn global_snapshot() -> Snapshot {
         .snapshot()
 }
 
-/// Process shadow log.
-pub fn global_shadows() -> Vec<ToolsListShadow> {
+/// Process count for one `tools/list` filter combination.
+pub fn global_shadow_count(filters: ListFilters) -> u64 {
     global()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .shadows()
-        .to_vec()
+        .shadow_count(filters)
 }
 
-fn emit_session_metrics(revision: Option<&str>, client: &str) {
-    let _ = (revision, client);
+fn emit_session_metrics(
+    requested_revision: Option<&str>,
+    negotiated_revision: &str,
+    client: &str,
+    transport: Transport,
+) {
+    let _ = (requested_revision, negotiated_revision, client, transport);
     #[cfg(feature = "metrics")]
     {
-        if let Some(rev) = revision {
+        if let Some(rev) = requested_revision {
             telemetry_metrics::counter!(
                 "mcp_protocol_revision_sessions_total",
-                "revision" => rev.to_string(),
-                "client" => client.to_string()
+                "requested_revision" => rev.to_string(),
+                "negotiated_revision" => negotiated_revision.to_string(),
+                "client" => client.to_string(),
+                "transport" => transport.as_str()
             )
             .increment(1);
         } else {
             telemetry_metrics::counter!(
                 "mcp_protocol_revision_unattributed_sessions_total",
-                "client" => client.to_string()
+                "negotiated_revision" => negotiated_revision.to_string(),
+                "client" => client.to_string(),
+                "transport" => transport.as_str()
             )
             .increment(1);
         }
@@ -399,12 +523,22 @@ mod tests {
     #[test]
     fn unattributed_is_its_own_series() {
         let mut reg = Registry::new();
-        reg.observe_session("s1", Some("2025-11-25"), "claude");
-        reg.observe_session("s2", None, "unknown");
+        reg.observe_session(
+            Some("2025-11-25"),
+            "2025-11-25",
+            "claude-desktop",
+            Transport::Http,
+        );
+        reg.observe_session(None, "2025-11-25", "unknown", Transport::Stdio);
         let snap = reg.snapshot();
         assert_eq!(snap.total, 2);
         assert_eq!(snap.unattributed, 1);
         assert_eq!(snap.by_revision.get("2025-11-25"), Some(&1));
+        assert_eq!(snap.by_negotiated_revision.get("2025-11-25"), Some(&2));
+        assert_eq!(snap.by_client.get("claude"), Some(&1));
+        assert_eq!(snap.by_client.get("other"), Some(&1));
+        assert_eq!(snap.by_transport.get("http"), Some(&1));
+        assert_eq!(snap.by_transport.get("stdio"), Some(&1));
         assert!(!snap.by_revision.contains_key("unattributed"));
         assert!((attribution_rate(&snap) - 0.5).abs() < f64::EPSILON);
         let table = distribution_table(&snap);
@@ -413,12 +547,22 @@ mod tests {
     }
 
     #[test]
-    fn same_session_is_not_double_counted() {
+    fn arbitrary_labels_are_bounded() {
         let mut reg = Registry::new();
-        assert!(reg.observe_session("s1", Some("2025-06-18"), "a"));
-        assert!(!reg.observe_session("s1", Some("2026-07-28"), "a"));
-        assert_eq!(reg.snapshot().total, 1);
-        assert_eq!(reg.snapshot().by_revision.get("2025-06-18"), Some(&1));
+        for i in 0..100 {
+            reg.observe_session(
+                Some(&format!("attacker-revision-{i}")),
+                "attacker-negotiated",
+                &format!("attacker-client-{i}"),
+                Transport::Http,
+            );
+        }
+        let snapshot = reg.snapshot();
+        assert_eq!(snapshot.by_revision.len(), 1);
+        assert_eq!(snapshot.by_revision.get(OTHER_REVISION), Some(&100));
+        assert_eq!(snapshot.by_negotiated_revision.len(), 1);
+        assert_eq!(snapshot.by_client.len(), 1);
+        assert_eq!(snapshot.by_client.get("other"), Some(&100));
     }
 
     #[test]
@@ -431,6 +575,7 @@ mod tests {
             principal: true,
             profile: false,
             session: false,
+            request: false,
         };
         assert_eq!(cache_scope_decision(filtered), CacheScope::Private);
         assert!(!public_over_filtered(filtered, CacheScope::Private));
@@ -442,8 +587,8 @@ mod tests {
         let empty = Registry::new().snapshot();
         assert!(retire_revisions(&empty).is_empty());
         let mut low = Registry::new();
-        low.observe_session("a", Some("2025-06-18"), "c");
-        low.observe_session("b", None, "c");
+        low.observe_session(Some("2025-06-18"), "2025-06-18", "c", Transport::Http);
+        low.observe_session(None, "2025-11-25", "c", Transport::Http);
         // 50% attributed < 80% floor
         assert!(retire_revisions(&low.snapshot()).is_empty());
     }
@@ -451,12 +596,13 @@ mod tests {
     #[test]
     fn two_percent_rule_retires_only_below_floor_when_attributed() {
         let mut reg = Registry::new();
-        for i in 0..99 {
-            reg.observe_session(&format!("keep-{i}"), Some("2025-11-25"), "c");
+        for _ in 0..99 {
+            reg.observe_session(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
         }
-        reg.observe_session("rare", Some("2024-11-05"), "c");
+        reg.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
         let retired = retire_revisions(&reg.snapshot());
-        assert_eq!(retired, vec!["2024-11-05".to_string()]);
+        assert!(retired.iter().any(|r| r == "2024-11-05"));
+        assert!(retired.iter().any(|r| r == "2024-10-07"));
         assert!(!retired.iter().any(|r| r == "2025-11-25"));
     }
 
@@ -467,9 +613,18 @@ mod tests {
             principal: false,
             profile: true,
             session: true,
+            request: false,
         });
         assert!(shadow.profile && shadow.session);
         assert_eq!(shadow.would_emit_cache_scope, CacheScope::Private);
-        assert_eq!(reg.shadows().len(), 1);
+        assert_eq!(
+            reg.shadow_count(ListFilters {
+                principal: false,
+                profile: true,
+                session: true,
+                request: false,
+            }),
+            1
+        );
     }
 }

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -177,6 +177,8 @@ pub enum RetirementBlocked {
     NoObservations,
     /// Fewer than 80% of requests carried attributable revision data.
     AttributionBelowFloor,
+    /// Unattributed requests alone could keep every revision above 2%.
+    UnattributedAtOrAboveRetirementThreshold,
 }
 
 impl Registry {
@@ -392,6 +394,9 @@ pub fn retire_revisions(
     }
     if attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
         return Err(RetirementBlocked::AttributionBelowFloor);
+    }
+    if ratio(snapshot.unattributed, snapshot.total) >= RETIRE_BELOW_SHARE {
+        return Err(RetirementBlocked::UnattributedAtOrAboveRetirementThreshold);
     }
     Ok(crate::protocol::SUPPORTED_VERSIONS
         .iter()
@@ -788,6 +793,18 @@ mod tests {
         assert_eq!(
             retire_revisions(&low.snapshot(), MIN_MEASUREMENT_WINDOW),
             Err(RetirementBlocked::AttributionBelowFloor)
+        );
+
+        let mut ambiguous = Registry::new();
+        for _ in 0..95 {
+            ambiguous.observe_request(Some("2025-11-25"), "c", Transport::Http);
+        }
+        for _ in 0..5 {
+            ambiguous.observe_request(None, "c", Transport::Http);
+        }
+        assert_eq!(
+            retire_revisions(&ambiguous.snapshot(), MIN_MEASUREMENT_WINDOW),
+            Err(RetirementBlocked::UnattributedAtOrAboveRetirementThreshold)
         );
     }
 

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -158,6 +158,17 @@ pub struct Snapshot {
     pub total: u64,
 }
 
+/// Why a production window cannot yet produce a retirement decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetirementBlocked {
+    /// Fewer than seven days have elapsed.
+    WindowTooShort,
+    /// No request observations were recorded.
+    NoObservations,
+    /// Fewer than 80% of requests carried attributable revision data.
+    AttributionBelowFloor,
+}
+
 impl Registry {
     /// Empty counters.
     pub fn new() -> Self {
@@ -357,23 +368,29 @@ pub fn attribution_rate(snapshot: &Snapshot) -> f64 {
 ///
 /// Every unattributed observation is treated as if it belonged to the revision
 /// being evaluated. This prevents missing attribution from making an older
-/// revision look safer to remove. Empty, short, or under-attributed windows
-/// return no candidates.
-pub fn retire_revisions(snapshot: &Snapshot, elapsed: Duration) -> Vec<String> {
-    if elapsed < MIN_MEASUREMENT_WINDOW
-        || snapshot.total == 0
-        || attribution_rate(snapshot) < ATTRIBUTION_FLOOR
-    {
-        return Vec::new();
+/// revision look safer to remove. An unusable window is returned separately
+/// from a usable window with no retirement candidates.
+pub fn retire_revisions(
+    snapshot: &Snapshot,
+    elapsed: Duration,
+) -> Result<Vec<String>, RetirementBlocked> {
+    if elapsed < MIN_MEASUREMENT_WINDOW {
+        return Err(RetirementBlocked::WindowTooShort);
     }
-    crate::protocol::SUPPORTED_VERSIONS
+    if snapshot.total == 0 {
+        return Err(RetirementBlocked::NoObservations);
+    }
+    if attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
+        return Err(RetirementBlocked::AttributionBelowFloor);
+    }
+    Ok(crate::protocol::SUPPORTED_VERSIONS
         .iter()
         .filter(|rev| {
             let count = snapshot.by_revision.get(**rev).copied().unwrap_or(0);
             ratio(count.saturating_add(snapshot.unattributed), snapshot.total) < RETIRE_BELOW_SHARE
         })
         .map(|rev| (*rev).to_string())
-        .collect()
+        .collect())
 }
 
 /// Markdown table for the Linear comment. Unattributed is its own row, not a revision.
@@ -432,6 +449,9 @@ pub fn observe_inbound_request(
     session_id: Option<&str>,
     transport: Transport,
 ) {
+    if method.starts_with("notifications/") {
+        return;
+    }
     let meta = request_meta(request, params);
     let initialize_params = (method == "initialize").then_some(params).flatten();
     let explicit_requested = requested_revision(initialize_params, meta)
@@ -467,7 +487,7 @@ pub fn observe_inbound_request(
     reg.observe_request(requested_label, client, transport);
     drop(reg);
     emit_request_metrics(requested_label, client, transport);
-    tracing::info!(
+    tracing::debug!(
         requested_revision = requested_label.unwrap_or("unattributed"),
         client,
         transport = transport.as_str(),
@@ -483,7 +503,7 @@ pub fn observe_tools_list(filters: ListFilters) -> ToolsListShadow {
     let shadow = reg.shadow_tools_list(filters);
     drop(reg);
     emit_tools_list_metrics(filters, shadow.would_emit_cache_scope);
-    tracing::info!(
+    tracing::debug!(
         principal = shadow.principal,
         profile = shadow.profile,
         session = shadow.session,
@@ -627,6 +647,43 @@ mod tests {
     }
 
     #[test]
+    fn every_supported_revision_has_a_dedicated_metric_label() {
+        for revision in crate::protocol::SUPPORTED_VERSIONS {
+            assert!(
+                MEASURED_REVISIONS.contains(revision),
+                "supported revision {revision} would collapse into the other bucket"
+            );
+        }
+    }
+
+    #[test]
+    fn notifications_are_not_request_observations() {
+        let before = global_snapshot()
+            .by_revision
+            .get(OTHER_REVISION)
+            .copied()
+            .unwrap_or(0);
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+        observe_inbound_request(
+            &notification,
+            None,
+            "notifications/initialized",
+            Some("notification-only-test-revision"),
+            None,
+            Transport::Http,
+        );
+        let after = global_snapshot()
+            .by_revision
+            .get(OTHER_REVISION)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(after, before);
+    }
+
+    #[test]
     fn cache_scope_public_only_when_unfiltered() {
         assert_eq!(
             cache_scope_decision(ListFilters::default()),
@@ -646,12 +703,18 @@ mod tests {
     #[test]
     fn two_percent_rule_does_not_fire_on_underattributed_or_empty() {
         let empty = Registry::new().snapshot();
-        assert!(retire_revisions(&empty, MIN_MEASUREMENT_WINDOW).is_empty());
+        assert_eq!(
+            retire_revisions(&empty, MIN_MEASUREMENT_WINDOW),
+            Err(RetirementBlocked::NoObservations)
+        );
         let mut low = Registry::new();
         low.observe_request(Some("2025-06-18"), "c", Transport::Http);
         low.observe_request(None, "c", Transport::Http);
         // 50% attributed < 80% floor
-        assert!(retire_revisions(&low.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
+        assert_eq!(
+            retire_revisions(&low.snapshot(), MIN_MEASUREMENT_WINDOW),
+            Err(RetirementBlocked::AttributionBelowFloor)
+        );
     }
 
     #[test]
@@ -661,8 +724,12 @@ mod tests {
             reg.observe_request(Some("2025-11-25"), "c", Transport::Http);
         }
         reg.observe_request(Some("2024-11-05"), "c", Transport::Http);
-        assert!(retire_revisions(&reg.snapshot(), Duration::from_secs(1)).is_empty());
-        let retired = retire_revisions(&reg.snapshot(), MIN_MEASUREMENT_WINDOW);
+        assert_eq!(
+            retire_revisions(&reg.snapshot(), Duration::from_secs(1)),
+            Err(RetirementBlocked::WindowTooShort)
+        );
+        let retired = retire_revisions(&reg.snapshot(), MIN_MEASUREMENT_WINDOW)
+            .expect("full attributed window is actionable");
         assert!(retired.iter().any(|r| r == "2024-11-05"));
         assert!(retired.iter().any(|r| r == "2024-10-07"));
         assert!(!retired.iter().any(|r| r == "2025-11-25"));

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -491,7 +491,10 @@ fn emit_session_metrics(
 #[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn reset_global_for_tests() {
-    global().lock().unwrap_or_else(|e| e.into_inner()).reset();
+    global()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .reset();
 }
 
 #[cfg(test)]

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -61,6 +61,9 @@ impl Transport {
 }
 
 /// Filters that make a `tools/list` result session- or tenant-specific.
+// These are four independent, bounded metric dimensions, not mutually
+// exclusive states; an enum would obscure valid combinations.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ListFilters {
     /// API-key / principal assembly ran.
@@ -100,6 +103,9 @@ impl CacheScope {
 }
 
 /// One `tools/list` shadow observation. Never attached to the live response.
+// Mirrors ListFilters in test snapshots so each independent dimension remains
+// directly assertable.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolsListShadow {
     /// Whether a principal filter ran.

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -9,11 +9,19 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Write as _;
+#[cfg(unix)]
+use std::fs::File;
+use std::fs::OpenOptions;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use crate::fs_lock::ExclusiveFileLock;
 
 /// Wire key for 2026 per-request protocol revision.
 pub const META_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
@@ -50,6 +58,12 @@ const MEASURED_CLIENTS: &[&str] = &[
     "other",
 ];
 const MEASURED_TRANSPORTS: &[Transport] = &[Transport::Http, Transport::Stdio, Transport::Internal];
+/// Directory below the gateway data directory that holds the restart-safe window.
+pub const DURABLE_TELEMETRY_DIR: &str = "protocol-revision-telemetry";
+/// Durable aggregate filename read by operators after the measurement window.
+pub const DURABLE_WINDOW_FILE: &str = "window.json";
+/// Schema identifier for the operator-readable aggregate.
+pub const DURABLE_WINDOW_SCHEMA: &str = "mcp_protocol_revision_window.v1";
 
 /// Inbound transport for a negotiated session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,7 +168,7 @@ pub struct Registry {
 }
 
 /// Snapshot for `/metrics` tests and the Linear table.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Snapshot {
     /// Requests whose revision was named on the wire.
     pub by_revision: BTreeMap<String, u64>,
@@ -179,6 +193,131 @@ pub enum RetirementBlocked {
     AttributionBelowFloor,
     /// Unattributed requests alone could keep every revision above 2%.
     UnattributedAtOrAboveRetirementThreshold,
+    /// Present but unrecognized revisions are too common to classify safely.
+    OtherAtOrAboveRetirementThreshold,
+}
+
+/// Restart-safe aggregate for a production measurement window.
+///
+/// The file contains bounded labels only. It never stores raw client names,
+/// session identifiers, request bodies, or tool arguments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DurableWindow {
+    /// Stable on-disk schema identifier.
+    pub schema_version: String,
+    /// Unix timestamp when this window started.
+    pub started_at_unix_seconds: u64,
+    /// Most recent successful aggregate update, recorded as Unix seconds for operator inspection
+    /// after the seven-day window.
+    pub updated_at_unix_seconds: u64,
+    /// Cross-process request counters accumulated since `started_at_unix_seconds`.
+    pub snapshot: Snapshot,
+    /// All 16 bounded `tools/list` filter combinations, including zeroes.
+    pub tools_list_shadow: BTreeMap<String, u64>,
+}
+
+impl DurableWindow {
+    fn empty(now: u64) -> Self {
+        Self {
+            schema_version: DURABLE_WINDOW_SCHEMA.to_string(),
+            started_at_unix_seconds: now,
+            updated_at_unix_seconds: now,
+            snapshot: Snapshot::default(),
+            tools_list_shadow: empty_shadow_counts(),
+        }
+    }
+
+    /// Evaluate the persisted counters using the durable start timestamp.
+    pub fn retirement_decision_at(
+        &self,
+        now_unix_seconds: u64,
+    ) -> Result<Vec<String>, RetirementBlocked> {
+        let elapsed =
+            Duration::from_secs(now_unix_seconds.saturating_sub(self.started_at_unix_seconds));
+        retire_revisions(&self.snapshot, elapsed)
+    }
+}
+
+/// Cross-process sink used by stdio servers.
+///
+/// Each process contributes only the delta since its preceding write. A shared
+/// advisory lock serializes the aggregate update across gateway processes.
+#[derive(Debug)]
+pub struct DurableTelemetrySink {
+    window_path: PathBuf,
+    lock_path: PathBuf,
+    previous_snapshot: Snapshot,
+    previous_shadow: BTreeMap<String, u64>,
+}
+
+impl DurableTelemetrySink {
+    /// Open or create the durable measurement window below `data_dir`.
+    pub fn open(data_dir: &Path) -> io::Result<Self> {
+        let directory = data_dir.join(DURABLE_TELEMETRY_DIR);
+        std::fs::create_dir_all(&directory)?;
+        force_directory_owner_only(&directory)?;
+        let window_path = directory.join(DURABLE_WINDOW_FILE);
+        let lock_path = directory.join(".window.lock");
+        {
+            let _lock = ExclusiveFileLock::acquire(&lock_path)?;
+            if window_path.exists() {
+                read_window_file(&window_path)?;
+            } else {
+                write_window_atomic(&window_path, &DurableWindow::empty(unix_seconds()?))?;
+            }
+        }
+        Ok(Self {
+            window_path,
+            lock_path,
+            previous_snapshot: Snapshot::default(),
+            previous_shadow: empty_shadow_counts(),
+        })
+    }
+
+    /// Add counters observed since this sink's preceding successful write.
+    pub fn persist_registry(&mut self, registry: &Registry) -> io::Result<()> {
+        self.persist(
+            registry.snapshot(),
+            registry.shadow_snapshot(),
+            unix_seconds()?,
+        )
+    }
+
+    /// Persist the current process-global counters.
+    pub fn persist_global(&mut self) -> io::Result<()> {
+        let (snapshot, shadow) = {
+            let registry = global()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (registry.snapshot(), registry.shadow_snapshot())
+        };
+        self.persist(snapshot, shadow, unix_seconds()?)
+    }
+
+    fn persist(
+        &mut self,
+        current: Snapshot,
+        current_shadow: BTreeMap<String, u64>,
+        now: u64,
+    ) -> io::Result<()> {
+        let snapshot_delta = snapshot_delta(&current, &self.previous_snapshot);
+        let shadow_delta = map_delta(&current_shadow, &self.previous_shadow);
+        if snapshot_delta.total == 0 && shadow_delta.values().all(|count| *count == 0) {
+            return Ok(());
+        }
+
+        let _lock = ExclusiveFileLock::acquire(&self.lock_path)?;
+        let mut window = read_window_file(&self.window_path)?;
+        add_snapshot(&mut window.snapshot, &snapshot_delta)?;
+        add_map(&mut window.tools_list_shadow, &shadow_delta)?;
+        window.updated_at_unix_seconds = window.updated_at_unix_seconds.max(now);
+        validate_window(&window)?;
+        write_window_atomic(&self.window_path, &window)?;
+
+        self.previous_snapshot = current;
+        self.previous_shadow = current_shadow;
+        Ok(())
+    }
 }
 
 impl Registry {
@@ -258,6 +397,17 @@ impl Registry {
         self.shadow_counts[shadow_index(filters)]
     }
 
+    fn shadow_snapshot(&self) -> BTreeMap<String, u64> {
+        all_filter_combinations()
+            .map(|filters| {
+                (
+                    shadow_key(filters, cache_scope_decision(filters)),
+                    self.shadow_count(filters),
+                )
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     #[allow(dead_code)]
     fn reset(&mut self) {
@@ -276,6 +426,38 @@ fn shadow_index(filters: ListFilters) -> usize {
         | (usize::from(filters.profile) << 1)
         | (usize::from(filters.session) << 2)
         | (usize::from(filters.request) << 3)
+}
+
+fn all_filter_combinations() -> impl Iterator<Item = ListFilters> {
+    [false, true].into_iter().flat_map(|principal| {
+        [false, true].into_iter().flat_map(move |profile| {
+            [false, true].into_iter().flat_map(move |session| {
+                [false, true].into_iter().map(move |request| ListFilters {
+                    principal,
+                    profile,
+                    session,
+                    request,
+                })
+            })
+        })
+    })
+}
+
+fn shadow_key(filters: ListFilters, scope: CacheScope) -> String {
+    format!(
+        "principal={},profile={},session={},request={},would_emit_cache_scope={}",
+        filters.principal,
+        filters.profile,
+        filters.session,
+        filters.request,
+        scope.as_str()
+    )
+}
+
+fn empty_shadow_counts() -> BTreeMap<String, u64> {
+    all_filter_combinations()
+        .map(|filters| (shadow_key(filters, cache_scope_decision(filters)), 0))
+        .collect()
 }
 
 /// Revision the client asked for. `_meta` wins when both are present.
@@ -398,11 +580,24 @@ pub fn retire_revisions(
     if ratio(snapshot.unattributed, snapshot.total) >= RETIRE_BELOW_SHARE {
         return Err(RetirementBlocked::UnattributedAtOrAboveRetirementThreshold);
     }
+    let other = snapshot
+        .by_revision
+        .get(OTHER_REVISION)
+        .copied()
+        .unwrap_or(0);
+    if ratio(other, snapshot.total) >= RETIRE_BELOW_SHARE {
+        return Err(RetirementBlocked::OtherAtOrAboveRetirementThreshold);
+    }
     Ok(crate::protocol::SUPPORTED_VERSIONS
         .iter()
         .filter(|rev| {
             let count = snapshot.by_revision.get(**rev).copied().unwrap_or(0);
-            ratio(count.saturating_add(snapshot.unattributed), snapshot.total) < RETIRE_BELOW_SHARE
+            ratio(
+                count
+                    .saturating_add(snapshot.unattributed)
+                    .saturating_add(other),
+                snapshot.total,
+            ) < RETIRE_BELOW_SHARE
         })
         .map(|rev| (*rev).to_string())
         .collect())
@@ -446,6 +641,217 @@ fn ratio(n: u64, total: u64) -> f64 {
     // human-facing shares and the pre-registered percentage threshold.
     n as f64 / total as f64
 }
+
+/// Location of the restart-safe aggregate below a gateway data directory.
+pub fn durable_window_path(data_dir: &Path) -> PathBuf {
+    data_dir
+        .join(DURABLE_TELEMETRY_DIR)
+        .join(DURABLE_WINDOW_FILE)
+}
+
+/// Load and validate the operator-readable production window.
+pub fn load_durable_window(data_dir: &Path) -> io::Result<DurableWindow> {
+    read_window_file(&durable_window_path(data_dir))
+}
+
+/// Evaluate retirement from the persisted start time and aggregate counters.
+///
+/// This is the production decision path. Unlike [`retire_revisions`], callers
+/// cannot supply an elapsed duration or an in-process snapshot.
+pub fn durable_retirement_decision(
+    data_dir: &Path,
+) -> io::Result<Result<Vec<String>, RetirementBlocked>> {
+    let window = load_durable_window(data_dir)?;
+    Ok(window.retirement_decision_at(unix_seconds()?))
+}
+
+fn snapshot_delta(current: &Snapshot, previous: &Snapshot) -> Snapshot {
+    Snapshot {
+        by_revision: map_delta(&current.by_revision, &previous.by_revision),
+        by_client: map_delta(&current.by_client, &previous.by_client),
+        by_transport: map_delta(&current.by_transport, &previous.by_transport),
+        unattributed: counter_delta(current.unattributed, previous.unattributed),
+        total: counter_delta(current.total, previous.total),
+    }
+}
+
+fn map_delta(
+    current: &BTreeMap<String, u64>,
+    previous: &BTreeMap<String, u64>,
+) -> BTreeMap<String, u64> {
+    current
+        .iter()
+        .map(|(key, value)| {
+            let prior = previous.get(key).copied().unwrap_or(0);
+            (key.clone(), counter_delta(*value, prior))
+        })
+        .collect()
+}
+
+fn counter_delta(current: u64, previous: u64) -> u64 {
+    current.checked_sub(previous).unwrap_or(current)
+}
+
+fn add_snapshot(target: &mut Snapshot, delta: &Snapshot) -> io::Result<()> {
+    add_map(&mut target.by_revision, &delta.by_revision)?;
+    add_map(&mut target.by_client, &delta.by_client)?;
+    add_map(&mut target.by_transport, &delta.by_transport)?;
+    target.unattributed = checked_counter_add(target.unattributed, delta.unattributed)?;
+    target.total = checked_counter_add(target.total, delta.total)?;
+    Ok(())
+}
+
+fn add_map(target: &mut BTreeMap<String, u64>, delta: &BTreeMap<String, u64>) -> io::Result<()> {
+    for (key, increment) in delta {
+        let value = target.entry(key.clone()).or_insert(0);
+        *value = checked_counter_add(*value, *increment)?;
+    }
+    Ok(())
+}
+
+fn checked_counter_add(current: u64, increment: u64) -> io::Result<u64> {
+    current
+        .checked_add(increment)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "telemetry counter overflow"))
+}
+
+fn read_window_file(path: &Path) -> io::Result<DurableWindow> {
+    let bytes = std::fs::read(path)?;
+    let window: DurableWindow = serde_json::from_slice(&bytes)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    validate_window(&window)?;
+    Ok(window)
+}
+
+fn validate_window(window: &DurableWindow) -> io::Result<()> {
+    if window.schema_version != DURABLE_WINDOW_SCHEMA {
+        return Err(invalid_window("unsupported durable telemetry schema"));
+    }
+    if window.updated_at_unix_seconds < window.started_at_unix_seconds {
+        return Err(invalid_window("window update precedes its start"));
+    }
+    validate_bounded_keys(
+        &window.snapshot.by_revision,
+        MEASURED_REVISIONS
+            .iter()
+            .copied()
+            .chain(std::iter::once(OTHER_REVISION)),
+        "revision",
+    )?;
+    validate_bounded_keys(
+        &window.snapshot.by_client,
+        MEASURED_CLIENTS.iter().copied(),
+        "client",
+    )?;
+    validate_bounded_keys(
+        &window.snapshot.by_transport,
+        MEASURED_TRANSPORTS
+            .iter()
+            .map(|transport| transport.as_str()),
+        "transport",
+    )?;
+    if checked_counter_sum(window.snapshot.by_revision.values().copied())?
+        .checked_add(window.snapshot.unattributed)
+        != Some(window.snapshot.total)
+    {
+        return Err(invalid_window("revision counters do not equal total"));
+    }
+    if checked_counter_sum(window.snapshot.by_client.values().copied())? != window.snapshot.total {
+        return Err(invalid_window("client counters do not equal total"));
+    }
+    if checked_counter_sum(window.snapshot.by_transport.values().copied())? != window.snapshot.total
+    {
+        return Err(invalid_window("transport counters do not equal total"));
+    }
+    let expected_shadow = empty_shadow_counts();
+    if window.tools_list_shadow.keys().ne(expected_shadow.keys()) {
+        return Err(invalid_window("tools/list shadow labels are incomplete"));
+    }
+    Ok(())
+}
+
+fn validate_bounded_keys<'a>(
+    values: &BTreeMap<String, u64>,
+    allowed: impl Iterator<Item = &'a str>,
+    label: &str,
+) -> io::Result<()> {
+    let allowed = allowed.collect::<std::collections::BTreeSet<_>>();
+    if let Some(unbounded) = values.keys().find(|key| !allowed.contains(key.as_str())) {
+        return Err(invalid_window(&format!(
+            "unbounded {label} label in durable telemetry: {unbounded}"
+        )));
+    }
+    Ok(())
+}
+
+fn invalid_window(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn checked_counter_sum(mut values: impl Iterator<Item = u64>) -> io::Result<u64> {
+    values.try_fold(0, checked_counter_add)
+}
+
+fn unix_seconds() -> io::Result<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn write_window_atomic(path: &Path, window: &DurableWindow) -> io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(window)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "window has no parent"))?;
+    let temporary = path.with_extension("json.tmp");
+    {
+        let mut options = OpenOptions::new();
+        options.create(true).write(true).truncate(true);
+        set_owner_only(&mut options);
+        let mut file = options.open(&temporary)?;
+        force_file_owner_only(&file)?;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&temporary, path)?;
+    #[cfg(unix)]
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt as _;
+    options.mode(0o600);
+}
+
+#[cfg(unix)]
+fn force_file_owner_only(file: &std::fs::File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn force_file_owner_only(_file: &std::fs::File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn force_directory_owner_only(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn force_directory_owner_only(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_options: &mut OpenOptions) {}
 
 fn global() -> &'static Mutex<Registry> {
     static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -195,6 +195,8 @@ pub enum RetirementBlocked {
     UnattributedAtOrAboveRetirementThreshold,
     /// Present but unrecognized revisions are too common to classify safely.
     OtherAtOrAboveRetirementThreshold,
+    /// HTTP and stdio evidence do not cover the same production window.
+    WindowMisaligned,
 }
 
 /// Restart-safe aggregate for a production measurement window.
@@ -673,15 +675,49 @@ pub fn load_durable_window(data_dir: &Path) -> io::Result<DurableWindow> {
     read_window_file(&durable_window_path(data_dir))
 }
 
-/// Evaluate retirement from the persisted start time and aggregate counters.
+/// Evaluate the production decision from exact-window HTTP and stdio evidence.
 ///
-/// This is the production decision path. Unlike [`retire_revisions`], callers
-/// cannot supply an elapsed duration or an in-process snapshot.
-pub fn durable_retirement_decision(
+/// HTTP observations live in Prometheus while stdio observations live in the
+/// durable window. A revision is eligible only when both independent sources
+/// mark it below the threshold for the same window.
+pub fn production_retirement_decision(
     data_dir: &Path,
+    http_snapshot: &Snapshot,
+    http_started_at_unix_seconds: u64,
+) -> io::Result<Result<Vec<String>, RetirementBlocked>> {
+    production_retirement_decision_at(
+        data_dir,
+        http_snapshot,
+        http_started_at_unix_seconds,
+        unix_seconds()?,
+    )
+}
+
+/// Time-injected production decision used by deterministic tests and offline exports.
+pub fn production_retirement_decision_at(
+    data_dir: &Path,
+    http_snapshot: &Snapshot,
+    http_started_at_unix_seconds: u64,
+    ended_at_unix_seconds: u64,
 ) -> io::Result<Result<Vec<String>, RetirementBlocked>> {
     let window = load_durable_window(data_dir)?;
-    Ok(window.retirement_decision_at(unix_seconds()?))
+    if http_started_at_unix_seconds != window.started_at_unix_seconds {
+        return Ok(Err(RetirementBlocked::WindowMisaligned));
+    }
+    let elapsed =
+        Duration::from_secs(ended_at_unix_seconds.saturating_sub(http_started_at_unix_seconds));
+    let stdio_candidates = match window.retirement_decision_at(ended_at_unix_seconds) {
+        Ok(candidates) => candidates,
+        Err(blocked) => return Ok(Err(blocked)),
+    };
+    let http_candidates = match retire_revisions(http_snapshot, elapsed) {
+        Ok(candidates) => candidates,
+        Err(blocked) => return Ok(Err(blocked)),
+    };
+    Ok(Ok(stdio_candidates
+        .into_iter()
+        .filter(|candidate| http_candidates.contains(candidate))
+        .collect()))
 }
 
 fn snapshot_delta(current: &Snapshot, previous: &Snapshot) -> Snapshot {

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 //! MIK-7218 / RFC-0060 U1: measure which MCP revisions clients speak.
 //!
-//! Negotiation still defaults a missing `protocolVersion` to `2024-11-05`.
-//! Telemetry must not: that default would hide the unattributed share the
-//! ticket requires as its own series.
-//!
-//! Only successful `initialize` dispatches are counted. This avoids retaining
-//! session capability tokens and prevents id-less HTTP requests from inflating
-//! the window with synthetic sessions.
+//! Modern MCP has no protocol session, so the only comparable unit across the
+//! legacy and modern eras is an inbound JSON-RPC request. Modern requests carry
+//! their identity in `_meta`; legacy HTTP requests carry a protocol header, and
+//! legacy stdio follow-ups reuse the bounded attribution learned at initialize.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Write as _;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use serde_json::Value;
 
@@ -26,6 +25,10 @@ pub const UNATTRIBUTED_CLIENT: &str = "unattributed";
 pub const ATTRIBUTION_FLOOR: f64 = 0.80;
 /// Pre-registered retire threshold (RFC-0060 Decision 2). Written before data.
 pub const RETIRE_BELOW_SHARE: f64 = 0.02;
+/// Minimum production observation window required by MIK-7218.
+pub const MIN_MEASUREMENT_WINDOW: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+/// Hard bound for legacy session attribution retained in process memory.
+const MAX_SESSION_ATTRIBUTIONS: usize = 4_096;
 /// Revisions accepted as bounded metric labels. Everything else is `other`.
 pub const MEASURED_REVISIONS: &[&str] = &[
     "2026-07-28",
@@ -120,7 +123,14 @@ pub struct ToolsListShadow {
     pub would_emit_cache_scope: CacheScope,
 }
 
-/// Process-wide counters. Every key is normalized to a finite label set.
+#[derive(Debug, Clone, Copy)]
+struct SessionAttribution {
+    requested_revision: Option<&'static str>,
+    negotiated_revision: &'static str,
+    client: &'static str,
+}
+
+/// Process-wide counters. Every metric key is normalized to a finite label set.
 #[derive(Debug, Default)]
 pub struct Registry {
     /// Requested revisions. Kept as `by_revision` for the pre-registered table.
@@ -131,6 +141,8 @@ pub struct Registry {
     unattributed: u64,
     total: u64,
     shadow_counts: [u64; 16],
+    session_attributions: BTreeMap<u64, SessionAttribution>,
+    session_order: VecDeque<u64>,
 }
 
 /// Snapshot for `/metrics` tests and the Linear table.
@@ -156,8 +168,8 @@ impl Registry {
         Self::default()
     }
 
-    /// Record one successfully negotiated session.
-    pub fn observe_session(
+    /// Record one inbound request observation.
+    pub fn observe_request(
         &mut self,
         requested_revision: Option<&str>,
         negotiated_revision: &str,
@@ -182,6 +194,26 @@ impl Registry {
             }
             None => self.unattributed += 1,
         }
+    }
+
+    fn bind_session(&mut self, session_id: &str, attribution: SessionAttribution) {
+        let key = session_key(session_id);
+        if !self.session_attributions.contains_key(&key) {
+            while self.session_attributions.len() >= MAX_SESSION_ATTRIBUTIONS {
+                let Some(oldest) = self.session_order.pop_front() else {
+                    break;
+                };
+                self.session_attributions.remove(&oldest);
+            }
+            self.session_order.push_back(key);
+        }
+        self.session_attributions.insert(key, attribution);
+    }
+
+    fn session_attribution(&self, session_id: Option<&str>) -> Option<SessionAttribution> {
+        self.session_attributions
+            .get(&session_key(session_id?))
+            .copied()
     }
 
     /// Shadow-log one `tools/list` (not session-deduped: every list is a cache decision).
@@ -219,6 +251,12 @@ impl Registry {
     fn reset(&mut self) {
         *self = Self::default();
     }
+}
+
+fn session_key(session_id: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    session_id.hash(&mut hasher);
+    hasher.finish()
 }
 
 fn shadow_index(filters: ListFilters) -> usize {
@@ -326,17 +364,24 @@ pub fn attribution_rate(snapshot: &Snapshot) -> f64 {
     ratio(attributed, snapshot.total)
 }
 
-/// Revisions below 2% of total. Empty or under-attributed windows return none
-/// (RFC-0060 stop criterion: do not narrow on partial data).
-pub fn retire_revisions(snapshot: &Snapshot) -> Vec<String> {
-    if snapshot.total == 0 || attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
+/// Revisions whose conservative upper-bound share is below 2% after one week.
+///
+/// Every unattributed observation is treated as if it belonged to the revision
+/// being evaluated. This prevents missing attribution from making an older
+/// revision look safer to remove. Empty, short, or under-attributed windows
+/// return no candidates.
+pub fn retire_revisions(snapshot: &Snapshot, elapsed: Duration) -> Vec<String> {
+    if elapsed < MIN_MEASUREMENT_WINDOW
+        || snapshot.total == 0
+        || attribution_rate(snapshot) < ATTRIBUTION_FLOOR
+    {
         return Vec::new();
     }
     crate::protocol::SUPPORTED_VERSIONS
         .iter()
         .filter(|rev| {
             let count = snapshot.by_revision.get(**rev).copied().unwrap_or(0);
-            ratio(count, snapshot.total) < RETIRE_BELOW_SHARE
+            ratio(count.saturating_add(snapshot.unattributed), snapshot.total) < RETIRE_BELOW_SHARE
         })
         .map(|rev| (*rev).to_string())
         .collect()
@@ -356,8 +401,13 @@ pub fn distribution_table(snapshot: &Snapshot) -> String {
         share(snapshot.unattributed, snapshot.total)
     )
     .expect("writing to a String cannot fail");
-    writeln!(rows, "| total | {} | 100% |", snapshot.total)
-        .expect("writing to a String cannot fail");
+    writeln!(
+        rows,
+        "| total | {} | {:.1}% |",
+        snapshot.total,
+        if snapshot.total == 0 { 0.0 } else { 100.0 }
+    )
+    .expect("writing to a String cannot fail");
     rows
 }
 
@@ -381,22 +431,63 @@ fn global() -> &'static Mutex<Registry> {
     REGISTRY.get_or_init(|| Mutex::new(Registry::new()))
 }
 
-/// Record one successful initialize on the process registry.
-pub fn observe_initialize(
-    initialize_params: Option<&Value>,
-    request_meta: Option<&Value>,
-    negotiated_revision: &str,
+/// Record one parsed inbound JSON-RPC request.
+///
+/// Metric labels and remembered legacy attribution are bounded. Session IDs are
+/// reduced to hashes and retained only for a fixed-capacity cache.
+pub fn observe_inbound_request(
+    request: &Value,
+    params: Option<&Value>,
+    method: &str,
+    protocol_header: Option<&str>,
+    session_id: Option<&str>,
     transport: Transport,
 ) {
-    let requested = requested_revision(initialize_params, request_meta);
-    let raw_client = client_identity(initialize_params, request_meta);
-    let requested_label = revision_label(requested.as_deref());
-    let negotiated_label = revision_label(Some(negotiated_revision)).unwrap_or(OTHER_REVISION);
-    let client = client_label(&raw_client);
+    let meta = request_meta(request, params);
+    let initialize_params = (method == "initialize").then_some(params).flatten();
+    let explicit_requested = requested_revision(initialize_params, meta)
+        .or_else(|| protocol_header.map(str::trim).map(str::to_string))
+        .filter(|value| !value.is_empty());
+    let explicit_client = client_identity(initialize_params, meta);
+
     let mut reg = global()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.observe_session(requested.as_deref(), negotiated_revision, client, transport);
+    let previous = reg.session_attribution(session_id);
+    let requested_label = revision_label(explicit_requested.as_deref())
+        .or_else(|| previous.and_then(|item| item.requested_revision));
+    let client = if explicit_client == UNATTRIBUTED_CLIENT {
+        previous.map_or(UNATTRIBUTED_CLIENT, |item| item.client)
+    } else {
+        client_label(&explicit_client)
+    };
+    let negotiated_label = if method == "initialize" {
+        let client_version = initialize_params
+            .and_then(|value| value.get("protocolVersion"))
+            .and_then(Value::as_str)
+            .unwrap_or(crate::protocol::PROTOCOL_VERSION);
+        revision_label(Some(crate::protocol::negotiate_version(client_version)))
+            .unwrap_or(OTHER_REVISION)
+    } else {
+        previous
+            .map(|item| item.negotiated_revision)
+            .or(requested_label)
+            .unwrap_or(OTHER_REVISION)
+    };
+
+    if method == "initialize"
+        && let Some(session_id) = session_id
+    {
+        reg.bind_session(
+            session_id,
+            SessionAttribution {
+                requested_revision: requested_label,
+                negotiated_revision: negotiated_label,
+                client,
+            },
+        );
+    }
+    reg.observe_request(requested_label, negotiated_label, client, transport);
     drop(reg);
     emit_session_metrics(requested_label, negotiated_label, client, transport);
     tracing::info!(
@@ -404,7 +495,7 @@ pub fn observe_initialize(
         negotiated_revision = negotiated_label,
         client,
         transport = transport.as_str(),
-        "mcp728.u1 negotiated session"
+        "mcp728.u1 inbound request observation"
     );
 }
 
@@ -469,7 +560,7 @@ fn emit_session_metrics(
     {
         if let Some(rev) = requested_revision {
             telemetry_metrics::counter!(
-                "mcp_protocol_revision_sessions_total",
+                "mcp_protocol_revision_observations_total",
                 "requested_revision" => rev.to_string(),
                 "negotiated_revision" => negotiated_revision.to_string(),
                 "client" => client.to_string(),
@@ -478,7 +569,7 @@ fn emit_session_metrics(
             .increment(1);
         } else {
             telemetry_metrics::counter!(
-                "mcp_protocol_revision_unattributed_sessions_total",
+                "mcp_protocol_revision_unattributed_observations_total",
                 "negotiated_revision" => negotiated_revision.to_string(),
                 "client" => client.to_string(),
                 "transport" => transport.as_str()
@@ -532,13 +623,13 @@ mod tests {
     #[test]
     fn unattributed_is_its_own_series() {
         let mut reg = Registry::new();
-        reg.observe_session(
+        reg.observe_request(
             Some("2025-11-25"),
             "2025-11-25",
             "claude-desktop",
             Transport::Http,
         );
-        reg.observe_session(None, "2025-11-25", "unknown", Transport::Stdio);
+        reg.observe_request(None, "2025-11-25", "unknown", Transport::Stdio);
         let snap = reg.snapshot();
         assert_eq!(snap.total, 2);
         assert_eq!(snap.unattributed, 1);
@@ -559,7 +650,7 @@ mod tests {
     fn arbitrary_labels_are_bounded() {
         let mut reg = Registry::new();
         for i in 0..100 {
-            reg.observe_session(
+            reg.observe_request(
                 Some(&format!("attacker-revision-{i}")),
                 "attacker-negotiated",
                 &format!("attacker-client-{i}"),
@@ -594,25 +685,96 @@ mod tests {
     #[test]
     fn two_percent_rule_does_not_fire_on_underattributed_or_empty() {
         let empty = Registry::new().snapshot();
-        assert!(retire_revisions(&empty).is_empty());
+        assert!(retire_revisions(&empty, MIN_MEASUREMENT_WINDOW).is_empty());
         let mut low = Registry::new();
-        low.observe_session(Some("2025-06-18"), "2025-06-18", "c", Transport::Http);
-        low.observe_session(None, "2025-11-25", "c", Transport::Http);
+        low.observe_request(Some("2025-06-18"), "2025-06-18", "c", Transport::Http);
+        low.observe_request(None, "2025-11-25", "c", Transport::Http);
         // 50% attributed < 80% floor
-        assert!(retire_revisions(&low.snapshot()).is_empty());
+        assert!(retire_revisions(&low.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
     }
 
     #[test]
     fn two_percent_rule_retires_only_below_floor_when_attributed() {
         let mut reg = Registry::new();
         for _ in 0..99 {
-            reg.observe_session(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
+            reg.observe_request(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
         }
-        reg.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
-        let retired = retire_revisions(&reg.snapshot());
+        reg.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+        assert!(retire_revisions(&reg.snapshot(), Duration::from_secs(1)).is_empty());
+        let retired = retire_revisions(&reg.snapshot(), MIN_MEASUREMENT_WINDOW);
         assert!(retired.iter().any(|r| r == "2024-11-05"));
         assert!(retired.iter().any(|r| r == "2024-10-07"));
         assert!(!retired.iter().any(|r| r == "2025-11-25"));
+    }
+
+    #[test]
+    fn modern_request_is_observed_without_initialize() {
+        let before = global_snapshot();
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    META_PROTOCOL_VERSION: "2026-07-28",
+                    META_CLIENT_INFO: {"name": "Codex"}
+                }
+            }
+        });
+        observe_inbound_request(
+            &request,
+            request.get("params"),
+            "tools/list",
+            None,
+            None,
+            Transport::Http,
+        );
+        let after = global_snapshot();
+        assert!(
+            after.by_revision.get("2026-07-28").copied().unwrap_or(0)
+                > before.by_revision.get("2026-07-28").copied().unwrap_or(0)
+        );
+        assert!(
+            after.by_client.get("codex").copied().unwrap_or(0)
+                > before.by_client.get("codex").copied().unwrap_or(0)
+        );
+    }
+
+    #[test]
+    fn legacy_stdio_followup_reuses_bounded_initialize_attribution() {
+        let session_id = "mik-7218-legacy-stdio";
+        let before = global_snapshot();
+        let initialize = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "clientInfo": {"name": "Claude Desktop"}
+            }
+        });
+        observe_inbound_request(
+            &initialize,
+            initialize.get("params"),
+            "initialize",
+            None,
+            Some(session_id),
+            Transport::Stdio,
+        );
+        let followup = json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"});
+        observe_inbound_request(
+            &followup,
+            None,
+            "tools/list",
+            None,
+            Some(session_id),
+            Transport::Stdio,
+        );
+        let after = global_snapshot();
+        assert!(
+            after.by_revision.get("2025-06-18").copied().unwrap_or(0)
+                >= before.by_revision.get("2025-06-18").copied().unwrap_or(0) + 2
+        );
     }
 
     #[test]

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -1,0 +1,463 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! MIK-7218 / RFC-0060 U1: measure which MCP revisions clients speak.
+//!
+//! Negotiation still defaults a missing `protocolVersion` to `2024-11-05`.
+//! Telemetry must not: that default would hide the unattributed share the
+//! ticket requires as its own series.
+//!
+//! Session-keyed: the first observation for a session id wins so initialize
+//! plus a later `_meta` stamp cannot double-count.
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use serde_json::Value;
+
+/// Wire key for 2026 per-request protocol revision.
+pub const META_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+/// Wire key for 2026 per-request client identity.
+pub const META_CLIENT_INFO: &str = "io.modelcontextprotocol/clientInfo";
+/// Client label when neither initialize nor `_meta` named one.
+pub const UNATTRIBUTED_CLIENT: &str = "unattributed";
+/// Fail-fast: do not freeze the compatibility window below this attribution rate.
+pub const ATTRIBUTION_FLOOR: f64 = 0.80;
+/// Pre-registered retire threshold (RFC-0060 Decision 2). Written before data.
+pub const RETIRE_BELOW_SHARE: f64 = 0.02;
+
+/// Filters that make a `tools/list` result session- or tenant-specific.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ListFilters {
+    /// API-key / principal assembly ran.
+    pub principal: bool,
+    /// Routing-profile assembly ran.
+    pub profile: bool,
+    /// Session-scoped assembly ran (promoted tools, session id).
+    pub session: bool,
+}
+
+impl ListFilters {
+    /// True when any filter that forbids `cacheScope=public` is on.
+    pub fn any(self) -> bool {
+        self.principal || self.profile || self.session
+    }
+}
+
+/// `cacheScope` the 2026-07-28 list result would advertise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheScope {
+    /// Unfiltered meta-tool skeleton only.
+    Public,
+    /// Anything assembled under principal, profile, or session state.
+    Private,
+}
+
+impl CacheScope {
+    /// Wire string the spec uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Private => "private",
+        }
+    }
+}
+
+/// One `tools/list` shadow observation. Never attached to the live response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolsListShadow {
+    /// Whether a principal filter ran.
+    pub principal: bool,
+    /// Whether a profile filter ran.
+    pub profile: bool,
+    /// Whether a session filter ran.
+    pub session: bool,
+    /// Scope the decision table would emit. Not sent to the client in this spike.
+    pub would_emit_cache_scope: CacheScope,
+}
+
+/// Process-wide counters plus the session ids already counted.
+#[derive(Debug, Default)]
+pub struct Registry {
+    seen_sessions: HashSet<String>,
+    by_revision: BTreeMap<String, u64>,
+    by_client: BTreeMap<String, u64>,
+    unattributed: u64,
+    total: u64,
+    shadows: Vec<ToolsListShadow>,
+}
+
+/// Snapshot for `/metrics` tests and the Linear table.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Snapshot {
+    /// Sessions whose revision was named on the wire.
+    pub by_revision: BTreeMap<String, u64>,
+    /// Sessions grouped by client identity (includes `unattributed`).
+    pub by_client: BTreeMap<String, u64>,
+    /// Sessions with no revision on either path. Own series, not a revision key.
+    pub unattributed: u64,
+    /// All observed sessions, attributed or not.
+    pub total: u64,
+}
+
+impl Registry {
+    /// Empty counters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one inbound session. Later observations for the same id are ignored.
+    pub fn observe_session(
+        &mut self,
+        session_id: &str,
+        revision: Option<&str>,
+        client: &str,
+    ) -> bool {
+        if !self.seen_sessions.insert(session_id.to_string()) {
+            return false;
+        }
+        self.total += 1;
+        let client = if client.is_empty() {
+            UNATTRIBUTED_CLIENT
+        } else {
+            client
+        };
+        *self.by_client.entry(client.to_string()).or_insert(0) += 1;
+        match revision.map(str::trim).filter(|v| !v.is_empty()) {
+            Some(rev) => {
+                *self.by_revision.entry(rev.to_string()).or_insert(0) += 1;
+            }
+            None => self.unattributed += 1,
+        }
+        true
+    }
+
+    /// Shadow-log one `tools/list` (not session-deduped: every list is a cache decision).
+    pub fn shadow_tools_list(&mut self, filters: ListFilters) -> ToolsListShadow {
+        let shadow = ToolsListShadow {
+            principal: filters.principal,
+            profile: filters.profile,
+            session: filters.session,
+            would_emit_cache_scope: cache_scope_decision(filters),
+        };
+        self.shadows.push(shadow.clone());
+        shadow
+    }
+
+    /// Current counters.
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            by_revision: self.by_revision.clone(),
+            by_client: self.by_client.clone(),
+            unattributed: self.unattributed,
+            total: self.total,
+        }
+    }
+
+    /// Shadow log, oldest first.
+    pub fn shadows(&self) -> &[ToolsListShadow] {
+        &self.shadows
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Revision the client asked for. `_meta` wins when both are present.
+///
+/// Missing is `None`. The initialize negotiator's `2024-11-05` default is
+/// deliberately not applied here.
+pub fn requested_revision(
+    initialize_params: Option<&Value>,
+    request_meta: Option<&Value>,
+) -> Option<String> {
+    meta_string(request_meta, META_PROTOCOL_VERSION)
+        .or_else(|| {
+            initialize_params.and_then(|p| p.get("protocolVersion")?.as_str().map(str::to_string))
+        })
+        .filter(|s| !s.is_empty())
+}
+
+/// Client name from initialize `clientInfo` or 2026 `_meta` clientInfo.
+pub fn client_identity(initialize_params: Option<&Value>, request_meta: Option<&Value>) -> String {
+    client_info_name(request_meta.and_then(|m| m.get(META_CLIENT_INFO)))
+        .or_else(|| client_info_name(initialize_params.and_then(|p| p.get("clientInfo"))))
+        .unwrap_or_else(|| UNATTRIBUTED_CLIENT.to_string())
+}
+
+fn client_info_name(value: Option<&Value>) -> Option<String> {
+    let name = value?.get("name")?.as_str()?.trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn meta_string(meta: Option<&Value>, key: &str) -> Option<String> {
+    meta?.get(key)?.as_str().map(str::to_string)
+}
+
+/// `_meta` may sit on the JSON-RPC request root or on `params`.
+pub fn request_meta<'a>(request: &'a Value, params: Option<&'a Value>) -> Option<&'a Value> {
+    request
+        .get("_meta")
+        .or_else(|| params.and_then(|p| p.get("_meta")))
+}
+
+/// Decision table from RFC-0060: public only for the unfiltered skeleton.
+pub fn cache_scope_decision(filters: ListFilters) -> CacheScope {
+    if filters.any() {
+        CacheScope::Private
+    } else {
+        CacheScope::Public
+    }
+}
+
+/// Hazard the ticket wants raised: `public` advertised over filtered assembly.
+pub fn public_over_filtered(filters: ListFilters, scope: CacheScope) -> bool {
+    scope == CacheScope::Public && filters.any()
+}
+
+/// Attributed sessions / total. Empty window is 0.0, not NaN.
+pub fn attribution_rate(snapshot: &Snapshot) -> f64 {
+    if snapshot.total == 0 {
+        return 0.0;
+    }
+    let attributed = snapshot.total.saturating_sub(snapshot.unattributed);
+    attributed as f64 / snapshot.total as f64
+}
+
+/// Revisions below 2% of total. Empty or under-attributed windows return none
+/// (RFC-0060 stop criterion: do not narrow on partial data).
+pub fn retire_revisions(snapshot: &Snapshot) -> Vec<String> {
+    if snapshot.total == 0 || attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
+        return Vec::new();
+    }
+    let total = snapshot.total as f64;
+    snapshot
+        .by_revision
+        .iter()
+        .filter(|(_, n)| (**n as f64 / total) < RETIRE_BELOW_SHARE)
+        .map(|(rev, _)| rev.clone())
+        .collect()
+}
+
+/// Markdown table for the Linear comment. Unattributed is its own row, not a revision.
+pub fn distribution_table(snapshot: &Snapshot) -> String {
+    let mut rows = String::from("| revision | sessions | share |\n| --- | ---: | ---: |\n");
+    for (rev, n) in &snapshot.by_revision {
+        rows.push_str(&format!(
+            "| {rev} | {n} | {:.1}% |\n",
+            share(*n, snapshot.total)
+        ));
+    }
+    rows.push_str(&format!(
+        "| unattributed | {} | {:.1}% |\n",
+        snapshot.unattributed,
+        share(snapshot.unattributed, snapshot.total)
+    ));
+    rows.push_str(&format!("| total | {} | 100% |\n", snapshot.total));
+    rows
+}
+
+fn share(n: u64, total: u64) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        (n as f64 / total as f64) * 100.0
+    }
+}
+
+fn global() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::new()))
+}
+
+/// Record one inbound session on the process registry.
+pub fn observe_inbound(
+    session_id: &str,
+    initialize_params: Option<&Value>,
+    request_meta: Option<&Value>,
+) {
+    let revision = requested_revision(initialize_params, request_meta);
+    let client = client_identity(initialize_params, request_meta);
+    let mut reg = global().lock().unwrap_or_else(|e| e.into_inner());
+    let recorded = reg.observe_session(session_id, revision.as_deref(), &client);
+    drop(reg);
+    if recorded {
+        emit_session_metrics(revision.as_deref(), &client);
+    }
+}
+
+/// Shadow-log one `tools/list` on the process registry.
+pub fn observe_tools_list(filters: ListFilters) -> ToolsListShadow {
+    let mut reg = global().lock().unwrap_or_else(|e| e.into_inner());
+    let shadow = reg.shadow_tools_list(filters);
+    drop(reg);
+    tracing::info!(
+        principal = shadow.principal,
+        profile = shadow.profile,
+        session = shadow.session,
+        would_emit_cache_scope = shadow.would_emit_cache_scope.as_str(),
+        public_over_filtered = public_over_filtered(filters, shadow.would_emit_cache_scope),
+        "mcp728.u1 tools/list cacheScope shadow"
+    );
+    shadow
+}
+
+/// Process snapshot for the measurement table.
+pub fn global_snapshot() -> Snapshot {
+    global()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .snapshot()
+}
+
+/// Process shadow log.
+pub fn global_shadows() -> Vec<ToolsListShadow> {
+    global()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .shadows()
+        .to_vec()
+}
+
+fn emit_session_metrics(revision: Option<&str>, client: &str) {
+    let _ = (revision, client);
+    #[cfg(feature = "metrics")]
+    {
+        if let Some(rev) = revision {
+            telemetry_metrics::counter!(
+                "mcp_protocol_revision_sessions_total",
+                "revision" => rev.to_string(),
+                "client" => client.to_string()
+            )
+            .increment(1);
+        } else {
+            telemetry_metrics::counter!(
+                "mcp_protocol_revision_unattributed_sessions_total",
+                "client" => client.to_string()
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn reset_global_for_tests() {
+    global().lock().unwrap_or_else(|e| e.into_inner()).reset();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn initialize_protocol_version_is_attributed() {
+        let params = json!({"protocolVersion": "2025-06-18", "clientInfo": {"name": "claude"}});
+        assert_eq!(
+            requested_revision(Some(&params), None).as_deref(),
+            Some("2025-06-18")
+        );
+        assert_eq!(client_identity(Some(&params), None), "claude");
+    }
+
+    #[test]
+    fn missing_protocol_version_is_unattributed_not_defaulted() {
+        let params = json!({"clientInfo": {"name": "old"}});
+        assert_eq!(requested_revision(Some(&params), None), None);
+        assert_eq!(requested_revision(None, None), None);
+    }
+
+    #[test]
+    fn meta_protocol_version_wins_over_initialize() {
+        let params = json!({"protocolVersion": "2025-06-18"});
+        let meta = json!({META_PROTOCOL_VERSION: "2026-07-28"});
+        assert_eq!(
+            requested_revision(Some(&params), Some(&meta)).as_deref(),
+            Some("2026-07-28")
+        );
+    }
+
+    #[test]
+    fn unattributed_is_its_own_series() {
+        let mut reg = Registry::new();
+        reg.observe_session("s1", Some("2025-11-25"), "claude");
+        reg.observe_session("s2", None, "unknown");
+        let snap = reg.snapshot();
+        assert_eq!(snap.total, 2);
+        assert_eq!(snap.unattributed, 1);
+        assert_eq!(snap.by_revision.get("2025-11-25"), Some(&1));
+        assert!(!snap.by_revision.contains_key("unattributed"));
+        assert!((attribution_rate(&snap) - 0.5).abs() < f64::EPSILON);
+        let table = distribution_table(&snap);
+        assert!(table.contains("| unattributed | 1 |"));
+        assert!(!table.contains("| unattributed | 1 |\n| unattributed |"));
+    }
+
+    #[test]
+    fn same_session_is_not_double_counted() {
+        let mut reg = Registry::new();
+        assert!(reg.observe_session("s1", Some("2025-06-18"), "a"));
+        assert!(!reg.observe_session("s1", Some("2026-07-28"), "a"));
+        assert_eq!(reg.snapshot().total, 1);
+        assert_eq!(reg.snapshot().by_revision.get("2025-06-18"), Some(&1));
+    }
+
+    #[test]
+    fn cache_scope_public_only_when_unfiltered() {
+        assert_eq!(
+            cache_scope_decision(ListFilters::default()),
+            CacheScope::Public
+        );
+        let filtered = ListFilters {
+            principal: true,
+            profile: false,
+            session: false,
+        };
+        assert_eq!(cache_scope_decision(filtered), CacheScope::Private);
+        assert!(!public_over_filtered(filtered, CacheScope::Private));
+        assert!(public_over_filtered(filtered, CacheScope::Public));
+    }
+
+    #[test]
+    fn two_percent_rule_does_not_fire_on_underattributed_or_empty() {
+        let empty = Registry::new().snapshot();
+        assert!(retire_revisions(&empty).is_empty());
+        let mut low = Registry::new();
+        low.observe_session("a", Some("2025-06-18"), "c");
+        low.observe_session("b", None, "c");
+        // 50% attributed < 80% floor
+        assert!(retire_revisions(&low.snapshot()).is_empty());
+    }
+
+    #[test]
+    fn two_percent_rule_retires_only_below_floor_when_attributed() {
+        let mut reg = Registry::new();
+        for i in 0..99 {
+            reg.observe_session(&format!("keep-{i}"), Some("2025-11-25"), "c");
+        }
+        reg.observe_session("rare", Some("2024-11-05"), "c");
+        let retired = retire_revisions(&reg.snapshot());
+        assert_eq!(retired, vec!["2024-11-05".to_string()]);
+        assert!(!retired.iter().any(|r| r == "2025-11-25"));
+    }
+
+    #[test]
+    fn shadow_tools_list_records_filters_and_would_be_scope() {
+        let mut reg = Registry::new();
+        let shadow = reg.shadow_tools_list(ListFilters {
+            principal: false,
+            profile: true,
+            session: true,
+        });
+        assert!(shadow.profile && shadow.session);
+        assert_eq!(shadow.would_emit_cache_scope, CacheScope::Private);
+        assert_eq!(reg.shadows().len(), 1);
+    }
+}

--- a/src/protocol_revision_telemetry.rs
+++ b/src/protocol_revision_telemetry.rs
@@ -10,6 +10,7 @@
 //! plus a later `_meta` stamp cannot double-count.
 
 use std::collections::{BTreeMap, HashSet};
+use std::fmt::Write as _;
 use std::sync::{Mutex, OnceLock};
 
 use serde_json::Value;
@@ -227,7 +228,7 @@ pub fn attribution_rate(snapshot: &Snapshot) -> f64 {
         return 0.0;
     }
     let attributed = snapshot.total.saturating_sub(snapshot.unattributed);
-    attributed as f64 / snapshot.total as f64
+    ratio(attributed, snapshot.total)
 }
 
 /// Revisions below 2% of total. Empty or under-attributed windows return none
@@ -236,11 +237,10 @@ pub fn retire_revisions(snapshot: &Snapshot) -> Vec<String> {
     if snapshot.total == 0 || attribution_rate(snapshot) < ATTRIBUTION_FLOOR {
         return Vec::new();
     }
-    let total = snapshot.total as f64;
     snapshot
         .by_revision
         .iter()
-        .filter(|(_, n)| (**n as f64 / total) < RETIRE_BELOW_SHARE)
+        .filter(|(_, n)| ratio(**n, snapshot.total) < RETIRE_BELOW_SHARE)
         .map(|(rev, _)| rev.clone())
         .collect()
 }
@@ -249,17 +249,18 @@ pub fn retire_revisions(snapshot: &Snapshot) -> Vec<String> {
 pub fn distribution_table(snapshot: &Snapshot) -> String {
     let mut rows = String::from("| revision | sessions | share |\n| --- | ---: | ---: |\n");
     for (rev, n) in &snapshot.by_revision {
-        rows.push_str(&format!(
-            "| {rev} | {n} | {:.1}% |\n",
-            share(*n, snapshot.total)
-        ));
+        writeln!(rows, "| {rev} | {n} | {:.1}% |", share(*n, snapshot.total))
+            .expect("writing to a String cannot fail");
     }
-    rows.push_str(&format!(
-        "| unattributed | {} | {:.1}% |\n",
+    writeln!(
+        rows,
+        "| unattributed | {} | {:.1}% |",
         snapshot.unattributed,
         share(snapshot.unattributed, snapshot.total)
-    ));
-    rows.push_str(&format!("| total | {} | 100% |\n", snapshot.total));
+    )
+    .expect("writing to a String cannot fail");
+    writeln!(rows, "| total | {} | 100% |", snapshot.total)
+        .expect("writing to a String cannot fail");
     rows
 }
 
@@ -267,8 +268,15 @@ fn share(n: u64, total: u64) -> f64 {
     if total == 0 {
         0.0
     } else {
-        (n as f64 / total as f64) * 100.0
+        ratio(n, total) * 100.0
     }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn ratio(n: u64, total: u64) -> f64 {
+    // The counters remain exact integers; floating point is used only for
+    // human-facing shares and the pre-registered percentage threshold.
+    n as f64 / total as f64
 }
 
 fn global() -> &'static Mutex<Registry> {
@@ -284,7 +292,9 @@ pub fn observe_inbound(
 ) {
     let revision = requested_revision(initialize_params, request_meta);
     let client = client_identity(initialize_params, request_meta);
-    let mut reg = global().lock().unwrap_or_else(|e| e.into_inner());
+    let mut reg = global()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let recorded = reg.observe_session(session_id, revision.as_deref(), &client);
     drop(reg);
     if recorded {
@@ -294,7 +304,9 @@ pub fn observe_inbound(
 
 /// Shadow-log one `tools/list` on the process registry.
 pub fn observe_tools_list(filters: ListFilters) -> ToolsListShadow {
-    let mut reg = global().lock().unwrap_or_else(|e| e.into_inner());
+    let mut reg = global()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let shadow = reg.shadow_tools_list(filters);
     drop(reg);
     tracing::info!(
@@ -312,7 +324,7 @@ pub fn observe_tools_list(filters: ListFilters) -> ToolsListShadow {
 pub fn global_snapshot() -> Snapshot {
     global()
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .snapshot()
 }
 
@@ -320,7 +332,7 @@ pub fn global_snapshot() -> Snapshot {
 pub fn global_shadows() -> Vec<ToolsListShadow> {
     global()
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .shadows()
         .to_vec()
 }

--- a/src/routing_profile/mod.rs
+++ b/src/routing_profile/mod.rs
@@ -160,6 +160,12 @@ impl RoutingProfile {
         self.tool_filter.is_allowed(tool)
     }
 
+    /// Whether this profile can remove a backend or tool from discovery.
+    #[must_use]
+    pub fn is_restrictive(&self) -> bool {
+        !self.backend_filter.is_unrestricted() || !self.tool_filter.is_unrestricted()
+    }
+
     /// Human-readable summary of what this profile allows/denies.
     #[must_use]
     pub fn describe(&self) -> serde_json::Value {
@@ -202,6 +208,10 @@ impl PatternFilter {
             allow: None,
             deny: None,
         }
+    }
+
+    fn is_unrestricted(&self) -> bool {
+        self.allow.is_none() && self.deny.is_none()
     }
 
     /// Return `true` if `name` passes both the allow and deny stages.

--- a/src/routing_profile/mod.rs
+++ b/src/routing_profile/mod.rs
@@ -211,7 +211,13 @@ impl PatternFilter {
     }
 
     fn is_unrestricted(&self) -> bool {
-        self.allow.is_none() && self.deny.is_none()
+        let allow_all = self.allow.as_ref().is_none_or(|patterns| {
+            patterns
+                .iter()
+                .any(|pattern| matches!(pattern, Pattern::Wildcard))
+        });
+        let deny_nothing = self.deny.as_ref().is_none_or(Vec::is_empty);
+        allow_all && deny_nothing
     }
 
     /// Return `true` if `name` passes both the allow and deny stages.

--- a/src/routing_profile/tests.rs
+++ b/src/routing_profile/tests.rs
@@ -37,6 +37,7 @@ fn allow_all_profile_has_unrestricted_description() {
     let profile = RoutingProfile::allow_all("open");
     // THEN: description communicates lack of restrictions
     assert!(!profile.description.is_empty());
+    assert!(!profile.is_restrictive());
 }
 
 // ── allow_tools list ─────────────────────────────────────────────────
@@ -52,6 +53,7 @@ fn allow_tools_exact_permits_listed_tool() {
 #[test]
 fn allow_tools_exact_blocks_unlisted_tool() {
     let p = profile_from(Some(&["brave_search"]), None, None, None);
+    assert!(p.is_restrictive());
     assert!(p.check("brave", "brave_suggest").is_err());
 }
 

--- a/src/routing_profile/tests.rs
+++ b/src/routing_profile/tests.rs
@@ -40,6 +40,20 @@ fn allow_all_profile_has_unrestricted_description() {
     assert!(!profile.is_restrictive());
 }
 
+#[test]
+fn wildcard_allowlist_and_empty_denylist_are_unrestricted() {
+    let profile = profile_from(Some(&["*"]), Some(&[]), Some(&["*"]), Some(&[]));
+    assert!(!profile.is_restrictive());
+    assert!(profile.check("any-backend", "any-tool").is_ok());
+}
+
+#[test]
+fn empty_allowlist_is_restrictive() {
+    let profile = profile_from(Some(&[]), None, None, None);
+    assert!(profile.is_restrictive());
+    assert!(profile.check("any-backend", "any-tool").is_err());
+}
+
 // ── allow_tools list ─────────────────────────────────────────────────
 
 #[test]

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -4,8 +4,8 @@
 
 use mcp_gateway::protocol_revision_telemetry::{
     ATTRIBUTION_FLOOR, CacheScope, ListFilters, META_CLIENT_INFO, META_PROTOCOL_VERSION,
-    MIN_MEASUREMENT_WINDOW, RETIRE_BELOW_SHARE, Registry, Transport, attribution_rate,
-    cache_scope_decision, client_identity, distribution_table, global_snapshot,
+    MIN_MEASUREMENT_WINDOW, RETIRE_BELOW_SHARE, Registry, RetirementBlocked, Transport,
+    attribution_rate, cache_scope_decision, client_identity, distribution_table, global_snapshot,
     observe_inbound_request, public_over_filtered, requested_revision, retire_revisions,
 };
 use serde_json::json;
@@ -114,7 +114,10 @@ fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
         attribution_rate(&production) < ATTRIBUTION_FLOOR,
         "empty window is not fit to decide on"
     );
-    assert!(retire_revisions(&production, MIN_MEASUREMENT_WINDOW).is_empty());
+    assert_eq!(
+        retire_revisions(&production, MIN_MEASUREMENT_WINDOW),
+        Err(RetirementBlocked::NoObservations)
+    );
 
     for _ in 0..5 {
         reg.observe_request(Some("2025-11-25"), "test", Transport::Http);
@@ -160,15 +163,22 @@ fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
     let mut under = Registry::new();
     under.observe_request(Some("2024-11-05"), "c", Transport::Http);
     under.observe_request(None, "c", Transport::Http);
-    assert!(retire_revisions(&under.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
+    assert_eq!(
+        retire_revisions(&under.snapshot(), MIN_MEASUREMENT_WINDOW),
+        Err(RetirementBlocked::AttributionBelowFloor)
+    );
 
     let mut full = Registry::new();
     for _ in 0..99 {
         full.observe_request(Some("2025-11-25"), "c", Transport::Http);
     }
     full.observe_request(Some("2024-11-05"), "c", Transport::Http);
-    assert!(retire_revisions(&full.snapshot(), std::time::Duration::from_secs(1)).is_empty());
-    let retired = retire_revisions(&full.snapshot(), MIN_MEASUREMENT_WINDOW);
+    assert_eq!(
+        retire_revisions(&full.snapshot(), std::time::Duration::from_secs(1)),
+        Err(RetirementBlocked::WindowTooShort)
+    );
+    let retired = retire_revisions(&full.snapshot(), MIN_MEASUREMENT_WINDOW)
+        .expect("full attributed window is actionable");
     assert!(retired.iter().any(|r| r == "2024-11-05"));
     assert!(retired.iter().any(|r| r == "2024-10-07"));
     assert!(!retired.iter().any(|r| r == "2025-11-25"));

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -4,9 +4,10 @@
 
 use mcp_gateway::protocol_revision_telemetry::{
     ATTRIBUTION_FLOOR, CacheScope, ListFilters, META_CLIENT_INFO, META_PROTOCOL_VERSION,
-    MIN_MEASUREMENT_WINDOW, RETIRE_BELOW_SHARE, Registry, RetirementBlocked, Transport,
-    attribution_rate, cache_scope_decision, client_identity, distribution_table, global_snapshot,
-    observe_inbound_request, public_over_filtered, requested_revision, retire_revisions,
+    MIN_MEASUREMENT_WINDOW, OTHER_REVISION, RETIRE_BELOW_SHARE, Registry, RetirementBlocked,
+    Transport, attribution_rate, cache_scope_decision, client_identity, distribution_table,
+    durable_window_path, global_snapshot, load_durable_window, observe_inbound_request,
+    public_over_filtered, requested_revision, retire_revisions,
 };
 use serde_json::json;
 
@@ -211,4 +212,87 @@ fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
     assert!(retired.iter().any(|r| r == "2024-11-05"));
     assert!(retired.iter().any(|r| r == "2024-10-07"));
     assert!(!retired.iter().any(|r| r == "2025-11-25"));
+}
+
+#[test]
+fn mcp728_u1_6_unknown_revisions_are_conservative() {
+    let mut blocked = Registry::new();
+    for _ in 0..98 {
+        blocked.observe_request(Some("2025-11-25"), "c", Transport::Http);
+    }
+    blocked.observe_request(Some("future-a"), "c", Transport::Http);
+    blocked.observe_request(Some("future-b"), "c", Transport::Http);
+    assert_eq!(
+        retire_revisions(&blocked.snapshot(), MIN_MEASUREMENT_WINDOW),
+        Err(RetirementBlocked::OtherAtOrAboveRetirementThreshold)
+    );
+
+    let mut upper_bound = Registry::new();
+    for _ in 0..98 {
+        upper_bound.observe_request(Some("2025-11-25"), "c", Transport::Http);
+    }
+    upper_bound.observe_request(Some("2024-11-05"), "c", Transport::Http);
+    upper_bound.observe_request(Some("future-revision"), "c", Transport::Http);
+    let snapshot = upper_bound.snapshot();
+    assert_eq!(snapshot.by_revision.get(OTHER_REVISION), Some(&1));
+    let retired = retire_revisions(&snapshot, MIN_MEASUREMENT_WINDOW)
+        .expect("one percent other is bounded into each revision's upper share");
+    assert!(!retired.iter().any(|revision| revision == "2024-11-05"));
+}
+
+#[test]
+fn mcp728_u1_2_stdio_window_survives_process_restart() {
+    let data_dir = tempfile::tempdir().expect("temporary data directory");
+    let mut first_sink =
+        mcp_gateway::protocol_revision_telemetry::DurableTelemetrySink::open(data_dir.path())
+            .expect("create durable telemetry window");
+    let mut first_process = Registry::new();
+    for _ in 0..60 {
+        first_process.observe_request(Some("2025-11-25"), "claude", Transport::Stdio);
+    }
+    first_process.shadow_tools_list(ListFilters::default());
+    first_sink
+        .persist_registry(&first_process)
+        .expect("persist first process counters");
+    let first_window = load_durable_window(data_dir.path()).expect("load first process window");
+    assert_eq!(first_window.snapshot.total, 60);
+    assert_eq!(first_window.tools_list_shadow.values().sum::<u64>(), 1);
+
+    drop(first_sink);
+    let mut restarted_sink =
+        mcp_gateway::protocol_revision_telemetry::DurableTelemetrySink::open(data_dir.path())
+            .expect("reopen durable telemetry window");
+    let mut restarted_process = Registry::new();
+    for _ in 0..40 {
+        restarted_process.observe_request(Some("2025-11-25"), "codex", Transport::Stdio);
+    }
+    restarted_sink
+        .persist_registry(&restarted_process)
+        .expect("persist restarted process counters");
+
+    let window = load_durable_window(data_dir.path()).expect("load aggregate after restart");
+    assert_eq!(
+        window.started_at_unix_seconds,
+        first_window.started_at_unix_seconds
+    );
+    assert_eq!(window.snapshot.total, 100);
+    assert_eq!(window.snapshot.by_transport.get("stdio"), Some(&100));
+    assert_eq!(window.tools_list_shadow.len(), 16);
+    assert_eq!(
+        durable_window_path(data_dir.path()).file_name().unwrap(),
+        "window.json"
+    );
+    assert_eq!(
+        window.retirement_decision_at(
+            window.started_at_unix_seconds + MIN_MEASUREMENT_WINDOW.as_secs() - 1
+        ),
+        Err(RetirementBlocked::WindowTooShort)
+    );
+    assert!(
+        window
+            .retirement_decision_at(
+                window.started_at_unix_seconds + MIN_MEASUREMENT_WINDOW.as_secs()
+            )
+            .is_ok()
+    );
 }

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -7,7 +7,7 @@ use mcp_gateway::protocol_revision_telemetry::{
     MIN_MEASUREMENT_WINDOW, OTHER_REVISION, RETIRE_BELOW_SHARE, Registry, RetirementBlocked,
     Transport, attribution_rate, cache_scope_decision, client_identity, distribution_table,
     durable_window_path, global_snapshot, load_durable_window, observe_inbound_request,
-    public_over_filtered, requested_revision, retire_revisions,
+    production_retirement_decision_at, public_over_filtered, requested_revision, retire_revisions,
 };
 use serde_json::json;
 
@@ -294,5 +294,51 @@ fn mcp728_u1_2_stdio_window_survives_process_restart() {
                 window.started_at_unix_seconds + MIN_MEASUREMENT_WINDOW.as_secs()
             )
             .is_ok()
+    );
+}
+
+#[test]
+fn mcp728_u1_4_production_decision_intersects_http_and_stdio_windows() {
+    let data_dir = tempfile::tempdir().expect("temporary data directory");
+    let mut sink =
+        mcp_gateway::protocol_revision_telemetry::DurableTelemetrySink::open(data_dir.path())
+            .expect("create durable telemetry window");
+    let mut stdio = Registry::new();
+    for _ in 0..99 {
+        stdio.observe_request(Some("2025-11-25"), "stdio", Transport::Stdio);
+    }
+    stdio.observe_request(Some("2024-11-05"), "stdio", Transport::Stdio);
+    sink.persist_registry(&stdio)
+        .expect("persist stdio production counters");
+
+    let window = load_durable_window(data_dir.path()).expect("load durable start time");
+    let mut http = Registry::new();
+    for _ in 0..98 {
+        http.observe_request(Some("2025-11-25"), "http", Transport::Http);
+    }
+    for _ in 0..2 {
+        http.observe_request(Some("2024-11-05"), "http", Transport::Http);
+    }
+
+    let candidates = production_retirement_decision_at(
+        data_dir.path(),
+        &http.snapshot(),
+        window.started_at_unix_seconds,
+        window.started_at_unix_seconds + MIN_MEASUREMENT_WINDOW.as_secs(),
+    )
+    .expect("evaluate production window")
+    .expect("aligned windows are actionable");
+    assert!(!candidates.iter().any(|revision| revision == "2024-11-05"));
+    assert!(candidates.iter().any(|revision| revision == "2024-10-07"));
+
+    assert_eq!(
+        production_retirement_decision_at(
+            data_dir.path(),
+            &http.snapshot(),
+            window.started_at_unix_seconds + 1,
+            window.started_at_unix_seconds + MIN_MEASUREMENT_WINDOW.as_secs(),
+        )
+        .expect("evaluate misaligned window"),
+        Err(RetirementBlocked::WindowMisaligned)
     );
 }

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -75,7 +75,7 @@ fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
     // snapshot must not freeze Decision 2.
     let production = Registry::new().snapshot();
     assert_eq!(production.total, 0);
-    assert_eq!(attribution_rate(&production), 0.0);
+    assert!(attribution_rate(&production).abs() <= f64::EPSILON);
     assert!(
         attribution_rate(&production) < ATTRIBUTION_FLOOR,
         "empty window is not fit to decide on"
@@ -122,7 +122,7 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
 
 #[test]
 fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
-    assert_eq!(RETIRE_BELOW_SHARE, 0.02);
+    assert!((RETIRE_BELOW_SHARE - 0.02).abs() <= f64::EPSILON);
     let mut under = Registry::new();
     under.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
     under.observe_session(None, "2025-11-25", "c", Transport::Http);

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -4,8 +4,9 @@
 
 use mcp_gateway::protocol_revision_telemetry::{
     ATTRIBUTION_FLOOR, CacheScope, ListFilters, META_CLIENT_INFO, META_PROTOCOL_VERSION,
-    RETIRE_BELOW_SHARE, Registry, attribution_rate, cache_scope_decision, client_identity,
-    distribution_table, public_over_filtered, requested_revision, retire_revisions,
+    RETIRE_BELOW_SHARE, Registry, Transport, attribution_rate, cache_scope_decision,
+    client_identity, distribution_table, public_over_filtered, requested_revision,
+    retire_revisions,
 };
 use serde_json::json;
 
@@ -35,8 +36,8 @@ fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
 #[test]
 fn mcp728_u1_2_unattributed_is_own_series_not_hidden_in_total() {
     let mut reg = Registry::new();
-    reg.observe_session("a", Some("2025-11-25"), "claude");
-    reg.observe_session("b", None, "");
+    reg.observe_session(Some("2025-11-25"), "2025-11-25", "claude", Transport::Stdio);
+    reg.observe_session(None, "2025-11-25", "", Transport::Http);
     let snap = reg.snapshot();
     assert_eq!(snap.total, 2);
     assert_eq!(snap.unattributed, 1);
@@ -57,6 +58,7 @@ fn mcp728_u1_3_tools_list_shadows_filters_and_would_be_cache_scope() {
         principal: true,
         profile: false,
         session: true,
+        request: false,
     };
     let shadow = reg.shadow_tools_list(filtered);
     assert!(shadow.principal && shadow.session);
@@ -80,8 +82,8 @@ fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
     );
     assert!(retire_revisions(&production).is_empty());
 
-    for i in 0..5 {
-        reg.observe_session(&format!("s{i}"), Some("2025-11-25"), "test");
+    for _ in 0..5 {
+        reg.observe_session(Some("2025-11-25"), "2025-11-25", "test", Transport::Http);
     }
     let table = distribution_table(&reg.snapshot());
     assert!(table.contains("2025-11-25"));
@@ -95,6 +97,7 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
             principal: true,
             profile: false,
             session: false,
+            request: false,
         },
         CacheScope::Public,
     );
@@ -104,12 +107,14 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
         principal: true,
         profile: false,
         session: false,
+        request: false,
     });
     assert!(!public_over_filtered(
         ListFilters {
             principal: shadow.principal,
             profile: shadow.profile,
             session: shadow.session,
+            request: shadow.request,
         },
         shadow.would_emit_cache_scope
     ));
@@ -119,17 +124,17 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
 fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
     assert_eq!(RETIRE_BELOW_SHARE, 0.02);
     let mut under = Registry::new();
-    under.observe_session("x", Some("2024-11-05"), "c");
-    under.observe_session("y", None, "c");
+    under.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+    under.observe_session(None, "2025-11-25", "c", Transport::Http);
     assert!(retire_revisions(&under.snapshot()).is_empty());
 
     let mut full = Registry::new();
-    for i in 0..99 {
-        full.observe_session(&format!("k{i}"), Some("2025-11-25"), "c");
+    for _ in 0..99 {
+        full.observe_session(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
     }
-    full.observe_session("old", Some("2024-11-05"), "c");
-    assert_eq!(
-        retire_revisions(&full.snapshot()),
-        vec!["2024-11-05".to_string()]
-    );
+    full.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+    let retired = retire_revisions(&full.snapshot());
+    assert!(retired.iter().any(|r| r == "2024-11-05"));
+    assert!(retired.iter().any(|r| r == "2024-10-07"));
+    assert!(!retired.iter().any(|r| r == "2025-11-25"));
 }

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -4,9 +4,9 @@
 
 use mcp_gateway::protocol_revision_telemetry::{
     ATTRIBUTION_FLOOR, CacheScope, ListFilters, META_CLIENT_INFO, META_PROTOCOL_VERSION,
-    RETIRE_BELOW_SHARE, Registry, Transport, attribution_rate, cache_scope_decision,
-    client_identity, distribution_table, public_over_filtered, requested_revision,
-    retire_revisions,
+    MIN_MEASUREMENT_WINDOW, RETIRE_BELOW_SHARE, Registry, Transport, attribution_rate,
+    cache_scope_decision, client_identity, distribution_table, global_snapshot,
+    observe_inbound_request, public_over_filtered, requested_revision, retire_revisions,
 };
 use serde_json::json;
 
@@ -31,13 +31,47 @@ fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
         Some("2026-07-28")
     );
     assert_eq!(client_identity(None, Some(&meta)), "streamable-http-client");
+
+    let before = global_snapshot();
+    let modern_request = json!({
+        "jsonrpc": "2.0",
+        "id": 7218,
+        "method": "tools/list",
+        "params": {"_meta": meta}
+    });
+    observe_inbound_request(
+        &modern_request,
+        modern_request.get("params"),
+        "tools/list",
+        None,
+        None,
+        Transport::Http,
+    );
+    let legacy_request = json!({"jsonrpc": "2.0", "id": 7219, "method": "tools/list"});
+    observe_inbound_request(
+        &legacy_request,
+        None,
+        "tools/list",
+        Some("2025-06-18"),
+        None,
+        Transport::Http,
+    );
+    let after = global_snapshot();
+    assert!(
+        after.by_revision.get("2026-07-28").copied().unwrap_or(0)
+            > before.by_revision.get("2026-07-28").copied().unwrap_or(0)
+    );
+    assert!(
+        after.by_revision.get("2025-06-18").copied().unwrap_or(0)
+            > before.by_revision.get("2025-06-18").copied().unwrap_or(0)
+    );
 }
 
 #[test]
 fn mcp728_u1_2_unattributed_is_own_series_not_hidden_in_total() {
     let mut reg = Registry::new();
-    reg.observe_session(Some("2025-11-25"), "2025-11-25", "claude", Transport::Stdio);
-    reg.observe_session(None, "2025-11-25", "", Transport::Http);
+    reg.observe_request(Some("2025-11-25"), "2025-11-25", "claude", Transport::Stdio);
+    reg.observe_request(None, "2025-11-25", "", Transport::Http);
     let snap = reg.snapshot();
     assert_eq!(snap.total, 2);
     assert_eq!(snap.unattributed, 1);
@@ -80,10 +114,10 @@ fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
         attribution_rate(&production) < ATTRIBUTION_FLOOR,
         "empty window is not fit to decide on"
     );
-    assert!(retire_revisions(&production).is_empty());
+    assert!(retire_revisions(&production, MIN_MEASUREMENT_WINDOW).is_empty());
 
     for _ in 0..5 {
-        reg.observe_session(Some("2025-11-25"), "2025-11-25", "test", Transport::Http);
+        reg.observe_request(Some("2025-11-25"), "2025-11-25", "test", Transport::Http);
     }
     let table = distribution_table(&reg.snapshot());
     assert!(table.contains("2025-11-25"));
@@ -124,16 +158,17 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
 fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
     assert!((RETIRE_BELOW_SHARE - 0.02).abs() <= f64::EPSILON);
     let mut under = Registry::new();
-    under.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
-    under.observe_session(None, "2025-11-25", "c", Transport::Http);
-    assert!(retire_revisions(&under.snapshot()).is_empty());
+    under.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+    under.observe_request(None, "2025-11-25", "c", Transport::Http);
+    assert!(retire_revisions(&under.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
 
     let mut full = Registry::new();
     for _ in 0..99 {
-        full.observe_session(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
+        full.observe_request(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
     }
-    full.observe_session(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
-    let retired = retire_revisions(&full.snapshot());
+    full.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+    assert!(retire_revisions(&full.snapshot(), std::time::Duration::from_secs(1)).is_empty());
+    let retired = retire_revisions(&full.snapshot(), MIN_MEASUREMENT_WINDOW);
     assert!(retired.iter().any(|r| r == "2024-11-05"));
     assert!(retired.iter().any(|r| r == "2024-10-07"));
     assert!(!retired.iter().any(|r| r == "2025-11-25"));

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -10,6 +10,23 @@ use mcp_gateway::protocol_revision_telemetry::{
 };
 use serde_json::json;
 
+#[cfg(feature = "metrics")]
+#[test]
+fn mcp728_u1_7_metric_series_exist_before_first_request() {
+    mcp_gateway::metrics::install();
+    mcp_gateway::protocol_revision_telemetry::register_metrics();
+    let rendered = mcp_gateway::metrics::render();
+
+    for revision in mcp_gateway::protocol_revision_telemetry::MEASURED_REVISIONS {
+        assert!(
+            rendered.contains(&format!("requested_revision=\"{revision}\"")),
+            "missing zero-valued series for {revision}"
+        );
+    }
+    assert!(rendered.contains("mcp_protocol_revision_unattributed_observations_total"));
+    assert!(rendered.contains("mcp_tools_list_cache_scope_shadow_total"));
+}
+
 #[test]
 fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
     let init = json!({

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -70,8 +70,8 @@ fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
 #[test]
 fn mcp728_u1_2_unattributed_is_own_series_not_hidden_in_total() {
     let mut reg = Registry::new();
-    reg.observe_request(Some("2025-11-25"), "2025-11-25", "claude", Transport::Stdio);
-    reg.observe_request(None, "2025-11-25", "", Transport::Http);
+    reg.observe_request(Some("2025-11-25"), "claude", Transport::Stdio);
+    reg.observe_request(None, "", Transport::Http);
     let snap = reg.snapshot();
     assert_eq!(snap.total, 2);
     assert_eq!(snap.unattributed, 1);
@@ -117,7 +117,7 @@ fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
     assert!(retire_revisions(&production, MIN_MEASUREMENT_WINDOW).is_empty());
 
     for _ in 0..5 {
-        reg.observe_request(Some("2025-11-25"), "2025-11-25", "test", Transport::Http);
+        reg.observe_request(Some("2025-11-25"), "test", Transport::Http);
     }
     let table = distribution_table(&reg.snapshot());
     assert!(table.contains("2025-11-25"));
@@ -158,15 +158,15 @@ fn mcp728_u1_5_public_over_filtered_is_detectable() {
 fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
     assert!((RETIRE_BELOW_SHARE - 0.02).abs() <= f64::EPSILON);
     let mut under = Registry::new();
-    under.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
-    under.observe_request(None, "2025-11-25", "c", Transport::Http);
+    under.observe_request(Some("2024-11-05"), "c", Transport::Http);
+    under.observe_request(None, "c", Transport::Http);
     assert!(retire_revisions(&under.snapshot(), MIN_MEASUREMENT_WINDOW).is_empty());
 
     let mut full = Registry::new();
     for _ in 0..99 {
-        full.observe_request(Some("2025-11-25"), "2025-11-25", "c", Transport::Http);
+        full.observe_request(Some("2025-11-25"), "c", Transport::Http);
     }
-    full.observe_request(Some("2024-11-05"), "2024-11-05", "c", Transport::Http);
+    full.observe_request(Some("2024-11-05"), "c", Transport::Http);
     assert!(retire_revisions(&full.snapshot(), std::time::Duration::from_secs(1)).is_empty());
     let retired = retire_revisions(&full.snapshot(), MIN_MEASUREMENT_WINDOW);
     assert!(retired.iter().any(|r| r == "2024-11-05"));

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -185,6 +185,18 @@ fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
         Err(RetirementBlocked::AttributionBelowFloor)
     );
 
+    let mut ambiguous = Registry::new();
+    for _ in 0..95 {
+        ambiguous.observe_request(Some("2025-11-25"), "c", Transport::Http);
+    }
+    for _ in 0..5 {
+        ambiguous.observe_request(None, "c", Transport::Http);
+    }
+    assert_eq!(
+        retire_revisions(&ambiguous.snapshot(), MIN_MEASUREMENT_WINDOW),
+        Err(RetirementBlocked::UnattributedAtOrAboveRetirementThreshold)
+    );
+
     let mut full = Registry::new();
     for _ in 0..99 {
         full.observe_request(Some("2025-11-25"), "c", Transport::Http);

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! MIK-7218 acceptance tests. Drive the shipped telemetry functions, not a copy.
+
+use mcp_gateway::protocol_revision_telemetry::{
+    ATTRIBUTION_FLOOR, CacheScope, ListFilters, META_CLIENT_INFO, META_PROTOCOL_VERSION,
+    RETIRE_BELOW_SHARE, Registry, attribution_rate, cache_scope_decision, client_identity,
+    distribution_table, public_over_filtered, requested_revision, retire_revisions,
+};
+use serde_json::json;
+
+#[test]
+fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
+    let init = json!({
+        "protocolVersion": "2025-06-18",
+        "clientInfo": {"name": "stdio-client"}
+    });
+    assert_eq!(
+        requested_revision(Some(&init), None).as_deref(),
+        Some("2025-06-18")
+    );
+    assert_eq!(client_identity(Some(&init), None), "stdio-client");
+
+    let meta = json!({
+        META_PROTOCOL_VERSION: "2026-07-28",
+        META_CLIENT_INFO: {"name": "streamable-http-client"}
+    });
+    assert_eq!(
+        requested_revision(None, Some(&meta)).as_deref(),
+        Some("2026-07-28")
+    );
+    assert_eq!(client_identity(None, Some(&meta)), "streamable-http-client");
+}
+
+#[test]
+fn mcp728_u1_2_unattributed_is_own_series_not_hidden_in_total() {
+    let mut reg = Registry::new();
+    reg.observe_session("a", Some("2025-11-25"), "claude");
+    reg.observe_session("b", None, "");
+    let snap = reg.snapshot();
+    assert_eq!(snap.total, 2);
+    assert_eq!(snap.unattributed, 1);
+    assert_eq!(snap.by_revision.values().sum::<u64>(), 1);
+    assert!(
+        !snap.by_revision.contains_key("unattributed"),
+        "unattributed must not be a revision bucket"
+    );
+    let table = distribution_table(&snap);
+    assert!(table.contains("| unattributed | 1 |"));
+    assert!(table.contains("| total | 2 |"));
+}
+
+#[test]
+fn mcp728_u1_3_tools_list_shadows_filters_and_would_be_cache_scope() {
+    let mut reg = Registry::new();
+    let filtered = ListFilters {
+        principal: true,
+        profile: false,
+        session: true,
+    };
+    let shadow = reg.shadow_tools_list(filtered);
+    assert!(shadow.principal && shadow.session);
+    assert_eq!(shadow.would_emit_cache_scope, CacheScope::Private);
+    assert_eq!(cache_scope_decision(filtered), CacheScope::Private);
+    assert!(public_over_filtered(filtered, CacheScope::Public));
+    assert!(!public_over_filtered(filtered, CacheScope::Private));
+}
+
+#[test]
+fn mcp728_u1_4_measurement_window_table_and_stop_criterion() {
+    let mut reg = Registry::new();
+    // In-process window. Production week has not elapsed; empty production
+    // snapshot must not freeze Decision 2.
+    let production = Registry::new().snapshot();
+    assert_eq!(production.total, 0);
+    assert_eq!(attribution_rate(&production), 0.0);
+    assert!(
+        attribution_rate(&production) < ATTRIBUTION_FLOOR,
+        "empty window is not fit to decide on"
+    );
+    assert!(retire_revisions(&production).is_empty());
+
+    for i in 0..5 {
+        reg.observe_session(&format!("s{i}"), Some("2025-11-25"), "test");
+    }
+    let table = distribution_table(&reg.snapshot());
+    assert!(table.contains("2025-11-25"));
+    assert!(table.contains("| total | 5 |"));
+}
+
+#[test]
+fn mcp728_u1_5_public_over_filtered_is_detectable() {
+    let hazard = public_over_filtered(
+        ListFilters {
+            principal: true,
+            profile: false,
+            session: false,
+        },
+        CacheScope::Public,
+    );
+    assert!(hazard);
+    let mut reg = Registry::new();
+    let shadow = reg.shadow_tools_list(ListFilters {
+        principal: true,
+        profile: false,
+        session: false,
+    });
+    assert!(!public_over_filtered(
+        ListFilters {
+            principal: shadow.principal,
+            profile: shadow.profile,
+            session: shadow.session,
+        },
+        shadow.would_emit_cache_scope
+    ));
+}
+
+#[test]
+fn mcp728_u1_6_two_percent_rule_unadjusted_and_blocked_when_underattributed() {
+    assert_eq!(RETIRE_BELOW_SHARE, 0.02);
+    let mut under = Registry::new();
+    under.observe_session("x", Some("2024-11-05"), "c");
+    under.observe_session("y", None, "c");
+    assert!(retire_revisions(&under.snapshot()).is_empty());
+
+    let mut full = Registry::new();
+    for i in 0..99 {
+        full.observe_session(&format!("k{i}"), Some("2025-11-25"), "c");
+    }
+    full.observe_session("old", Some("2024-11-05"), "c");
+    assert_eq!(
+        retire_revisions(&full.snapshot()),
+        vec!["2024-11-05".to_string()]
+    );
+}

--- a/tests/mik_7218_acs.rs
+++ b/tests/mik_7218_acs.rs
@@ -86,6 +86,43 @@ fn mcp728_u1_1_initialize_and_meta_paths_record_revision_and_client() {
 }
 
 #[test]
+fn mcp728_u1_1_root_and_params_meta_fall_back_per_field() {
+    let before = global_snapshot();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 7220,
+        "method": "tools/list",
+        "_meta": {
+            META_PROTOCOL_VERSION: "2026-07-28"
+        },
+        "params": {
+            "_meta": {
+                META_CLIENT_INFO: {"name": "Codex"}
+            }
+        }
+    });
+
+    observe_inbound_request(
+        &request,
+        request.get("params"),
+        "tools/list",
+        None,
+        None,
+        Transport::Http,
+    );
+
+    let after = global_snapshot();
+    assert!(
+        after.by_revision.get("2026-07-28").copied().unwrap_or(0)
+            > before.by_revision.get("2026-07-28").copied().unwrap_or(0)
+    );
+    assert!(
+        after.by_client.get("codex").copied().unwrap_or(0)
+            > before.by_client.get("codex").copied().unwrap_or(0)
+    );
+}
+
+#[test]
 fn mcp728_u1_2_unattributed_is_own_series_not_hidden_in_total() {
     let mut reg = Registry::new();
     reg.observe_request(Some("2025-11-25"), "claude", Transport::Stdio);


### PR DESCRIPTION
Summary
- records MCP protocol revisions by session and transport
- counts unattributed sessions separately
- shadow-logs cacheScope without changing protocol behavior
- exposes measurement snapshots for the retirement decision

Validation
- focused Spark tests, clippy, and formatting
- no retirement decision is applied in this change

The full measurement window remains open after merge. Linear: MIK-7218