### PR TITLE
fix(session): enforce ownership for legacy MCP termination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, codex/v4-release-delivery]
 
 permissions:
   contents: read

--- a/docs/design/2026-09-06-gh452-session-delete-ownership.md
+++ b/docs/design/2026-09-06-gh452-session-delete-ownership.md
@@ -37,9 +37,16 @@ Formatting, actionlint and diff checks pass. The original failed Clippy run is
 preserved. Prior runtime reviews, critical coverage, mutation and independent
 acceptance evidence remain valid for the unchanged runtime patch.
 
-CI on the eventual PR revision, integration and release closure remain pending.
-The integration base's two ORDER.2 failures are a separate prerequisite; they
-must be resolved before this increment can pass the complete CI suite.
+This increment is committed and pushed at
+`55560ef5e7c7d1491b35b42255e41d4c00aa9127` as draft
+[PR #484](https://github.com/MikkoParkkola/mcp-gateway/pull/484).
+Its [CI run](https://github.com/MikkoParkkola/mcp-gateway/actions/runs/34064175041)
+passes 17 jobs, including Clippy and dependency audit. The Tests job fails the
+same two ORDER.2 assertions reproduced on the unchanged integration base:
+4052 library tests pass, two fail and four are ignored. Resolve that prerequisite
+before claiming passing CI. Delivery-delta review requires the two evidence
+corrections and finder confirmation; integration and release closure also remain
+pending. Runtime approvals are retained for the unchanged runtime files.
 
 **FOR:** closing the 4.0 release gap where a caller who knows another caller's
 legacy session ID can terminate that session through `DELETE /mcp`.
@@ -446,7 +453,10 @@ stream artifacts, and `cleanup-verification.json`. The concise final result is
 `gh452-independent-driver-r2/result.md`. Remote originals remain at
 `/home/mikko/codex/mcp-gateway-v4-gh452-functional/driver/20260906T145616Z-independent-r2`.
 
-Full Clippy, dependency/security scanning, integrated CI and deployment acceptance
-remain release gates owned by the delivery coordinator. This local implementation
-is uncommitted and has not been published or deployed; passing this increment's
-focused gates does not establish release completion.
+The isolated increment is committed and pushed as draft PR #484 at the revision
+recorded above. All-feature/all-target Clippy with warnings denied passes, and
+that revision's CI dependency audit and secret checks pass. The remaining gates
+are delivery-evidence finder confirmation, passing CI after the ORDER.2
+prerequisite, integration, full release acceptance and issue closure. This PR
+has not been merged, deployed or published as a release; focused acceptance
+does not establish release completion.

--- a/docs/design/2026-09-06-gh452-session-delete-ownership.md
+++ b/docs/design/2026-09-06-gh452-session-delete-ownership.md
@@ -1,0 +1,452 @@
+<!--
+SPDX-FileCopyrightText: 2026 Mikko Parkkola
+SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+-->
+
+# GH452: apply session ownership to legacy DELETE
+
+Status: design/test-plan, separate tests-as-tests and final code reviews returned
+SHIP from both vendors. The repair passes all eleven focused acceptance tests,
+fourteen existing streaming regressions and the independent seven-criterion
+endpoint drive. Changed functions have 56/56 source regions covered; critical
+mutation score is 10/11 (90.9%). CI/integration/release gates remain pending;
+this component evidence does not constitute a published release.
+Tracking: [GitHub #452](https://github.com/MikkoParkkola/mcp-gateway/issues/452).
+Release criterion: `GH452.SESSION.1`; the detailed clauses below expand this
+aggregate and preserve the original GitHub issue's acceptance mapping.
+
+## Isolated delivery checkpoint — 2026-09-07
+
+[Machine-readable delivery evidence](../release/gh452-session-ownership-evidence.json)
+records source bindings, commands, review provenance and remaining gates.
+
+The original two-file runtime patch was extracted into
+`codex/v4-session-owner-increment`, based on
+`0d4df3c0bd4e3b3ca5afa3f2d63bdb3261b118cf`. Both runtime files are byte-identical
+to their approved code-review inputs. A fresh isolated build passes all eleven
+acceptance cases and fourteen existing streaming/ownership controls. The test
+fixture now initializes `Config.auth` directly to satisfy Clippy; the existing
+assertions and configured values are unchanged. All-feature/all-target Clippy
+with warnings denied passes after that mechanical correction.
+
+Repository formatting also exposed an existing method-chain layout issue in
+`discovery_names`. The formatter-only correction is byte-identical to the
+already reviewed configuration increment. The CI selector is likewise the exact
+approved integration-branch selector; no job or permission changes are made.
+Formatting, actionlint and diff checks pass. The original failed Clippy run is
+preserved. Prior runtime reviews, critical coverage, mutation and independent
+acceptance evidence remain valid for the unchanged runtime patch.
+
+CI on the eventual PR revision, integration and release closure remain pending.
+The integration base's two ORDER.2 failures are a separate prerequisite; they
+must be resolved before this increment can pass the complete CI suite.
+
+**FOR:** closing the 4.0 release gap where a caller who knows another caller's
+legacy session ID can terminate that session through `DELETE /mcp`.
+
+**OUT:**
+
+- Changing modern protocol version negotiation or adding modern sessions.
+- Changing authentication configuration or middleware, principal derivation,
+  credential rotation, or GET/POST session creation/resumption policy. The DELETE
+  handler's credential requirement on auth-enabled deployments is in scope.
+- Redesigning the legacy stream, session expiry, task recovery, or subscriptions.
+- Removing the existing public unconditional multiplexer removal API.
+
+## Readiness and current caller proof
+
+The operator approved #452 for 4.0 and then authorized delivery of all release
+gaps on 2026-09-06. This supplies the product decision; owner-check placement and
+atomic removal are engineering decisions. This is a security/reliability increment
+with mandatory tenant isolation, not a new product capability or technology bet.
+Value is eliminating successful cross-caller termination while preserving owner
+termination; the falsifier below measures that result without inventing a monetary
+return. No dependency, storage migration, configuration key, or cryptography is added.
+
+Evidence inspected in the delivery worktree before edits:
+
+| Question | Current source / result | Consequence |
+|---|---|---|
+| Does this issue still exist? | `gh issue view 452 --json number,title,body,state,url`: OPEN; `src/gateway/router/handlers.rs:346-367` uses `has_session` then unconditional `remove_session` without caller extraction. | This is a live teardown bypass, not duplicate implementation. |
+| Is there an owner already? | `ClientSession.owner`, `src/gateway/streaming.rs:45-67`; `get_or_create_session_for`, `:169-215`, checks and stores it under `sessions.write()`. | Reuse the recorded owner; do not infer it from the session ID. |
+| Which identity is authoritative? | `session_owner`, `src/gateway/router/handlers.rs:132-147`, uses the validated credential principal, with an unauthenticated namespace. GET calls it at `:300-306`, legacy POST at `:590-596`. | DELETE must call the same helper. Same display names are not ownership. |
+| Is the caller available? | `create_router`, `src/gateway/router/mod.rs:229-260`, registers DELETE on `/mcp` inside `auth_middleware`; validated API keys receive `principal_of(key)` in `src/gateway/auth.rs:220-235`. | Extract the existing optional `AuthenticatedClient` extension, matching GET/POST. |
+| Can auth-enabled DELETE reach the handler anonymously? | `src/gateway/auth.rs:856-880` validates a presented static credential on a public route, but otherwise inserts an unauthenticated `public` client with an empty principal and continues. | The handler must require an authenticated, nonempty principal whenever auth is enabled, including a public `/mcp`. |
+| What currently calls unconditional removal? | Scoped `rg` finds the DELETE handler and the existing multiplexer test at `src/gateway/streaming.rs:578`. | Switch the HTTP caller only; preserve the public API for trusted existing consumers. |
+| Is there duplicate/in-flight work in these files? | `git diff -- src/gateway/router/handlers.rs src/gateway/streaming.rs` was empty at inspection. The delivery coordinator assigned this increment exclusive ownership of DELETE and owner-aware removal. | Do not modify unrelated handlers or other agents' files; recheck the narrow diff before source edits. |
+| Can GitNexus prove the graph? | Query and upstream impact for `mcp_delete_handler` and `remove_session` returned `Repository "mcp-gateway" not found. Available: hebb`. | Graph analysis is unavailable, not a zero-risk result. The static route/middleware/caller trace above is the fallback; no index mutation in a shared tree. |
+
+The inspected impact is the authenticated legacy DELETE route and its shared
+multiplexer; existing GET/POST ownership must remain unchanged. Security impact is
+material, though the implementation surface is small. The HTTP handler already
+exceeds the repository's 800-line guideline (1,644 lines); this increment changes
+only its existing function and does not undertake a router split. `streaming.rs`
+is 788 lines before this increment; if the new operation crosses 800 lines,
+extract the existing inline session-ownership tests unchanged to a sibling test
+module during implementation. New acceptance tests use the dedicated integration
+file. This is focused test organization, not a broader streaming refactor.
+The coordinator owns review receipts, tracker metadata and final delivery gates.
+
+## Chosen behavior
+
+Add a crate-visible `NotificationMultiplexer::remove_session_for` operation taking
+a session ID and the resolved owner key. Acquire the sessions write lock once,
+use `HashMap::entry` to obtain one occupied entry, compare its stored owner, and
+remove only the matching entry while that same guard is held. Return one boolean:
+a matching entry was removed, or it was not. Do not expose separate unknown/foreign
+states and do not compose a read check with a later
+unconditional delete. This serializes deletion against session creation, expiry,
+and another deletion without a new lock or an await while holding the guard.
+
+`mcp_delete_handler` extracts the same optional authenticated-client extension used
+by GET. Before reading the session ID or looking up a session, if
+`state.auth_config.enabled` is true, it requires a client with `authenticated=true`
+and a nonempty principal. Otherwise it returns the existing
+`bearer_unauthorized_response` (HTTP 401 with the standard bearer challenge),
+independent of the supplied session ID. This applies when `/mcp` is configured as
+a public path too. It then derives `session_owner` and calls the owner-aware
+operation. A successful removal remains HTTP 204. Unknown and foreign IDs both return HTTP 404 with the
+same empty body and response headers. Neither refusal changes session state nor
+creates a replacement session. After the authentication precondition, missing or
+non-text session headers remain HTTP 400; an empty text ID follows the existing
+unknown-ID behavior. With authentication
+disabled, HTTP sessions share the same existing unauthenticated owner and can
+still be deleted. Public anonymous sessions on an auth-enabled deployment remain
+usable according to the unchanged GET/POST policy, but cannot be terminated by
+anonymous DELETE; existing expiry remains their cleanup path. Valid credentials
+on that same public route retain ordinary owner deletion.
+
+Retain the existing successful termination log. Refusals share one message and
+must not log a stored owner or validated credential. The existing public
+`remove_session` remains a trusted in-process cleanup API and is no longer reached
+from HTTP DELETE. The new operation is crate-visible, so there is no added public
+library API. No automatic retry or resurrection is introduced.
+
+| Alternative | Reason not selected |
+|---|---|
+| Check owner via a getter, then call `remove_session` | Ownership and mutation would occur under different lock acquisitions; a replacement entry could be removed after the check. |
+| Bind DELETE to display name | Distinct configured credentials may share a name; GET/POST already reject that identity model. |
+| Return 403 for foreign IDs and 404 for unknown IDs | Discloses whether a session exists; contradicts issue and release acceptance. |
+| Reject all DELETE requests | Avoids the bypass but breaks supported legacy owner termination. |
+| Change the public `remove_session` signature | Needlessly breaks library callers for an HTTP authorization repair. |
+
+## Acceptance criteria and discriminating test plan
+
+Tests live in `tests/gh452_session_owner.rs`, following the real `create_router`
+and `AppState` fixture used in `tests/nfr_sec1_controls.rs`. Configure actual test
+API keys and pass them through authentication middleware. Obtain IDs through
+legacy GET/POST requests; do not seed an owner string or fabricate an authenticated
+extension. Use the legacy protocol version explicitly so the modern stateless
+path cannot make an ownership assertion vacuously pass. Do not depend on live
+backends, account credentials, or Spark for this increment.
+
+The issue's original `MIK.SESSION.1-4` identifiers map respectively to the foreign,
+owner, indistinguishability and router coverage rows below. The release's single
+`GH452.SESSION.1` row is the aggregate requirement; `.2-.7` are its detailed cases.
+
+| Stable ID | Given / action / required result | V-model level; type | Discriminating assertion / expected red evidence |
+|---|---|---|---|
+| `GH452.SESSION.1` | A and B create distinct sessions. B DELETEs A's ID. A's session remains usable, B's remains untouched, DELETE is 404. | Integration; authorization regression | Check original session presence/count before resuming, then POST ping as A with the original ID and verify response ID. Retain A's original SSE response and deliver a tagged notification after refusal to prove the original stream survived, rather than a new session being created with the old ID. Pre-fix DELETE returns 204 and removes A. |
+| `GH452.SESSION.2` | A DELETEs its own ID; response is 204, original entry disappears, a second DELETE is 404, B still works. | Integration; positive lifecycle/control | Assert both HTTP status and absence before any request that might recreate an entry; stream delivery to the removed ID fails. Prevents a deny-all implementation from passing. |
+| `GH452.SESSION.3` | B DELETEs a never-created ID and A's live ID. | Integration; privacy/negative | Compare 404 status, empty bodies and response headers; verify neither request changes count or the live entry. Pre-fix status differs. Compare semantic response metadata, excluding any generic per-request trace header if added independently. |
+| `GH452.SESSION.4` | Missing and non-text session header, auth disabled owner session, and missing credentials with auth enabled. | Integration; boundary/compatibility | After the auth gate has passed, missing/non-text ID is 400 and empty text ID is 404. Auth-disabled anonymous owner DELETE is 204, never 401; unauthenticated requests with auth enabled are refused before session lookup. These controls prevent replacing the targeted fix with a blanket refusal or bypass. |
+| `GH452.SESSION.5` | Two valid API keys share the same configured display name and have distinct secrets; one tries to delete the other's session. | Integration; identity collision regression | Through real auth and DELETE, assert 404 and original stream/session survival. A display-name-only owner mutant would incorrectly return 204. Include the name `anonymous` to cover the reserved-label namespace. |
+| `GH452.SESSION.6` | Two owner DELETE requests contend for one entry; foreign callers also attempt removal. | Integration plus source review; concurrency/lifecycle | Exactly one owner request returns 204, later requests are 404, foreign calls never remove it, and unrelated sessions survive. The interleaving test supplements rather than proves atomicity: review confirms a single write guard and occupied entry cover lookup, comparison and removal with no unlock/await. |
+| `GH452.SESSION.7` | Auth is enabled and `/mcp` is an actual configured public path. Anonymous callers create sessions through the real router, then issue DELETE for a known public session and an unknown ID. A valid credential tries deleting that public anonymous session and also creates and deletes its own session on that public path. | Integration; public-route bypass regression | Both anonymous DELETEs receive identical 401 bearer-challenge responses and leave original streams and counts intact. A valid authenticated nonowner DELETE of the public session is 404 and preserves both original streams; valid authenticated owner DELETE remains 204. Include a request with no ID and with an invalid credential to prove refusal occurs before lookup and that a presented-but-unvalidated credential cannot bypass it. Pre-fix known public session deletion returns 204. |
+
+## Contract event and review receipt, 2026-09-06
+
+The first review found a missing authorization precondition: an auth-enabled
+deployment can expose `/mcp` as public, and its anonymous sessions share the
+`unauthenticated:public` owner. Comparing owners alone would continue to permit
+cross-caller teardown in that configuration. Verified against
+`src/gateway/auth.rs:856-880`; disposition: **fix it in this change**. The scope
+now explicitly includes a DELETE-only credential gate when authentication is
+enabled, while auth-disabled deployments retain their shared-owner compatibility.
+This changes the first draft's public anonymous DELETE contract and adds
+`GH452.SESSION.7`; design and test-plan confirmation are required before tests.
+No authentication middleware behavior or GET/POST contract is changed.
+
+The coordinator reports the following receipts as SHIP-WITH-FIXES on the same
+original material:
+
+- GPT: `gpt-20260906T125419Z-64997`, evidence at
+  `/Users/mikko/.claude/data/reviews/runs/gpt-20260906T125419Z-64997.md`.
+- Grok: `grok-20260906T125419Z-64996`, evidence at
+  `/Users/mikko/.claude/data/reviews/runs/grok-20260906T125419Z-64996.md`.
+
+Both found the public-route gap; `src/commands/mod.rs:176-180` confirms that the
+init template lists `/mcp` publicly. Disposition for both findings: **fix it in
+this change** with the credential precondition and `.7` route cases. The chosen
+401 challenge applies to every request without a validated principal, whether
+its ID is known, unknown or absent; it reveals no session existence. Authenticated
+foreign and unknown IDs remain identical 404s. The coordinator confirmed this
+contract after considering Grok's suggested anonymous 404. Current middleware
+does validate a presented static key before public fallback
+(`src/gateway/auth.rs:856-863`), so the public valid-key positive control remains.
+
+GPT's occupied-entry improvement is incorporated. Grok's same-thread atomicity
+test suggestion is disposed as an **observation**: a synchronous function with no
+injected pause cannot be forced to interleave by running it on one thread. The
+plan retains real competing requests plus source review of the single write
+guard, and does not claim a scheduler-dependent test proves atomicity. No new
+test-only production synchronization hook is warranted for this small operation.
+At the first-review stage these findings were addressed in the proposed design
+but not yet independently confirmed or implemented; subsequent confirmation is
+recorded below. Review prose alone does not establish acceptance.
+
+Confirmation receipts reported by the coordinator: GPT
+`gpt-20260906T130728Z-98459` and Grok `grok-20260906T130729Z-98458`, both SHIP with
+successful process exits. Both reviewed material SHA-256
+`5de39d7d1ceab1bf1749971626438c2f351ce0660a158233a14cb965c765d1fa` (49,074 bytes).
+Evidence files are under `/Users/mikko/.claude/data/reviews/runs/` with those names
+and `.md` suffixes. Grok's requested wording clarifications are incorporated:
+`.4`'s status matrix follows the auth gate, auth-disabled callers do not receive
+401, and file size may require focused extraction of existing tests.
+
+GitNexus is now available as `mcp-gateway-v4-delivery`. Upstream impact for
+`mcp_delete_handler` returned LOW with zero graph callers on 2026-09-06; this does
+not supersede the static `/mcp` route registration proof because that Rust route
+edge is absent from the graph. No behavior edit is authorized by this test stage.
+
+## Tests-as-tests review and red evidence
+
+The coordinator ran `cargo test --all-features --test gh452_session_owner --jobs 6
+-- --nocapture` on Spark before any production repair. Compilation succeeded;
+exit 101 reported five passing controls and five assertion failures. The failing
+cases observed cross-owner 204 versus required 404, foreign versus unknown
+response differences, same-name credential confusion, foreign termination among
+competing requests, and anonymous public 404 versus required 401. This is intended
+pre-fix evidence, not release acceptance. Exact log:
+`/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/gh452-red.log`.
+
+The separate test review used run ID `mcp-v4-session-tests-20260906-r1`. Both
+authoritative ledger rows and actual wrapper exits were checked: process status
+`ok`, exit 0, identical 304,897-byte material with SHA-256
+`f78959a99c8befa953907831de461a123583517c5ca0e5ee5f3f648d659edf0a`.
+Receipts: GPT `gpt-20260906T133105Z-54875` (SHIP-WITH-FIXES), Grok
+`grok-20260906T133105Z-54870` (SHIP); full outputs are in
+`/Users/mikko/.claude/data/reviews/runs/` with `.md` suffixes.
+
+| Review finding or improvement | Source check and disposition |
+|---|---|
+| Valid credential deleting someone else's public anonymous session is not covered (GPT finding; Grok improvement). | **Fix it in this change.** Public fallback has owner `unauthenticated:public`; validated credentials have their own owner. Add `gh452_session_7_public_session_rejects_authenticated_nonowner`, asserting 404, both original streams survive, and the credential holder's ping succeeds. `.7` now explicitly names this case. |
+| SESSION.5 should prove Bob's stream and calls after Alice deletes her own session (Grok). | **Fix it in this change.** Replace presence-only evidence with tagged delivery through Bob's original stream, successful ping, and unchanged remaining count. |
+| Cross-product both creation routes with every owner/foreign test (GPT). | **Observation.** Current `.1` drives GET creation plus foreign refusal; `.2` drives POST creation, GET resumption and owner deletion with the same ID. Both creation branches use the same `session_owner` helper. The existing coverage is retained; no complete cross-product is claimed. |
+| Compare only status/challenge/body rather than the whole header map (both). | **Observation.** The recorded responses contain stable `content-length` headers and no per-request trace header. Keep the stronger comparison so an added session-existence header cannot silently escape the assertion. If a generic per-request header is introduced, exclude only that named non-semantic header, as the plan already permits. |
+| Remove Bob's in-race 404 assertion (Grok). | **Observation.** Bob must receive 404 whether his request precedes or follows owner deletion. The invariant does not depend on winning a race; the test still makes no claim to prove atomicity. Retain it alongside deterministic `.1`. |
+| Share the state constructor with `nfr_sec1_controls.rs` (Grok). | **Observation.** That constructor is private to another test binary and configures a modern-protocol fixture. There is no reusable public fixture today. This increment follows the established `AppState` pattern; extracting a shared constructor would change another test suite and is not necessary to close the authorization gap. |
+
+The repaired file contains eleven tests; its source has been formatted and its
+diff checked. The coordinator's second Spark run compiled and exited 101 with
+six passes and five assertion failures, including the new authenticated nonowner
+of a public session (actual 204, required 404). Exact evidence:
+`/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/gh452-red-r2.log`.
+The contention case passed this run and failed the first, which confirms its
+classification as a concurrency regression/control, not a deterministic pre-fix
+falsifier or proof of atomicity. The owner-check and public-identity cases provide
+the deterministic reds. Focused confirmation reviewed these repaired tests.
+GitNexus does not yet index the new test symbol; the required impact query
+for the `.5` test returned UNKNOWN/not found. Static scope is that test alone and
+the new `.7` case; no production source has changed.
+
+Focused confirmation used `mcp-v4-session-tests-20260906-r2`. Authoritative GPT
+`gpt-20260906T134554Z-91005` and Grok `grok-20260906T134554Z-91000` rows both say
+SHIP, both process statuses are `ok`, and both actual wrapper exits are 0. The
+exact submitted material is 107,360 bytes, SHA-256
+`144eaa8ba1339e7e535ebcaa4e6ed0b645e1246f92201f6d64b652f6abe1d1b7`.
+The current test-file hash was checked against that frozen material after both
+reviews returned. Complete receipts are under
+`/Users/mikko/.claude/data/reviews/runs/` with the named `.md` files.
+
+Neither confirmation returned a blocking finding. The remaining suggestions are
+recorded as observations: direct unit cases for the future removal helper repeat
+the matching/foreign/unknown branches already reached by the route tests; shared
+fixture extraction has the disposition above. A full public-path response
+comparison and anonymous POST ping would broaden the matrix; `.3` already checks
+the shared DELETE response producer's privacy semantics, and `.7` directly proves
+the public original stream survives. The auth layer resolves identity before the
+same handler, and both legacy GET/POST use `session_owner`. No full cross-product
+of middleware configuration and operation is claimed. These suggestions do not
+change the approved acceptance contract or justify another test-review round.
+
+## Sequence and validation
+
+1. Coordinator obtains design and test-plan reviews before any test/source edit.
+2. Write the router tests; run `cargo test --test gh452_session_owner`. Record the
+   foreign-delete and privacy assertions failing against unchanged production
+   code. A compiler failure or a refusal from unrelated middleware is not the
+   required red evidence. Coordinator schedules the shared Rust build.
+3. Obtain the separate tests-as-tests review, then implement the narrow fix and
+   rerun that same command. Every case must pass, with no ignored/flaky tests.
+4. Run the existing `gateway::streaming` and session/router regression tests,
+   formatting, targeted Clippy and the coordinator's release gates. Review the
+   changed diff for one production caller and no credential-bearing logs.
+5. Measure changed-line coverage and mutation for this critical authorization
+   branch (target 100% changed-line coverage and at least 85% mutation score).
+   Explicitly falsify unconditional deletion, deny-all, display-name ownership,
+   and foreign/unknown response distinction; record surviving mutants as gaps.
+6. A fresh non-author driver uses a binary built from the reviewed revision and
+   exercises the endpoint's owner/foreign/unknown cases. Coordinator records the
+   revision, AC results, dual code review, CI, deployment and rollback evidence;
+   tests alone do not close #452.
+
+No unresolved product decision blocks this design. Incomplete Rust route edges
+in the available graph remain a tooling limitation; static impact and real-route tests are required
+compensating evidence. Build availability and independent review are execution
+gates owned by the delivery coordinator; if either fails, this increment remains
+unaccepted. Rollback is the previous reviewed binary/config with no data migration,
+but rolling back restores the known teardown bypass and must be recorded as such.
+
+## Local implementation handoff
+
+The coordinator authorized production implementation after the test-review gates
+closed. `mcp_delete_handler` now extracts the existing authenticated client,
+requires a validated principal when auth is enabled before inspecting the session
+header, derives the unchanged `session_owner`, and calls
+`NotificationMultiplexer::remove_session_for`. The new crate-visible operation
+uses one occupied map entry under one write guard; foreign and absent entries
+return the same false result. Only these two production symbols changed. No
+response-finalizer, authentication middleware or legacy creation path changed.
+
+Pre-edit GitNexus checks for the handler and multiplexer impl both returned LOW;
+the initially ambiguous impl/struct target was resolved with the explicit impl
+UID. Static checks supplement the missing Rust route edge and confirm the real
+`/mcp` DELETE registration reaches this operation. `streaming.rs` is exactly 800
+lines after normal formatting, so no test extraction was needed.
+
+Local `rustfmt --edition 2024 --check` for the two source files and acceptance test
+passes; `git diff --check` passes. The inspected diff is 18 added / 3 removed lines
+in the DELETE handler and 12 added lines in the multiplexer. Static AC checks
+confirm `.7`'s credential gate precedes header lookup, `.1`'s shared owner reaches
+the new removal operation, and `.6`'s lookup/comparison/removal hold the same guard
+without an await. These source checks do not replace runtime acceptance.
+
+The synchronized Spark green run passed all eleven cases under
+`cargo test --all-features --test gh452_session_owner --jobs 6 -- --nocapture`.
+The fourteen existing owner, streaming and reaper regressions also passed under
+`cargo test --all-features --lib gateway::streaming --jobs 6 -- --nocapture`.
+Logs are `mcp-gateway-v4-gh452-green.log` and
+`mcp-gateway-v4-gh452-streaming-green.log` under
+`/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/`.
+Read-only SHA-256 checks confirmed both modified source files and the acceptance
+test on Spark match the local review input. The real-route failures recorded
+before implementation now pass, including the public-session nonowner case.
+
+Self-QA inspected the final diff, checked formatting/wiring and read both runtime
+logs. The improvement pass retained the existing owner/auth response helpers and
+single occupied entry; no duplicate owner store, getter/check/remove sequence,
+extra public API, or test-only synchronization hook was introduced. No further
+behavior change was necessary after green.
+
+### Final code reviews and dispositions
+
+Final code review run `mcp-v4-session-code-20260906-r1` returned SHIP from both
+vendors. Authoritative receipts are `gpt-20260906T141238Z-56965` and
+`grok-20260906T141238Z-56960` under
+`/Users/mikko/.claude/data/reviews/runs/`, with `.md` suffixes. Both ledger rows
+have process status `ok`, both actual wrapper exits are 0, and their material
+SHA-256 and byte count match:
+`a17a0e734df4de71159ca47cff63d88b7e7d3eeecf1fc9294fabc636e9362c1c`,
+193,501 bytes. The frozen packet, manifest and process receipts are
+`gh452-code-review-r1.*` in the local scope-review evidence directory.
+
+Neither code review returned a blocking finding. Their optional improvements
+have these dispositions:
+
+| Suggestion | Disposition |
+|---|---|
+| Avoid the owned-key allocation by borrowed lookup followed by removal under the same write guard (both). | **Observation.** The accepted design chose one occupied entry for an explicit atomic compare-and-remove. The current bounded allocation has no measured regression; retain the reviewed implementation rather than change it solely for an unmeasured micro-optimization. A future measured optimization must retain the same guard throughout. |
+| Derive the credential gate from `session_owner_key` (Grok). | **Observation.** Both predicates currently require authenticated and nonempty principal, which source review confirms. Calling the string-producing helper would allocate an owner key just to test its emptiness, before producing the actual legacy owner again. This increment preserves both existing helpers and explicitly tests the public anonymous boundary. |
+| Replace the side-effecting match guard with an explicit if/else (Grok). | **Observation.** The guard calls the atomic operation exactly once; the remaining arms only choose 404 or 400. Current code follows the existing handler structure. No ambiguity or failing behavior warrants another production change. |
+
+### Mutation evidence
+
+The first copied-tree mutation attempt failed during its unmutated baseline:
+Spark's `/tmp` tmpfs ran out of space. Cargo exited 101 and cargo-mutants exited
+4; **no mutants were tested and no score is attributed to that attempt**. It also
+revealed that trailing libtest arguments did not select the baseline build
+target. The retry set a task-specific `TMPDIR` on the spacious `/home` disk and
+passed target selection to every Cargo invocation. The failed scratch directory
+was automatically removed by cargo-mutants; its full logs remain preserved.
+
+The retry command was:
+
+```text
+TMPDIR=/home/mikko/codex/mcp-gateway-v4-gh452-mutation-r2/tmp cargo mutants --all-features --file src/gateway/router/handlers.rs --file src/gateway/streaming.rs --re 'mcp_delete_handler|remove_session_for' --jobs 1 --jobserver-tasks 6 --copy-target true --output /home/mikko/codex/mcp-gateway-v4-gh452-mutation-r2 --cargo-arg=--test --cargo-arg=gh452_session_owner
+```
+
+With cargo-mutants 27.1.0, the unmutated baseline passed and all eleven mutants
+completed: **10 caught, 1 missed, 0 unviable, 0 timeout**. The raw score is
+**10/11 = 90.9%**, exceeding the planned 85% threshold without excluding the
+survivor. The actual cargo-mutants exit is **2**, because a mutant survived; it is
+not reported as a zero-exit run. Baseline build and run arguments both selected
+only `gh452_session_owner`, so unrelated in-progress lib tests were excluded.
+
+The survivor changes the inner `authenticated && !principal.is_empty()` to `||`
+at `handlers.rs:358`. A source scan of every production `AuthenticatedClient`
+constructor found only true/nonempty or false/empty states: validated static
+credentials in `gateway/auth.rs:207,222`, dashboard identity at `:735`, temporary
+and delegated tokens in `key_server/mod.rs:96,152`, and anonymous/public fallback
+at `gateway/auth.rs:797,867`. Credential principals use a nonempty digest.
+Consequently that mutant is equivalent for the current production-reachable
+identity states. This is a bounded invariant argument, not a claim that arbitrary
+fabricated extensions are equivalent. Retain the survivor in the denominator and
+retain the defensive conjunction in production; no artificial client fixture was
+added to inflate the score. The ten caught mutations cover unconditional success,
+deny-all, bypassed/reversed owner comparison, incorrect outer auth gating, removed
+negations and bypassed/reversed removal result handling.
+
+Complete logs, per-mutant diffs, `mutants.json`, `outcomes.json` and actual process
+receipts are preserved outside the repository in:
+
+- `/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/gh452-mutation-r1-infrastructure-failure/`
+- `/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/gh452-mutation-r2/`
+
+### Coverage, independent functional drive and remaining release gates
+
+The coordinator installed and verified cargo-llvm-cov 0.9.0 on Spark and ran
+`cargo llvm-cov --all-features --test gh452_session_owner --jobs 4 --json`.
+Both changed functions have all 56 source regions covered (56/56, 100%),
+excluding dependency tracing-macro regions. This is source-region coverage,
+not a branch-coverage claim. Exact summary is `gh452-critical-coverage-summary.json`,
+with full JSON and log alongside it in the local scope-review evidence directory.
+The coordinator supplied a separate AC-only brief and an immutable binary to a
+fresh non-author driver; the author did not launch or exercise that service.
+Binary SHA-256 was independently checked and matched:
+`6d128266e994d460cc5cec8d0c7d141bf93f034e04ee65f423061b667a826530`.
+The brief is `gh452-functional-driver-brief.md` in the local scope-review evidence
+directory and supplies every `GH452.SESSION.*` criterion without implementation
+or author-test material.
+
+The first independent-driver attempt failed at environment setup before any AC
+execution because of its nested sandbox. It supplies no functional pass. The
+corrected isolated run `20260906T145616Z-independent-r2` completed **7 PASS,
+0 FAIL, 0 INVESTIGATE**, with no skipped criteria. The author inspected its final
+report, machine-readable outcomes and cleanup verification. It drove authenticated,
+auth-disabled and public-MCP instances through actual HTTP, retained original SSE
+streams, and exercised missing/non-text/empty session headers, credential-identity
+separation, foreign/unknown equivalence and an observed concurrent delete schedule.
+
+Every required retained stream produced new keep-alive bytes within 1.2 seconds;
+owner teardown reached EOF within 0.05 seconds (6-second observation limit).
+Foreign and unknown response metadata matched with only Date normalized. The
+concurrency result covers one observed barrier-released schedule, not every
+interleaving. Initial raw requests that half-closed the socket produced no HTTP
+response; those inconclusive artifacts remain retained, and corrected requests
+established the reported 400/404 results. No inconclusive request is counted as a
+pass. The intentionally retained public stream kept graceful shutdown draining;
+only that recorded driver PID required forced cleanup after the acceptance checks.
+Final verification found all driver PIDs absent and all temporary ports bindable.
+
+Local driver evidence is under
+`gh452-independent-driver-r2/gh452-functional-evidence-20260906T145616Z/` in the
+scope-review directory: `report.md`, `outcomes.json`, `facts.json`, raw request and
+stream artifacts, and `cleanup-verification.json`. The concise final result is
+`gh452-independent-driver-r2/result.md`. Remote originals remain at
+`/home/mikko/codex/mcp-gateway-v4-gh452-functional/driver/20260906T145616Z-independent-r2`.
+
+Full Clippy, dependency/security scanning, integrated CI and deployment acceptance
+remain release gates owned by the delivery coordinator. This local implementation
+is uncommitted and has not been published or deployed; passing this increment's
+focused gates does not establish release completion.

--- a/docs/release/gh452-session-ownership-evidence.json
+++ b/docs/release/gh452-session-ownership-evidence.json
@@ -92,8 +92,17 @@
     "scope_limit": "One observed concurrency schedule; atomicity is supported separately by the reviewed single write guard."
   },
   "remaining_gates": [
-    "Mechanical delivery delta review",
+    "Delivery-evidence corrections and GPT finder confirmation",
     "CI on final PR revision; existing ORDER.2 failures are a separate prerequisite",
     "Integration, full release acceptance and issue closure"
-  ]
+  ],
+  "test_fixture_revision": {
+    "reviewed_sha256": "1ba5a3287fe6e96da61361b487925e8f22acfed0d89e1d621e4fd23d8c3c8e0c",
+    "current_sha256": "1027fb68293a934787ae28b36297484f20c17b20c40aebbde439d4e42e78f1ab",
+    "byte_identical_to_original_review": false,
+    "delta": "Direct initialization of unchanged Config.auth fixture; assertions and configured values unchanged. Covered by delivery-delta review, not byte identity.",
+    "review_run_id": "mcp-v4-gh452-delivery-delta-20260907-r1",
+    "gpt": "SHIP-WITH-FIXES: two evidence/documentation corrections; finder confirmation pending",
+    "grok": "SHIP"
+  }
 }

