### PR TITLE
fix(mtls): generate certificates accepted by strict clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, codex/v4-release-delivery]
 
 permissions:
   contents: read

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -265,6 +265,52 @@ mtls:
   require_client_cert: true
 ```
 
+### Strict validation and existing certificate generations
+
+Newly generated 4.0 CA certificates include certificate-signing and CRL-signing
+key usage; issued server and client certificates include an Authority Key
+Identifier matching their issuer. These extensions support strict X.509 clients,
+including Python 3.13's default TLS context. Keep certificate and hostname
+verification enabled.
+
+Check a new generation before deploying it:
+
+```bash
+openssl verify -x509_strict -purpose sslserver \
+  -verify_hostname gateway.company.com \
+  -CAfile ./tls-next/ca.crt ./tls-next/server.crt
+openssl verify -x509_strict -purpose sslclient \
+  -CAfile ./tls-next/ca.crt ./tls-next/clients/claude-code-agent.crt
+```
+
+Existing gateway-generated CAs may lack key usage, and existing leaves may lack
+issuer identifiers. A new leaf alone cannot repair a malformed CA. The gateway
+does not replace an existing certificate generation automatically.
+
+For an existing deployment, perform the following rollout during an operator
+chosen maintenance window:
+
+1. Retain the old CA, leaf certificates, private keys, configuration and trust
+   bundles. Generate the replacement CA/server/client material with the commands
+   above in a **new directory**, such as `./tls-next`, rather than in the live
+   certificate directory. Protect and store the new CA key offline after issuance.
+2. Distribute a trust bundle containing both old and new CA certificates to the
+   gateway and clients before switching leaf certificates. The gateway's
+   `mtls.ca_cert` accepts a PEM bundle. Restart it after changing its TLS paths or
+   trust bundle, and verify existing clients still authenticate.
+3. Switch server and client certificate/key paths to the new generation. Restart
+   the gateway and reconnect clients. Verify an actual authenticated MCP
+   initialize/tool-list exchange with the new client certificate, as well as
+   continued operation of supported existing clients. An old malformed chain
+   remains incompatible with strict clients even when both CAs are trusted;
+   enable those clients only after the new server chain is active.
+4. Rehearse rollback in an isolated deployment: restore the retained old
+   certificate/key/configuration paths while keeping overlapping trust, restart,
+   and verify the original client **with its old certificate and key**. This
+   restores prior compatibility; it does not make the old chain strict-valid.
+5. Remove old trust only after every consumer has migrated and the operator has
+   ended the rollback window. Retention and key disposal follow your PKI policy.
+
 ## Reverse Proxy
 
 Bind the gateway to `127.0.0.1` (default) and proxy from the public-facing server. SSE streaming requires disabled response buffering.

--- a/docs/design/2026-09-07-generated-tls-strict-validation.md
+++ b/docs/design/2026-09-07-generated-tls-strict-validation.md
@@ -1,0 +1,214 @@
+# Generated certificates: strict X.509 compatibility
+
+Status: design/plan gate closed (Grok SHIP, GPT finder SHIP). Both test reviewers
+approved the compiled regression. Implementation passes five new and 67 existing
+mTLS tests; CLI-generated server and client chains pass strict OpenSSL validation.
+Quantitative checks pass for the changed code. Both final code reviewers returned
+SHIP; independent strict mTLS and isolated rollout/rollback acceptance passed.
+The isolated increment passes all 72 selected tests and all-feature/all-target
+Clippy with warnings denied. CI and integration remain open.
+
+Owner ticket: [MIK-7212](https://linear.app/parm/issue/MIK-7212/critical-proxy-drops-mrtr-inputresponses-and-requeststate-write-the).
+All four `MIK-7212.TLSCERT` acceptance checkboxes are in its description.
+
+FOR: unblock the 4.0 HTTP/TLS independent acceptance drive by making newly
+generated gateway CA and issued server/client certificates acceptable to strict
+X.509 validators without weakening authentication.
+
+OUT: replacing existing keys or certificates automatically, new trust policy,
+new certificate CLI options, certificate algorithm/validity changes, and changes
+to the HTTP shutdown repair. This is W01 compatibility repair within the approved
+release scope; release delivery remains the parent objective.
+
+## Evidence and decision
+
+The initial independent HTTP driver used CLI binary SHA256
+`4ebf189bad8e0af59540fb56fdb10754ebb6e6696cc5c61efbf27cc85cc6adbc`.
+Plain MCP initialization/listing and CA-verified TLS health worked. Python 3.13
+default verification rejected the generated TLS chain before the MCP request.
+That initial driver's HTTP.1–HTTP.5 verdicts remain INVESTIGATE. The later
+confirmation uses the repaired generator, as recorded below.
+
+Coordinator reproduction with the same certificates:
+`openssl verify -x509_strict -CAfile tls/ca.crt tls/server.crt` reports error 85,
+missing Authority Key Identifier, and error 92, missing CA key-usage extension.
+The CA already has a Subject Key Identifier and critical CA basic constraints.
+No product private keys were exported from a live service; the fixture is isolated.
+
+[Python's ssl documentation](https://docs.python.org/3/library/ssl.html#ssl.create_default_context)
+records strict verification in the defaults from 3.13.
+[RFC 5280 sections 4.2.1.1–4.2.1.3](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.1)
+define CA-issued AKI, CA SKI and CA key-usage requirements. The self-signed root
+exception permits omission of root AKI. rcgen 0.14.9's current source defaults
+to empty key usages and disabled AKI; its existing extension support is reusable.
+
+The bounded repair configures certificate-signing and CRL-signing usage for newly
+generated CAs, and enables issuer-derived AKI for both issued leaf variants.
+Keep existing algorithms, SANs, identity fields, validity, file permissions and
+TLS verification settings. Existing external CA input remains supported.
+Changing validator flags would conceal malformed output and is rejected;
+replacing rcgen would add unnecessary dependency and cryptographic risk.
+
+Target: `CertGenerator::init_ca` and `CertGenerator::issue_leaf` in
+`src/mtls/cert_manager.rs`, focused tests, and operator TLS documentation.
+GitNexus upstream impact: medium for both; init_ca has 14 direct callers and
+issue_leaf has 7, in mTLS and TLS CLI flows. Verify both server and client issuance.
+
+## Acceptance and test plan
+
+| AC | Case and level/type | Falsifier and required evidence |
+| --- | --- | --- |
+| MIK-7212.TLSCERT.1 | Generate a CA; parse actual DER and require critical key usage with certificate-signing and CRL-signing bits. Component, positive conformance. | Current init_ca lacks the extension: compiled assertion failure. Existing unique-key and PEM tests stay green. |
+| MIK-7212.TLSCERT.2 | Issue DNS server and SPIFFE client leaves; parse DER and require noncritical AKI equal to issuer SKI. Preserve DNS/URI SANs. Component, positive identity/conformance. | Current issue_leaf lacks AKI: both compiled assertion failures. Also issue from an external fixture CA with an explicit nondefault SKI, proving issuer reuse rather than a new derived value. |
+| MIK-7212.TLSCERT.3 | Generate CA/server/client through real CLI; require strict OpenSSL server/client chain verification. Serve with `require_client_cert: true`; Python 3.13 default context loads the generated client certificate/key and completes MCP initialize/list. System/acceptance, interoperability. | Original binary fails strict verification. On the same positively verified live endpoint, wrong hostname and untrusted CA must raise `SSLCertVerificationError` with the respective hostname-mismatch and issuer/trust verification reason; connection refusal/timeout is not a passing negative. Missing/untrusted client certificates must also fail the authenticated handshake. Reuse the independent driver for affected confirmation. |
+| MIK-7212.TLSCERT.4 | Rehearse side-by-side CA generation, overlapping trust distribution, leaf cutover and rollback in isolated directories/services. System/acceptance, upgrade. | Preserve hashes of old material; new strict mTLS succeeds only after new trust and leaf distribution. Existing legacy-client access remains verifiable with CA-verified curl, and reverting the isolated service to retained old material restores the original legacy connection. Do not claim strict clients work with the malformed old generation. |
+
+Tests precede implementation and receive their own review. Portable DER assertions
+run in normal Rust tests. OpenSSL and Python checks run in the Spark release lane;
+missing or older tooling is a blocked check, never a silent pass. Cheapest next
+check is the DER regression against unchanged production, then strict chain and
+real TLS validation after repair. Any additional strict-validator failure is
+diagnosed before claiming TLSCERT.3.
+
+DoR: the user has authorized closing release gaps and retaining full DoD. There
+is no new user policy decision. Value is restoring standards-compliant TLS
+interoperability. Security risk is overbroad CA usage or wrong issuer binding;
+the assertions constrain those fields and negative trust/hostname controls
+prevent verification relaxation. No new dependencies, personal data or service
+deployment. Critical changed-code coverage >=95% and viable mutants >=85%
+apply; unchanged module coverage is reported separately. Final review remains
+two code legs and independent functional confirmation, with actual exit and
+material-bound ledger receipts.
+
+Backlog evidence read live on 2026-09-07: B1 MIK-7212 exists and is In Progress;
+B2 Urgent priority, 8-point parent estimate, mcp-gateway label/project, Mikko
+assignee/team and v4.0.0 milestone are populated; B3 parent MIK-7211 and existing
+blocked-by MIK-7388 are retained. That dependency concerns wider MRTR dispatch;
+this certificate generator repair is independent, and explicitly blocks the
+existing HTTP acceptance drive. B4 the four ticket-prefixed checkboxes above
+are recorded in the issue description. B5 the existing Urgent v4.0.0 position
+applies. No new cycle, point estimate, due date or workflow state is invented.
+
+## Upgrade and delivery
+
+Only newly generated material changes. An existing gateway-generated CA without
+key usage also needs reissuance and trust-store updates for strict validation;
+issuing a new leaf alone does not repair that CA. The operator procedure is:
+
+1. Preserve the old certificates, keys, config and trust bundles. Generate the new
+   CA and server/client leaves in a separate directory, never over existing files.
+2. Distribute combined old/new CA trust to server and clients before cutting over
+   leaf/key paths. Verify existing legacy clients still connect. Old malformed
+   chains remain incompatible with strict verification even with overlapping trust.
+3. Switch the isolated server and client leaf/key configuration to the new
+   generation, then prove strict Python mTLS initialize/list and legacy-client
+   compatibility. Enable strict consumers only once that positive check passes.
+4. Rehearse rollback by restoring retained old leaf/key/config references while
+   keeping overlapping trust; verify the original legacy client again. Rollback
+   restores legacy service, not strict compatibility with a malformed old CA.
+5. Remove old trust only after all consumers have migrated and the operator has
+   ended the rollback window. This repair never chooses that window or removes
+   a user's existing trust automatically.
+
+MIK-7212.TLSCERT.4 exercises steps 1–4 using isolated service instances. The
+documentation explains step 5 as an operator action; no live Spark service or
+user trust store is changed during validation.
+Run focused mTLS regressions and formatting/lint checks, then integrate evidence
+into W01. This design grants no release, merge or deployment verdict.
+
+## Review disposition
+
+The first GPT process exited 143 without a verdict; its identical-material retry
+exited 0 with SHIP-WITH-FIXES. Grok exited 0 with SHIP. Unique ledger rows and
+scope/material/head bindings are verified. The first design digest remains
+`6084dd1ff5855846550d7f02f8c0884c956c4e3b3a80a489e46d6a03fcaf4750`.
+
+The four GPT findings are addressed by the rollout sequence plus TLSCERT.4,
+mandatory live client-certificate authentication, verification-specific negative
+oracles, and the populated owner ticket/AC mapping. This receipt adds explicit
+upgrade acceptance detail within W01 and the existing release upgrade obligation;
+it changes no automatic rotation behavior or approved product scope. GPT finder
+confirmation returned SHIP with actual exit 0 and verified material/ledger
+binding (`43ba777f41ae0164bf49854a58efed06b95baf2b871e289bfa11f707c9c13162`).
+Unchanged Grok approval is retained. Both test-review legs returned SHIP for
+material `7daa9c681cfb6ea54a375790d53df7f0cbb71d59a0513a5ab9082abb200fd048`.
+
+## Implementation checkpoint, 2026-09-06 21:59 UTC
+
+`src/mtls/cert_manager.rs` now sets the two CA signing usages and enables
+issuer-derived AKI on issued leaves. Its SHA256 is
+`aded91190f51bfd3ed6e34ab581607eb5bba526b45f05153e8b60f2d516d5b43`.
+All five DER regressions first failed on the unchanged generator at the intended
+missing-extension assertions, then passed after the repair. The existing 67
+mTLS tests also pass. The first fixture compilation failure was corrected before
+the semantic red run and does not count as a behavioral test failure.
+
+Rebuilt CLI SHA256
+`c560d16fb3fe0b512b8dc47f6f0da89eeab8548cacefc5a4d5559501ed98b59c`
+generated fresh isolated CA/server/client material. Both `openssl verify
+-x509_strict` purpose checks passed, with hostname verification for the server.
+This proves generation and strict chain validation; TLSCERT.3/.4 still require
+live mTLS, specific negative controls and the isolated rollout/rollback drive.
+
+The first cargo-mutants run generated two whole-function `Default` replacements.
+Both fail to compile because `GeneratedCert` has no `Default` implementation:
+zero viable mutants is not an 85% pass. Do not change the production API merely
+to make these generated replacements viable. The first coverage run exercised
+both changed executable lines, but its source-binding receipt raced with that
+in-place mutation run. That receipt is preserved. A fresh bounded run passed all
+five tests with the expected source hash verified before and after execution.
+Both changed lines (203 and 248) were exercised: 2/2 changed-line coverage.
+Whole-module coverage from this five-test scope is 67/208 lines (32.21%); it is
+not a module-wide 95% claim. The replacement receipt is
+`/home/mikko/codex/tlscert-coverage-r2/summary.json` on Spark, exported directly
+from the current test binary.
+
+The second cargo-mutants run supplies a valid existing `Error::Config` value:
+two viable replacements caught, zero missed or timed out, and the two unviable
+`Default` replacements still disclosed. This is 100% of a small two-mutant viable
+inventory, not a broad module score. Four additional compiling faults remove
+certificate-signing usage, remove CRL-signing usage, grant unrelated digital-
+signature usage, and disable leaf AKI. Every fault fails at the corresponding
+DER assertion. The source is restored byte-for-byte and all five tests pass.
+Commands, diffs, actual exits and source hashes are preserved in
+`/home/mikko/codex/tlscert-mutations-r2/summary.json` and its adjacent logs.
+No production `Default` implementation or lint suppression was added.
+
+## Final code and independent acceptance evidence
+
+Final code review run `mcp-v4-tlscert-code-20260907-r1` returned SHIP from both
+vendors, each with actual exit 0 and verified source/material/head bindings.
+The digest is
+`1569f2dfad43d2462103909581c4c2e2644abc0e1ad6d152017e414e4d161b95`.
+Its digest input is 51,121 bytes (scope, NUL separator and 50,304-byte body).
+The initial receipt counted only the body; the verified receipt diagnoses that
+metadata error without changing the submitted material or reviewer ledgers.
+
+The independent confirmation exited 0 using immutable CLI SHA256
+`c560d16fb3fe0b512b8dc47f6f0da89eeab8548cacefc5a4d5559501ed98b59c`.
+TLSCERT.3 passed strict OpenSSL server/client verification and actual MCP
+initialize/list with Python 3.13's default TLS context and required client
+authentication. Wrong hostname, untrusted server CA, missing client certificate
+and untrusted client certificate produced the intended verification/client-auth
+failures, with no application response for the latter two. TLS 1.3 client-auth
+alerts were observed on the first application read.
+
+TLSCERT.4 passed the isolated old-only, overlapping-trust, new-leaf and rollback
+stages. Retained old material was unchanged. This demonstrates legacy-client
+compatibility during migration; it does not make the malformed old generation
+strict-valid or change the real operator's trust-distribution window. All owned
+driver processes and ports were released.
+
+The report, machine outcomes, raw observations and original artifact manifest
+are retained under `http-tlscert-independent-confirmation-r2/` in the coordinator's
+scope-review evidence directory. The CLI overwrote the local authored report
+with its final summary after the manifest was created; the remote original was
+recovered and verified against the preserved hash. Both reports remain available.
+Earlier invalid harness probes remain explicitly excluded from passing evidence.
+
+The HTTP ownership repair has separate code and component-test evidence; this
+certificate increment does not claim to deliver that source change. Existing
+runtime/test approvals are reused only while their source hashes remain identical.
+CI uses the already reviewed integration-branch selector, with the same
+formatter-only discovery helper correction as configuration PR #483.
+Full release acceptance, CI and integration remain separate gates.

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -4656,7 +4656,9 @@ fn discovery_names(v: &Value) -> Vec<String> {
             // `gateway_search` names a tool `server:tool_name`; the other three
             // readers name it bare. Compare on the bare name so one pinned
             // literal covers all four entry points.
-            raw.rsplit_once(':').map_or(raw, |(_, name)| name).to_string()
+            raw.rsplit_once(':')
+                .map_or(raw, |(_, name)| name)
+                .to_string()
         })
         .collect();
     names.sort();

--- a/src/mtls/cert_manager.rs
+++ b/src/mtls/cert_manager.rs
@@ -24,8 +24,8 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use rcgen::string::Ia5String;
 use rcgen::{
-    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair, SanType,
-    date_time_ymd,
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose, SanType, date_time_ymd,
 };
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
@@ -200,6 +200,7 @@ impl CertGenerator {
         dn.push(DnType::CommonName, params.cn);
         ca_params.distinguished_name = dn;
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         ca_params.not_after = validity_to_date(params.validity_days)?;
 
         let ca_cert = ca_params
@@ -244,6 +245,7 @@ impl CertGenerator {
         }
         leaf_params.distinguished_name = dn;
         leaf_params.not_after = validity_to_date(params.validity_days)?;
+        leaf_params.use_authority_key_identifier_extension = true;
 
         // Add SANs — rcgen 0.14 uses Ia5String (from rcgen::string) for DNS and URI SAN types
         let mut sans: Vec<SanType> = Vec::new();

--- a/tests/generated_tls_strict.rs
+++ b/tests/generated_tls_strict.rs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! MIK-7212.TLSCERT.1–2: inspect actual generated X.509 extensions.
+
+use mcp_gateway::mtls::{CaParams, CertGenerator, GeneratedCert, LeafCertParams};
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyIdMethod, KeyPair,
+    KeyUsagePurpose,
+};
+use x509_parser::extensions::{GeneralName, ParsedExtension};
+use x509_parser::oid_registry::{
+    OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER, OID_X509_EXT_SUBJECT_KEY_IDENTIFIER,
+};
+use x509_parser::pem::parse_x509_pem;
+use x509_parser::prelude::{FromDer, X509Certificate};
+
+fn inspect<T>(pem: &str, check: impl FnOnce(&X509Certificate<'_>) -> T) -> T {
+    let (remaining, pem) = parse_x509_pem(pem.as_bytes()).expect("certificate PEM");
+    assert!(remaining.iter().all(u8::is_ascii_whitespace));
+    let (remaining, cert) = X509Certificate::from_der(&pem.contents).expect("certificate DER");
+    assert!(remaining.is_empty(), "unparsed certificate bytes");
+    check(&cert)
+}
+
+fn generated_ca() -> GeneratedCert {
+    CertGenerator::init_ca(&CaParams {
+        cn: "TLSCERT regression CA",
+        validity_days: 30,
+    })
+    .unwrap()
+}
+
+fn issuer_key_id(ca: &GeneratedCert) -> Vec<u8> {
+    inspect(&ca.cert_pem, |cert| {
+        let extension = cert
+            .get_extension_unique(&OID_X509_EXT_SUBJECT_KEY_IDENTIFIER)
+            .unwrap()
+            .expect("issuer must carry SKI");
+        match extension.parsed_extension() {
+            ParsedExtension::SubjectKeyIdentifier(id) => id.0.to_vec(),
+            other => panic!("malformed issuer SKI: {other:?}"),
+        }
+    })
+}
+
+fn external_ca() -> GeneratedCert {
+    let key = KeyPair::generate().unwrap();
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, "External TLSCERT CA");
+    let expected_id = vec![0xa7; 20];
+    let mut params = CertificateParams::default();
+    params.distinguished_name = dn;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    // Deliberately differs from rcgen's default public-key digest.
+    params.key_identifier_method = KeyIdMethod::PreSpecified(expected_id.clone());
+    let ca = GeneratedCert {
+        cert_pem: params.self_signed(&key).unwrap().pem(),
+        key_pem: key.serialize_pem(),
+    };
+    assert_eq!(
+        issuer_key_id(&ca),
+        expected_id,
+        "external fixture precondition"
+    );
+    ca
+}
+
+fn check_leaf(ca: &GeneratedCert, server: bool) {
+    let expected_id = issuer_key_id(ca);
+    assert!(!expected_id.is_empty());
+    let params = LeafCertParams {
+        cn: if server {
+            "localhost"
+        } else {
+            "tls-test-agent"
+        },
+        ou: Some("engineering"),
+        san_dns: if server {
+            vec!["localhost".into()]
+        } else {
+            vec![]
+        },
+        san_uris: if server {
+            vec![]
+        } else {
+            vec!["spiffe://tlscert.test/agent".into()]
+        },
+        validity_days: 7,
+    };
+    let leaf = CertGenerator::issue_leaf(&params, &ca.cert_pem, &ca.key_pem).unwrap();
+    inspect(&leaf.cert_pem, |cert| {
+        assert_eq!(
+            cert.subject()
+                .iter_common_name()
+                .next()
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            params.cn
+        );
+        assert_eq!(
+            cert.subject()
+                .iter_organizational_unit()
+                .next()
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "engineering"
+        );
+        let sans = &cert
+            .subject_alternative_name()
+            .unwrap()
+            .unwrap()
+            .value
+            .general_names;
+        let expected_sans = if server {
+            vec![GeneralName::DNSName("localhost")]
+        } else {
+            vec![GeneralName::URI("spiffe://tlscert.test/agent")]
+        };
+        assert_eq!(*sans, expected_sans, "leaf identity must be preserved");
+        let extension = cert
+            .get_extension_unique(&OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER)
+            .unwrap()
+            .expect("MIK-7212.TLSCERT.2: CA-issued leaf is missing AKI");
+        assert!(!extension.critical, "AKI must be noncritical");
+        match extension.parsed_extension() {
+            ParsedExtension::AuthorityKeyIdentifier(id) => {
+                assert_eq!(
+                    id.key_identifier.as_ref().expect("AKI keyIdentifier").0,
+                    expected_id,
+                    "AKI must reuse this issuer's actual SKI"
+                );
+            }
+            other => panic!("malformed leaf AKI: {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn generated_ca_has_critical_certificate_and_crl_signing_usage() {
+    // MIK-7212.TLSCERT.1
+    inspect(&generated_ca().cert_pem, |cert| {
+        let usage = cert
+            .key_usage()
+            .unwrap()
+            .expect("MIK-7212.TLSCERT.1: generated CA is missing key usage");
+        assert!(usage.critical, "CA key usage must be critical");
+        assert!(usage.value.key_cert_sign());
+        assert!(usage.value.crl_sign());
+        assert_eq!(usage.value.flags, 0x60, "do not grant unrelated key usages");
+        assert!(cert.basic_constraints().unwrap().unwrap().value.ca);
+    });
+}
+
+#[test]
+fn generated_ca_server_leaf_has_issuer_bound_noncritical_aki() {
+    check_leaf(&generated_ca(), true);
+}
+
+#[test]
+fn generated_ca_client_leaf_has_issuer_bound_noncritical_aki() {
+    check_leaf(&generated_ca(), false);
+}
+
+#[test]
+fn external_ca_server_leaf_reuses_prespecified_issuer_ski() {
+    check_leaf(&external_ca(), true);
+}
+
+#[test]
+fn external_ca_client_leaf_reuses_prespecified_issuer_ski() {
+    check_leaf(&external_ca(), false);
+}


### PR DESCRIPTION
Gateway-generated certificates are rejected by strict X.509 clients because the CA lacks signing key usages and issued leaves lack an issuer identifier. Set those existing rcgen options for new certificates and document a rollout that retains old trust and supports rollback.

Validation: 5 DER regression tests plus 67 existing mTLS tests pass in a fresh isolated build; all-feature/all-target Clippy with warnings denied, formatting and actionlint pass. Both final code reviewers approved the byte-identical runtime and tests. Both changed executable lines are covered; both viable generated mutants and four targeted faults are caught (two generated mutants were unviable). Independent strict mTLS and isolated rollout/rollback checks pass. Existing keys and trust are unchanged.

The CI branch selector and formatter-only discovery helper match the already reviewed configuration increment. Full CI and integration are pending; the base has two confirmed ORDER.2 failures being repaired in a prerequisite. This PR does not claim the separate HTTP shutdown repair or complete 4.0 readiness.

Refs MIK-7212.TLSCERT.1–4. Evidence and operator instructions are included in the design document and deployment guide.