--- a/docs/release/gh452-session-ownership-evidence.json
+++ b/docs/release/gh452-session-ownership-evidence.json
@@ -1,0 +1,99 @@
+{
+  "criterion": "GH452.SESSION.1",
+  "base": "0d4df3c0bd4e3b3ca5afa3f2d63bdb3261b118cf",
+  "runtime_matches_reviewed_files": true,
+  "source_pins": {
+    "src/gateway/router/handlers.rs": "c92849aaf2043af0c17dbfb2cf2069f963b570b41e9bc9acb4ea3dc29307ff45",
+    "src/gateway/streaming.rs": "f789a86be1215773122b4e5b12c207ec05ec11c7f1ef9501f737406bdd19b8c9",
+    "tests/gh452_session_owner.rs": "1027fb68293a934787ae28b36297484f20c17b20c40aebbde439d4e42e78f1ab"
+  },
+  "code_review": {
+    "run_id": "mcp-v4-session-code-20260906-r1",
+    "material_sha256": "a17a0e734df4de71159ca47cff63d88b7e7d3eeecf1fc9294fabc636e9362c1c",
+    "gpt": "SHIP",
+    "grok": "SHIP",
+    "actual_exits": [
+      0,
+      0
+    ],
+    "unique_ledger_bindings_verified": true
+  },
+  "isolated_validation": {
+    "acceptance": {
+      "command": "cargo test --all-features --test gh452_session_owner",
+      "passed": 11,
+      "exit_code": 0
+    },
+    "streaming_controls": {
+      "commands": [
+        "cargo test --all-features --lib gateway::streaming::tests::",
+        "cargo test --all-features --lib gateway::streaming::session_ownership_tests::"
+      ],
+      "passed": [
+        9,
+        5
+      ],
+      "exit_codes": [
+        0,
+        0
+      ]
+    },
+    "clippy": {
+      "command": "cargo clippy --all-features --all-targets -- -D warnings",
+      "exit_code": 0,
+      "initial_failure": "field_reassign_with_default in test fixture; repaired by direct initialization"
+    },
+    "format": {
+      "command": "cargo fmt --check",
+      "exit_code": 0
+    },
+    "workflow": {
+      "command": "actionlint .github/workflows/ci.yml",
+      "exit_code": 0,
+      "identical_to_commit": "bfa16dc3d179d8acc9889454d66f8c23eae1ee18"
+    }
+  },
+  "unchanged_runtime_quantitative_evidence": {
+    "coverage_source_regions": {
+      "covered": 56,
+      "total": 56
+    },
+    "mutation": {
+      "caught": 10,
+      "viable": 11,
+      "missed": 1,
+      "unviable": 0,
+      "caught_percent": 90.9090909090909,
+      "missed_names": [
+        "src/gateway/router/handlers.rs:358:46: replace && with || in mcp_delete_handler"
+      ]
+    }
+  },
+  "independent_functional_acceptance": {
+    "binary_sha256": "6d128266e994d460cc5cec8d0c7d141bf93f034e04ee65f423061b667a826530",
+    "criterion_verdicts": {
+      "GH452.SESSION.1": "PASS",
+      "GH452.SESSION.2": "PASS",
+      "GH452.SESSION.3": "PASS",
+      "GH452.SESSION.4": "PASS",
+      "GH452.SESSION.5": "PASS",
+      "GH452.SESSION.6": "PASS",
+      "GH452.SESSION.7": "PASS"
+    },
+    "observations": [
+      "Foreign and unknown DELETE return indistinguishable 404 and preserve streams",
+      "Owner DELETE returns204 and terminates only its own session; repeated DELETE404",
+      "Missing/non-text headers400; missing/invalid credentials401 with Bearer challenge",
+      "Same display name does not merge credential identities",
+      "Observed concurrent owner results204/404 and foreign404",
+      "Auth-enabled public path refuses anonymous DELETE before lookup; authenticated owner remains supported"
+    ],
+    "all_owned_processes_stopped": true,
+    "scope_limit": "One observed concurrency schedule; atomicity is supported separately by the reviewed single write guard."
+  },
+  "remaining_gates": [
+    "Mechanical delivery delta review",
+    "CI on final PR revision; existing ORDER.2 failures are a separate prerequisite",
+    "Integration, full release acceptance and issue closure"
+  ]
+}

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -4656,7 +4656,9 @@ fn discovery_names(v: &Value) -> Vec<String> {
             // `gateway_search` names a tool `server:tool_name`; the other three
             // readers name it bare. Compare on the bare name so one pinned
             // literal covers all four entry points.
-            raw.rsplit_once(':').map_or(raw, |(_, name)| name).to_string()
+            raw.rsplit_once(':')
+                .map_or(raw, |(_, name)| name)
+                .to_string()
         })
         .collect();
     names.sort();

--- a/src/gateway/router/handlers.rs
+++ b/src/gateway/router/handlers.rs
@@ -345,22 +345,37 @@ pub(super) async fn mcp_sse_handler(
 /// Per MCP spec 2025-03-26, clients SHOULD send DELETE to terminate session.
 pub(super) async fn mcp_delete_handler(
     State(state): State<Arc<AppState>>,
+    client: Option<axum::Extension<AuthenticatedClient>>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    let client = client.map(|axum::Extension(c)| c);
+    // Public paths may reach this handler without a validated identity even
+    // when authentication is enabled. Their shared anonymous owner is not a
+    // credential, so refuse before inspecting any session identifier.
+    if state.auth_config.enabled
+        && !client
+            .as_ref()
+            .is_some_and(|c| c.authenticated && !c.principal.is_empty())
+    {
+        return crate::gateway::middleware::bearer_unauthorized_response(
+            "Session termination requires an authenticated credential.",
+        );
+    }
     let session_id = headers.get("mcp-session-id").and_then(|v| v.to_str().ok());
+    let owner = session_owner(client.as_ref());
 
     match session_id {
-        Some(id) if state.multiplexer.has_session(id) => {
-            state.multiplexer.remove_session(id);
+        Some(id) if state.multiplexer.remove_session_for(id, &owner) => {
             info!(session_id = %id, "Session terminated by client");
             StatusCode::NO_CONTENT
         }
         Some(id) => {
-            debug!(session_id = %id, "Session not found for DELETE");
+            debug!(session_id = %id, "No owned session for DELETE");
             StatusCode::NOT_FOUND
         }
         None => StatusCode::BAD_REQUEST,
     }
+    .into_response()
 }
 
 /// Deprecated SSE endpoint handler - surfaces a clear error instead of silent 404

--- a/src/gateway/streaming.rs
+++ b/src/gateway/streaming.rs
@@ -222,6 +222,18 @@ impl NotificationMultiplexer {
         }
     }
 
+    /// Remove only a matching owner, with lookup and removal under one write lock.
+    pub(crate) fn remove_session_for(&self, session_id: &str, owner: &str) -> bool {
+        let mut sessions = self.sessions.write();
+        match sessions.entry(session_id.to_owned()) {
+            std::collections::hash_map::Entry::Occupied(entry) if entry.get().owner == owner => {
+                entry.remove();
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Check if a session exists
     pub fn has_session(&self, session_id: &str) -> bool {
         self.sessions.read().contains_key(session_id)

--- a/tests/gh452_session_owner.rs
+++ b/tests/gh452_session_owner.rs
@@ -1,0 +1,476 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! GH452.SESSION.1-.7: legacy DELETE must enforce the owner used by GET/POST.
+//! IDs and caller identities are established through the production router.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{Body, BodyDataStream, to_bytes};
+use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode};
+use axum::response::Response;
+use futures::StreamExt;
+use mcp_gateway::backend::BackendRegistry;
+use mcp_gateway::config::{ApiKeyConfig, AuthConfig, Config};
+use mcp_gateway::gateway::auth::{DashboardBootstrap, ResolvedAuthConfig};
+use mcp_gateway::gateway::oauth::{AgentAuthState, AgentRegistry, GatewayKeyPair};
+use mcp_gateway::gateway::proxy::ProxyManager;
+use mcp_gateway::gateway::streaming::{NotificationMultiplexer, TaggedNotification};
+use mcp_gateway::gateway::test_helpers::{AppState, MetaMcp, create_router};
+use mcp_gateway::mtls::{MtlsConfig, MtlsPolicy};
+use mcp_gateway::security::{ToolPolicy, ToolPolicyConfig};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const ALICE_KEY: &str = "gh452-alice-test-credential";
+const BOB_KEY: &str = "gh452-bob-test-credential";
+
+fn state(auth_enabled: bool, public_mcp: bool, names: [&str; 2]) -> Arc<AppState> {
+    let mut config = Config {
+        auth: AuthConfig {
+            enabled: auth_enabled,
+            api_keys: [ALICE_KEY, BOB_KEY]
+                .into_iter()
+                .zip(names)
+                .map(|(key, name)| ApiKeyConfig {
+                    key: key.to_owned(),
+                    name: name.to_owned(),
+                    rate_limit: 0,
+                    backends: vec!["*".to_owned()],
+                    allowed_tools: None,
+                    denied_tools: None,
+                    admin: false,
+                })
+                .collect(),
+            public_paths: if public_mcp {
+                vec!["/mcp".to_owned()]
+            } else {
+                vec!["/health".to_owned()]
+            },
+            ..AuthConfig::default()
+        },
+        ..Config::default()
+    };
+    config.streaming.enabled = true;
+    config.streaming.auto_subscribe.clear();
+    let backends = Arc::new(BackendRegistry::new());
+    let multiplexer = Arc::new(NotificationMultiplexer::new(
+        Arc::clone(&backends),
+        config.streaming.clone(),
+    ));
+    Arc::new(AppState {
+        continuation: Arc::new(mcp_gateway::protocol::continuation::ContinuationState::new()),
+        env: None,
+        meta_mcp: Arc::new(MetaMcp::new(Arc::clone(&backends))),
+        backends,
+        meta_mcp_enabled: true,
+        proxy_manager: Arc::new(ProxyManager::new(Arc::clone(&multiplexer))),
+        multiplexer,
+        streaming_config: config.streaming.clone(),
+        auth_config: Arc::new(ResolvedAuthConfig::from_config(&config.auth)),
+        key_server: None,
+        tool_policy: Arc::new(ToolPolicy::from_config(&ToolPolicyConfig::default())),
+        mtls_policy: Arc::new(MtlsPolicy::from_config(&MtlsConfig::default())),
+        sanitize_input: false,
+        ssrf_protection: false,
+        trust_configured_backends: false,
+        inflight: Arc::new(tokio::sync::Semaphore::new(100)),
+        agent_auth: AgentAuthState::new(false, Arc::new(AgentRegistry::new())),
+        gateway_key_pair: Arc::new(GatewayKeyPair::generate().expect("test key pair")),
+        capability_dirs: Vec::new(),
+        config_path: None,
+        #[cfg(feature = "firewall")]
+        firewall: None,
+        agent_identity_config: mcp_gateway::config::AgentIdentityConfig::default(),
+        control_plane_store: None,
+        live_config: Arc::new(mcp_gateway::config_reload::LiveConfig::new(config)),
+        export_status: None,
+        transparency_log: None,
+        dashboard_bootstrap: Arc::new(DashboardBootstrap::new()),
+        subscriptions: Arc::new(
+            mcp_gateway::gateway::subscription_registry::SubscriptionRegistry::new(64),
+        ),
+    })
+}
+
+fn request(method: Method, key: Option<&str>) -> axum::http::request::Builder {
+    let mut request = Request::builder()
+        .method(method)
+        .uri("/mcp")
+        .header("mcp-protocol-version", "2025-11-25");
+    if let Some(key) = key {
+        request = request.header("authorization", format!("Bearer {key}"));
+    }
+    request
+}
+
+async fn send(state: &Arc<AppState>, request: Request<Body>) -> Response {
+    create_router(Arc::clone(state))
+        .oneshot(request)
+        .await
+        .expect("router answers")
+}
+
+async fn delete(state: &Arc<AppState>, key: Option<&str>, id: Option<&str>) -> Response {
+    let mut request = request(Method::DELETE, key);
+    if let Some(id) = id {
+        request = request.header("mcp-session-id", id);
+    }
+    send(state, request.body(Body::empty()).expect("DELETE request")).await
+}
+
+async fn response_parts(response: Response) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let (parts, body) = response.into_parts();
+    (
+        parts.status,
+        parts.headers,
+        to_bytes(body, 16_384).await.expect("bounded body").to_vec(),
+    )
+}
+
+struct Session {
+    id: String,
+    stream: BodyDataStream,
+}
+
+async fn next_event(stream: &mut BodyDataStream) -> String {
+    let bytes = tokio::time::timeout(Duration::from_secs(3), stream.next())
+        .await
+        .expect("SSE event arrives within deadline")
+        .expect("original stream remains open")
+        .expect("SSE body readable");
+    String::from_utf8(bytes.to_vec()).expect("SSE UTF-8")
+}
+
+async fn open_session(state: &Arc<AppState>, key: Option<&str>, id: Option<&str>) -> Session {
+    let mut request = request(Method::GET, key).header("accept", "text/event-stream");
+    if let Some(id) = id {
+        request = request.header("mcp-session-id", id);
+    }
+    let response = send(state, request.body(Body::empty()).expect("GET request")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let id = response.headers()["mcp-session-id"]
+        .to_str()
+        .expect("session header")
+        .to_owned();
+    let mut stream = response.into_body().into_data_stream();
+    let connected = next_event(&mut stream).await;
+    assert!(connected.contains("event: connected"), "{connected}");
+    assert!(connected.contains(&id), "{connected}");
+    Session { id, stream }
+}
+
+fn notification(marker: &str) -> TaggedNotification {
+    TaggedNotification {
+        source: "gh452-test".to_owned(),
+        event_type: "message".to_owned(),
+        data: json!({"jsonrpc": "2.0", "method": "notifications/test", "params": {"marker": marker}}),
+        event_id: None,
+    }
+}
+
+async fn prove_original_stream(state: &Arc<AppState>, session: &mut Session, marker: &str) {
+    assert!(state.multiplexer.has_session(&session.id));
+    assert!(
+        state
+            .multiplexer
+            .send_to_session(&session.id, notification(marker)),
+        "the original session must accept a notification"
+    );
+    let event = next_event(&mut session.stream).await;
+    assert!(event.contains("event: message"), "{event}");
+    assert!(event.contains(marker), "{event}");
+}
+
+async fn post(state: &Arc<AppState>, key: &str, id: Option<&str>, body: Value) -> Response {
+    let mut request = request(Method::POST, Some(key))
+        .header("content-type", "application/json")
+        .header("accept", "application/json");
+    if let Some(id) = id {
+        request = request.header("mcp-session-id", id);
+    }
+    send(
+        state,
+        request
+            .body(Body::from(serde_json::to_vec(&body).expect("JSON body")))
+            .expect("POST request"),
+    )
+    .await
+}
+
+async fn prove_ping(state: &Arc<AppState>, key: &str, session: &Session) {
+    let response = post(
+        state,
+        key,
+        Some(&session.id),
+        json!({"jsonrpc": "2.0", "id": 42, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["mcp-session-id"], session.id);
+    let bytes = to_bytes(response.into_body(), 16_384)
+        .await
+        .expect("ping body");
+    let body: Value = serde_json::from_slice(&bytes).expect("JSON ping result");
+    assert_eq!(body["id"], 42);
+    assert!(body.get("result").is_some(), "{body}");
+    assert!(body.get("error").is_none(), "{body}");
+}
+
+/// GH452.SESSION.1: refusal must preserve the actual live stream, not recreate it.
+#[tokio::test]
+async fn gh452_session_1_foreign_delete_preserves_original_stream_and_calls() {
+    let state = state(true, false, ["alice", "bob"]);
+    let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+    let mut bob = open_session(&state, Some(BOB_KEY), None).await;
+    assert_ne!(alice.id, bob.id);
+
+    let response = delete(&state, Some(BOB_KEY), Some(&alice.id)).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(state.multiplexer.session_count(), 2);
+    prove_original_stream(&state, &mut alice, "alice-survived-foreign-delete").await;
+    prove_original_stream(&state, &mut bob, "bob-was-unaffected").await;
+    prove_ping(&state, ALICE_KEY, &alice).await;
+    prove_ping(&state, BOB_KEY, &bob).await;
+    assert_eq!(state.multiplexer.session_count(), 2);
+}
+
+/// GH452.SESSION.2: POST creation, GET resumption and DELETE use the same owner.
+#[tokio::test]
+async fn gh452_session_2_owner_deletes_post_created_session_once() {
+    let state = state(true, false, ["alice", "bob"]);
+    let initialized = post(
+        &state,
+        ALICE_KEY,
+        None,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25", "capabilities": {},
+                "clientInfo": {"name": "gh452-client", "version": "1.0"}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(initialized.status(), StatusCode::OK);
+    let id = initialized.headers()["mcp-session-id"]
+        .to_str()
+        .expect("POST session id")
+        .to_owned();
+    let mut alice = open_session(&state, Some(ALICE_KEY), Some(&id)).await;
+    assert_eq!(alice.id, id);
+    let mut bob = open_session(&state, Some(BOB_KEY), None).await;
+    prove_original_stream(&state, &mut alice, "owner-stream-before-delete").await;
+
+    let response = delete(&state, Some(ALICE_KEY), Some(&id)).await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(!state.multiplexer.has_session(&id));
+    assert_eq!(state.multiplexer.session_count(), 1);
+    assert!(!state.multiplexer.send_to_session(&id, notification("gone")));
+    assert_eq!(
+        delete(&state, Some(ALICE_KEY), Some(&id)).await.status(),
+        StatusCode::NOT_FOUND
+    );
+    prove_original_stream(&state, &mut bob, "other-owner-still-live").await;
+    prove_ping(&state, BOB_KEY, &bob).await;
+}
+
+/// GH452.SESSION.3: exact response comparison catches an existence oracle.
+#[tokio::test]
+async fn gh452_session_3_foreign_and_unknown_are_indistinguishable() {
+    let state = state(true, false, ["alice", "bob"]);
+    let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+    let unknown =
+        response_parts(delete(&state, Some(BOB_KEY), Some("gh452-never-created")).await).await;
+    let foreign = response_parts(delete(&state, Some(BOB_KEY), Some(&alice.id)).await).await;
+    assert_eq!(unknown.0, StatusCode::NOT_FOUND);
+    assert!(unknown.2.is_empty());
+    assert_eq!(foreign, unknown);
+    assert_eq!(state.multiplexer.session_count(), 1);
+    prove_original_stream(&state, &mut alice, "not-found-does-not-delete").await;
+}
+
+/// GH452.SESSION.4: malformed/missing IDs are tested after valid authentication.
+#[tokio::test]
+async fn gh452_session_4_session_header_boundaries_after_authentication() {
+    let state = state(true, false, ["alice", "bob"]);
+    let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+    assert_eq!(
+        delete(&state, Some(ALICE_KEY), None).await.status(),
+        StatusCode::BAD_REQUEST
+    );
+    let invalid = request(Method::DELETE, Some(ALICE_KEY))
+        .header(
+            "mcp-session-id",
+            HeaderValue::from_bytes(&[0xff]).expect("non-text header bytes"),
+        )
+        .body(Body::empty())
+        .expect("non-text session header request");
+    assert_eq!(
+        send(&state, invalid).await.status(),
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        delete(&state, Some(ALICE_KEY), Some("")).await.status(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(state.multiplexer.session_count(), 1);
+    prove_original_stream(&state, &mut alice, "bad-header-does-not-delete").await;
+}
+
+/// GH452.SESSION.4: the compatibility promise applies only with auth disabled.
+#[tokio::test]
+async fn gh452_session_4_auth_disabled_anonymous_owner_can_delete() {
+    let state = state(false, false, ["alice", "bob"]);
+    let session = open_session(&state, None, None).await;
+    assert_eq!(
+        delete(&state, None, Some(&session.id)).await.status(),
+        StatusCode::NO_CONTENT
+    );
+    assert!(!state.multiplexer.has_session(&session.id));
+    assert_eq!(state.multiplexer.session_count(), 0);
+}
+
+/// GH452.SESSION.4: ordinary authenticated routes still reject missing credentials.
+#[tokio::test]
+async fn gh452_session_4_authenticated_route_refuses_missing_credentials() {
+    let state = state(true, false, ["alice", "bob"]);
+    let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+    let response = delete(&state, None, Some(&alice.id)).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response.headers()["www-authenticate"], "Bearer");
+    prove_original_stream(&state, &mut alice, "missing-credential-refused").await;
+}
+
+/// GH452.SESSION.5: real credentials with colliding display names remain distinct.
+#[tokio::test]
+async fn gh452_session_5_same_display_name_is_not_the_same_credential() {
+    for name in ["shared", "anonymous"] {
+        let state = state(true, false, [name, name]);
+        let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+        let mut bob = open_session(&state, Some(BOB_KEY), None).await;
+        assert_ne!(alice.id, bob.id);
+        assert_eq!(
+            delete(&state, Some(BOB_KEY), Some(&alice.id))
+                .await
+                .status(),
+            StatusCode::NOT_FOUND,
+            "different secrets must not share ownership under display name {name}"
+        );
+        prove_original_stream(&state, &mut alice, "same-name-foreign-refused").await;
+        assert_eq!(state.multiplexer.session_count(), 2);
+        assert_eq!(
+            delete(&state, Some(ALICE_KEY), Some(&alice.id))
+                .await
+                .status(),
+            StatusCode::NO_CONTENT,
+            "valid original owner must still be recognized"
+        );
+        prove_original_stream(&state, &mut bob, "same-name-owner-delete-leaves-bob").await;
+        prove_ping(&state, BOB_KEY, &bob).await;
+        assert_eq!(state.multiplexer.session_count(), 1);
+    }
+}
+
+/// GH452.SESSION.6: competing requests supplement the single-write-guard review.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gh452_session_6_only_one_competing_owner_delete_succeeds() {
+    let state = state(true, false, ["alice", "bob"]);
+    let alice = open_session(&state, Some(ALICE_KEY), None).await;
+    let mut bob = open_session(&state, Some(BOB_KEY), None).await;
+    let barrier = Arc::new(tokio::sync::Barrier::new(4));
+    let mut requests = tokio::task::JoinSet::new();
+    for key in [ALICE_KEY, ALICE_KEY, BOB_KEY] {
+        let state = Arc::clone(&state);
+        let barrier = Arc::clone(&barrier);
+        let id = alice.id.clone();
+        requests.spawn(async move {
+            barrier.wait().await;
+            (key, delete(&state, Some(key), Some(&id)).await.status())
+        });
+    }
+    barrier.wait().await;
+    let mut owner_successes = 0;
+    while let Some(result) = requests.join_next().await {
+        let (key, status) = result.expect("DELETE task completed");
+        if key == BOB_KEY {
+            assert_eq!(status, StatusCode::NOT_FOUND);
+        } else if status == StatusCode::NO_CONTENT {
+            owner_successes += 1;
+        } else {
+            assert_eq!(status, StatusCode::NOT_FOUND);
+        }
+    }
+    assert_eq!(owner_successes, 1);
+    assert!(!state.multiplexer.has_session(&alice.id));
+    assert_eq!(state.multiplexer.session_count(), 1);
+    prove_original_stream(&state, &mut bob, "competing-deletes-leave-bob").await;
+}
+
+/// GH452.SESSION.7: public-path middleware fallback is not a DELETE owner identity.
+#[tokio::test]
+async fn gh452_session_7_public_anonymous_delete_requires_a_validated_principal() {
+    let state = state(true, true, ["alice", "bob"]);
+    let mut public = open_session(&state, None, None).await;
+    let expected = response_parts(delete(&state, None, Some("gh452-unknown-public")).await).await;
+    assert_eq!(expected.0, StatusCode::UNAUTHORIZED);
+    assert_eq!(expected.1["www-authenticate"], "Bearer");
+    for (key, id) in [
+        (None, Some(public.id.as_str())),
+        (None, None),
+        (Some("gh452-invalid-credential"), Some(public.id.as_str())),
+    ] {
+        let actual = response_parts(delete(&state, key, id).await).await;
+        assert_eq!(actual, expected, "no credential means no session lookup");
+    }
+    assert_eq!(state.multiplexer.session_count(), 1);
+    prove_original_stream(&state, &mut public, "public-session-survives").await;
+}
+
+/// GH452.SESSION.7: public paths validate supplied keys before public fallback.
+#[tokio::test]
+async fn gh452_session_7_public_valid_credential_owner_can_delete() {
+    let state = state(true, true, ["alice", "bob"]);
+    let mut public = open_session(&state, None, None).await;
+    let alice = open_session(&state, Some(ALICE_KEY), None).await;
+    assert_eq!(
+        delete(&state, Some(ALICE_KEY), Some(&alice.id))
+            .await
+            .status(),
+        StatusCode::NO_CONTENT
+    );
+    assert!(!state.multiplexer.has_session(&alice.id));
+    assert_eq!(state.multiplexer.session_count(), 1);
+    prove_original_stream(&state, &mut public, "authenticated-delete-leaves-public").await;
+}
+
+/// GH452.SESSION.7: a valid credential does not own an anonymous public session.
+#[tokio::test]
+async fn gh452_session_7_public_session_rejects_authenticated_nonowner() {
+    let state = state(true, true, ["alice", "bob"]);
+    let mut public = open_session(&state, None, None).await;
+    let mut alice = open_session(&state, Some(ALICE_KEY), None).await;
+    assert_ne!(public.id, alice.id);
+    assert_eq!(
+        delete(&state, Some(ALICE_KEY), Some(&public.id))
+            .await
+            .status(),
+        StatusCode::NOT_FOUND,
+        "a valid key does not authorize deletion of another owner's public session"
+    );
+    assert_eq!(state.multiplexer.session_count(), 2);
+    prove_original_stream(
+        &state,
+        &mut public,
+        "public-survives-authenticated-nonowner",
+    )
+    .await;
+    prove_original_stream(
+        &state,
+        &mut alice,
+        "authenticated-nonowner-keeps-own-stream",
+    )
+    .await;
+    prove_ping(&state, ALICE_KEY, &alice).await;
+    assert_eq!(state.multiplexer.session_count(), 2);
+}


### PR DESCRIPTION
Legacy `DELETE /mcp` currently lets a caller terminate another caller's session if they know its ID. This increment checks the validated owner and removes the session atomically. Foreign and unknown IDs return the same 404; owner deletion and auth-disabled anonymous sessions remain supported. Auth-enabled public paths require a valid credential before session lookup.

Refs #452. This is a separate 4.0 stability increment targeting `codex/v4-release-delivery`.

Validation: fresh isolated build passes 11 acceptance tests and 14 existing streaming/ownership controls. All-feature/all-target Clippy with warnings denied, formatting, actionlint and diff checks pass. The unchanged runtime patch retains both SHIP code reviews, 56/56 covered source regions, 10/11 caught viable mutations and seven passing independent endpoint criteria. The test fixture initialization was adjusted for Clippy; the integration-branch CI selector and formatter-only discovery helper change reuse the already reviewed configuration increment.

Source bindings, commands and remaining gates are committed in `docs/release/gh452-session-ownership-evidence.json`; the design documents the acceptance cases and delivery checkpoint.

Draft: mechanical delivery-delta confirmation and CI/integration are still pending. The integration base has two independently reproduced ORDER.2 failures being repaired in a separate prerequisite. No release or issue-closure claim.

## KPI Impact

Cross-caller session termination changes from successful deletion to a non-disclosing refusal, with the original session and stream remaining usable. The independent drive verified all seven acceptance criteria; no numerical performance claim is made.
