### PR TITLE
fix(protocol): isolate sessionless workflow state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, codex/v4-release-delivery]
 
 permissions:
   contents: read

--- a/docs/design/2026-09-06-order-2-per-connection-list-variance-test-plan.md
+++ b/docs/design/2026-09-06-order-2-per-connection-list-variance-test-plan.md
@@ -45,7 +45,7 @@ each reach both surfaces — which is why some cells are empty on purpose.
 |---|---|---|---|
 | routing profile | yes — `surfaced.rs:107` (reached only from `mod.rs:1310`), `spec_preview.rs:47`. **Not** `mod.rs:1263`: that `active_profile` read feeds `observe_tools_list` telemetry (`:1259-1262`) and shapes no list | yes — `search.rs:376,629,728` | B-01 (2a), B-02 (2b) on `tools/list`; **B-06 (2a)** on the filtered `tools/list` path, which is a profile case (`spec_preview.rs:47`), not a promotion one |
 | spec-preview promotion | yes — `mod.rs:1330`, `spec_preview.rs:112` | **no reader**: `promoted_tools_for_session` is not called from `search.rs` or `surfaced.rs` at all | B-07 (2a), B-10 (2b) |
-| FSM workflow state | **no reader**: nothing on the `tools/list` path reads it | yes, and only here — four entry points: `code_mode_search` (`search.rs:378`), `search_tools` (`:730`), and `list_tools` / `list_tools_single_server`, which today read the store directly (`:647-650`, `:581-584`) | B-08 (2a), B-09 (2b) |
+| FSM workflow state | **no reader**: nothing on the `tools/list` path reads it | yes, and only here — four entry points: `code_mode_search` (`search.rs:378`), `search_tools` (`:730`), and `list_tools` / `list_tools_single_server`, which now delegate to that accessor (`76b8536c`) | B-08 (2a), B-09 (2b) |
 
 Two empty cells need no case, because there is no behaviour in them to assert:
 promotion has no discovery-surface reader, and the FSM state has no `tools/list`
@@ -73,9 +73,9 @@ rather than accidental.
 | 2a | spec-preview promotion | **B-07, repaired in the sibling plan on 2026-09-06**: as previously written (`:187-204`) the case could not fail against the defect §2 describes. Its premise promotes tool `T` for a **legacy-era** session A and observes it in A's legacy list; the two modern lists it then pins are read under the key `""`, which that promotion never touched, so the case stays green whether or not modern connections share promotions. The repair, now applied there: drive the promotion through **a modern connection's own successful `gateway_invoke`** (`invoke.rs:1826-1828` writes under `Some("")`), move the reverse-A5 observable to a **legacy control connection** whose own list must contain `T` (so a silently no-oping promotion fails the control instead of greening the case), and pin both modern lists to a literal that excludes `T` | integration | After the repair: `T` appears in the other modern connection's list — which is what happens today, because both read `""`. It also fails if the legacy control does not see `T`, which is what catches a promotion that no-ops. Before the repair it could fail on nothing, which was the finding. The fixture must not stub `promote_tool_for_session`, or the case asserts against its own fixture rather than production. |
 | 2a | spec-preview preview list | **B-06**: B-01 re-run under `--features spec-preview` with a pinned match-all `params.query` | integration | The two modern connections' filtered lists differ from each other or from one pinned **filtered** literal. Not "differs from the default build's list" — an earlier draft said that, and it cannot hold: `handle_tools_list_filtered` deliberately omits the meta-tools from a filtered response (`spec_preview.rs:28-29`), so the two builds are *expected* to differ and a case asserting otherwise stays red after a correct fix. Covers `spec_preview.rs:46`. Runs only in a job that enables the feature; a suite that never enables it reports green while proving nothing, so the feature-enabled job is part of the case, not an optional extra. |
 | 2b — must not vary as a side effect of other requests on the connection | routing profile | **B-02**: `tools/list`, then `gateway_set_profile`, then `tools/list`; both lists compared to the same pinned literal | integration | Either list differs from the literal. Note the case must assert on the *lists*, not on the `gateway_set_profile` response: that call now returns `NO_SESSION_FOR_PROFILE` (§1 fact 4), and a case that asserts only the refusal would pass even if the lists diverged. |
-| 2b | spec-preview promotion | **new — B-10**: repaired B-07 covers the cross-connection half; the same-connection half is its own case, the sequence `tools/list` → successful `gateway_invoke` → `tools/list` on one modern connection, with **both** lists asserted against the same pinned literal and the invoke asserted to have succeeded. **The promoted tool `T` must be one that is NOT already in the first list, and the pinned literal must exclude it** — promotion is de-duplicated against already-surfaced tools (`mod.rs:1332-1335`), so invoking an already-listed tool leaves both lists identical and the case green while promotion still writes under `""`. Same constraint repaired B-07 carries — and it binds on both merges, since the filtered path de-dups the same way (`spec_preview.rs:113-114`). **Each `tools/list` in the sequence is issued twice, once unfiltered and once with `params.query` set**, so 2b covers the filtered merge (`spec_preview.rs:112`) as well as the unfiltered one (`mod.rs:1330`). Repaired B-07 already forces the query on the 2a side, so the filtered path has 2a coverage; without this, 2b reaches it only if (c) puts the guard inside `promoted_tools_for_session` rather than at the unfiltered call site — and the test plan must not be contingent on an implementation choice it also has to check. (The committed case already pins a literal excluding `echo` and asserts `before` against it; this row is where the constraint was missing.) Feature-gated: it runs only in the `--features spec-preview` job, on the same terms as B-06 | integration | Either list differs from the literal, or the invoke did not succeed. Asserting the two observed lists against each other would pass both when the invoke silently failed (nothing was promoted, so nothing changed) and when a regression moved both lists in step; the pinned literal and the invoke assertion are what remove those two green-while-broken paths. This is the direct statement of 2b and fails against §2 today. |
-| 2a | FSM workflow state (§2b) | **new — B-08**: connection A calls `gateway_set_state` to a non-default state; connection B, opened independently, calls **`gateway_list_tools` and `gateway_search_tools`** — both, and not `tools/list`, which reads this store on no path (§7 matrix) — and each result is compared against the pinned default-state literal | integration | B's set differs from the literal — which is what happens today, because A wrote under the key `""` and B reads the same entry. Fails in the **default build**, no feature flag needed. It cannot pass by construction: the fixture must drive the real `gateway_set_state` meta-tool, since the defect is the argument at `mod.rs:1689`, and a fixture calling `SessionStateStore::set_state` directly bypasses the line under test. **What it asserts after (c) depends on Q4, and the case must be written for that** — B-09's row states this and this row did not, which is the asymmetry that would have shipped the weaker case. If Q4 ratifies the refusal, A's `gateway_set_state` is refused on a modern HTTP connection, so A never writes; B then reads the default literal and the case goes green **without ever constructing the leaked state it exists to observe** — green for the wrong reason, and unfalsifiable. One fixture fact the row owes an implementer, because it looks like a shortcut and is not: **A and B carry the same session tuple**. A modern HTTP connection presents `Some("")` (`server/mod.rs:1604` supplies it), so below the transport two independently opened connections are one key — which is the defect this case exists to state, not a corner the fixture cut. After (c) `session_key` maps that key to `None` and neither connection can hold a state, so the shared entry stops existing rather than stops being shared. What separates this case from B-09 is therefore the claim, not the fixture: B issues no `gateway_set_state` of its own. So the case asserts *both*, exactly as B-02 does for `gateway_set_profile`: A's call is refused, **and** B's two sets equal the pinned default literal. Written that way it still fails if the refusal is dropped, if B's set moves, or if `gateway_set_state` becomes a silent no-op instead of an error. If Q4 declines the refusal, the leak assertion is the whole case **plus one stimulus pin**: A's `gateway_set_state` must be asserted to have SUCCEEDED, exactly as B-10 asserts of its `gateway_invoke`. Without it a failed or no-op write makes "B's set equals the default literal" true of a world where nothing was ever written — green over an empty stimulus. The ratify branch does not need this line, because its refusal assertion already pins the outcome of A's call; the decline branch had no such pin and that asymmetry is the gap. Note what the pairing costs nothing to say: after (c) the leak is not merely undetected, it is unconstructible from a modern HTTP connection — `session_key` gives that connection no entry to share. Each case drives a **third** discovery call, `gateway_list_tools` with `server=` set to the staged capability backend, to reach `list_tools_single_server` (`search.rs:581-584`) — the one FSM reader the other two calls do not touch. **Staging is part of the case, and it is an assertion, not a note**: the discovery filter is `visible_in_states` (`capability/backend.rs:342-343`, `search.rs:196-199,285-288`), and **every fixture in the tree today declares `visible_in_states: vec![]`** — always visible, in every state (V 2026-09-06: 18 sites, all empty). Against such a fixture the tool set is invariant under the FSM state, so a leaked state moves nothing and this case is green whether or not the leak exists. The fixture must therefore register one capability visible in `"default"` and **not** in the state A sets (or the reverse), and the pinned literal must be pinned to that staging. Without a proof that the staging held, the staging is unverified prose and the case decays back to the invariant-fixture version — but **that proof must not be phrased as a discovery call from a modern HTTP connection made while the target state is in force**. On the Q4-ratify branch no modern connection can hold a non-default state after (c) — that is what (c) is for — so a staging assertion of that shape is unsatisfiable on that branch and the case is red forever: `test-plan-honesty`'s second survivor, a case that can never go green, not the one this repair was guarding against. The proof therefore runs on a **session-bearing connection**, one that legitimately owns a session id so its `gateway_set_state` is refused under neither answer to Q4, driving the same discovery entry point: set the state, observe the OTHER set. That proves both halves the staging needs — the capability is genuinely state-dependent, and the discovery path honours the dependence — and it is Q4-independent. The leak assertion then asserts only what its own branch permits. |
-| 2b | FSM workflow state (§2b) | **new — B-09**: on one modern connection, `gateway_list_tools` → `gateway_set_state` → `gateway_list_tools`, and the same sequence again through `gateway_search_tools`, each list compared against the same pinned literal | integration | Either list differs from the literal. Note this case's expected behaviour changes under (c): today the second list differs; after (c) the `gateway_set_state` call is *refused*, and the case must assert the refusal **and** the unchanged lists, exactly as B-02 does for `gateway_set_profile` — asserting only the refusal would pass while the lists diverged. Each case drives a **third** discovery call, `gateway_list_tools` with `server=` set to the staged capability backend, to reach `list_tools_single_server` (`search.rs:581-584`) — the one FSM reader the other two calls do not touch. **Staging is part of the case, and it is an assertion, not a note**: the discovery filter is `visible_in_states` (`capability/backend.rs:342-343`, `search.rs:196-199,285-288`), and **every fixture in the tree today declares `visible_in_states: vec![]`** — always visible, in every state (V 2026-09-06: 18 sites, all empty). Against such a fixture the tool set is invariant under the FSM state, so a leaked state moves nothing and this case is green whether or not the leak exists. The fixture must therefore register one capability visible in `"default"` and **not** in the state A sets (or the reverse), and the pinned literal must be pinned to that staging. Without a proof that the staging held, the staging is unverified prose and the case decays back to the invariant-fixture version — but **that proof must not be phrased as a discovery call from a modern HTTP connection made while the target state is in force**. On the Q4-ratify branch no modern connection can hold a non-default state after (c) — that is what (c) is for — so a staging assertion of that shape is unsatisfiable on that branch and the case is red forever: `test-plan-honesty`'s second survivor, a case that can never go green, not the one this repair was guarding against. The proof therefore runs on a **session-bearing connection**, one that legitimately owns a session id so its `gateway_set_state` is refused under neither answer to Q4, driving the same discovery entry point: set the state, observe the OTHER set. That proves both halves the staging needs — the capability is genuinely state-dependent, and the discovery path honours the dependence — and it is Q4-independent. The leak assertion then asserts only what its own branch permits. |
+| 2b | spec-preview promotion | **B-10 (existing promotion regression)**: repaired B-07 covers the cross-connection half; the same-connection half is its own case, the sequence `tools/list` → successful `gateway_invoke` → `tools/list` on one modern connection, with **both** lists asserted against the same pinned literal and the invoke asserted to have succeeded. **The promoted tool `T` must be one that is NOT already in the first list, and the pinned literal must exclude it** — promotion is de-duplicated against already-surfaced tools (`mod.rs:1332-1335`), so invoking an already-listed tool leaves both lists identical and the case green while promotion still writes under `""`. Same constraint repaired B-07 carries — and it binds on both merges, since the filtered path de-dups the same way (`spec_preview.rs:113-114`). **Each `tools/list` in the sequence is issued twice, once unfiltered and once with `params.query` set**, so 2b covers the filtered merge (`spec_preview.rs:112`) as well as the unfiltered one (`mod.rs:1330`). Repaired B-07 already forces the query on the 2a side, so the filtered path has 2a coverage; without this, 2b reaches it only if (c) puts the guard inside `promoted_tools_for_session` rather than at the unfiltered call site — and the test plan must not be contingent on an implementation choice it also has to check. (The committed case already pins a literal excluding `echo` and asserts `before` against it; this row is where the constraint was missing.) Feature-gated: it runs only in the `--features spec-preview` job, on the same terms as B-06 | integration | Either list differs from the literal, or the invoke did not succeed. Asserting the two observed lists against each other would pass both when the invoke silently failed (nothing was promoted, so nothing changed) and when a regression moved both lists in step; the pinned literal and the invoke assertion are what remove those two green-while-broken paths. This is the direct statement of 2b and is an expected green regression against the already guarded promotion store. |
+| 2a | FSM workflow state (§2b) | **B-08 / MIK-7272.ORDER2.FSM.1**: A drives the real `gateway_set_state` with `Some("")`; assert JSON-RPC protocol refusal (-32600), exact modern-aware message, no result, and no empty-key store write. B then drives all four discovery readers (list, list with server, search_tools, code_mode_search), each pinned to `STAGED_DEFAULT_TOOLS`. Both callers use the router's actual empty session key (`handlers.rs`); no caller has a session. | integration / isolation and error contract | Fails if the write guard is absent, if the method silently succeeds, or if any bystander list changes. The shared state-dependent fixture and its non-empty session staging control prove the observed membership can change. No declined-Q4 branch remains. |
+| 2b | FSM workflow state (§2b) | **B-09 / MIK-7272.ORDER2.FSM.2**: on one sessionless caller, pin all four discovery lists before, drive the real state call, assert the same exact refusal and no store write, then pin all four lists after. | integration / sequence and error contract | Fails for a successful or silent-no-op response even when the lists happen to remain unchanged, or for any changed list. Q4 was ratified; success is not an allowed alternative. |
 
 ## Preconditions on the implementation — plan-blocking, not advisory
 
@@ -83,24 +83,12 @@ A test plan normally constrains only tests. Two of these cases are honest **only
 if the implementation takes a particular shape**, so the shape is stated here as
 a rule that blocks the plan rather than as a note the implementer may weigh.
 
-**1. The fold is load-bearing.** B-08 and B-09 each drive **two** discovery entry
-points — `gateway_list_tools` and `gateway_search_tools` — so a skipped fold would
-already fail their `gateway_list_tools` assertion. The reader those two calls still
-do not reach is **`list_tools_single_server`** (`search.rs:581-584`, inside the
-function opening at `:560`), which reads the store directly on its own copy. Each
-case therefore drives a **third** call, `gateway_list_tools` with `server=` set to
-the capability backend carrying the staged state-dependent capability. With that
-call present the fold is a correctness improvement rather than a load-bearing
-precondition; without it the fold is what keeps the unfolded copy from going
-unobserved, and (c) folds `list_tools` and `list_tools_single_server` back into
-`current_search_state` before guarding it.
-The FSM store is not single-owner today: those two read it directly
-(`search.rs:581-584`, `:647-650`). If the fold is skipped and `session_key` is
-applied to the accessor alone, **B-08 and B-09 go green while `gateway_list_tools`
-still reads the shared entry** — a case passing over a live defect, which is
-exactly what §P2's second question exists to prevent. An implementation that
-skips the fold owes two more cases, one per unfolded reader, before this plan is
-satisfied.
+**1. The fold is already complete; FSM.4 falsifies the read guard.** Base
+`0d4df3c0` has one discovery-state read in `current_search_state` and all four
+entry points delegate to it. No fold is required. B08/B09 pin the refused writer;
+a write-only repair can pass them. FSM.4 therefore seeds old empty-key state and
+drives all four real discovery readers, exposing an omitted read guard without
+requiring the repaired writer to create forbidden state.
 
 **2. The empty profile/discovery cell is conditional on the accessor guard.** The
 justification above holds because the filter sits inside `active_profile`. If the
@@ -121,7 +109,9 @@ identically, and the case stays green through it.
 **Drive the real meta-tool path.** A fixture calling `promote_tool_for_session`
 or `SessionStateStore::set_state` directly bypasses the exact line under test.
 The defects are in the arguments passed at those call sites; a fixture that
-supplies its own argument asserts against itself.
+supplies its own argument asserts against itself. The explicitly named FSM.4
+exception seeds an old store entry only as the read-side precondition; its
+observations still drive the real discovery entry points.
 
 ## A property stated in prose is not a test
 
@@ -151,20 +141,39 @@ recorded as untested:
   by B-07, so until B-07 exists, `B-10` (2b, same-connection) is the *only*
   promotion case with code behind it.
 
-## Open question this plan waits on
+The preceding inventory preserves the original test-plan investigation. At the
+prerequisite base `0d4df3c0`, the FSM consolidation `76b8536c` is already present;
+it must not be repeated. Current remaining FSM cases and their gate status are
+in the checkpoint at the end of this plan. No other cluster is graded here.
 
-**Q4** — whether `gateway_set_state` should be refused on a modern connection in
-the default build, as `gateway_set_profile` already is. With the operator, queued
-by the team lead, not self-decidable: it changes a tool that succeeds today for a
-client doing nothing wrong.
+## Resolved decision governing B-08 and B-09
 
-Q4 governs **B-08's and B-09's assertions, not their existence.** Both are
-written to assert the refusal *and* the unchanged lists if Q4 ratifies, or the
-leak alone if it declines — B-08's row says so, and that conditional phrasing is
-what stops it going green without ever constructing the state it observes. B-10
-and the repaired B-07 do not depend on Q4 and are unblocked.
+**Q4 is resolved.** The operator selected **"Ratify the refusal (recommended)"**
+at `2026-09-06T11:19:59.466Z`. The actual question/answer provenance is recorded
+in [the design's Q4 decision](2026-09-06-order-2-per-connection-list-variance.md#6-questions-put-to-the-requester--decisions-recorded).
+The design and this plan previously retained their OPEN wording after the answer.
 
-## Review record
+Q4 governs **B-08's and B-09's assertions, not their existence.** Execute the
+ratified branch described in those rows: assert the refusal *and* unchanged lists,
+with the session-bearing positive control proving the fixture's state-dependent
+visibility. There is no alternative decline branch in the executable contract. B-10 and the repaired B-07 remain independent of Q4.
+Decision recovery does not grade test execution, implementation review or release
+acceptance; those remain pending until their evidence is recorded.
+
+Both cases MUST assert the returned error, not merely that the lists did not move.
+A `gateway_set_state` that silently does nothing satisfies an unchanged-list
+assertion exactly as well as the ratified refusal does, so a case that discards the
+call's response cannot tell the repair from its absence — the §P2 failure mode of a
+case that passes while the thing it names is broken.
+
+The message is asserted too, and it is NOT today's. HEAD returns
+`gateway_set_state requires a session (send Mcp-Session-Id header)`
+(`mod.rs:1696`), and the modern HTTP router deliberately ignores that header — so
+the remediation it offers a modern caller cannot be followed. The refusal this plan
+asserts names the condition rather than an impossible fix. B-10 and the repaired
+B-07 never depended on Q4 and stay unblocked.
+
+## Historical review record
 
 Two independent **non-author** legs are required. This work is Claude-authored,
 so `gpt`, `grok` and `kimi` are all eligible and any two make a valid pair; the
@@ -173,7 +182,7 @@ reviewer that is forbidden here is `claude-review`, not `grok`.
 | leg | vendor | verdict | run |
 |---|---|---|---|
 | 1 | Grok | SHIP-WITH-FIXES | `grok-20260906T071032Z-19225` |
-| 2 | Kimi | pending | material submitted inline on stdin — kimi has no filesystem |
+| 2 | Kimi | SHIP-WITH-FIXES (recovered ledger) | `synthetic-20260906T080350Z-26796`; differing material, not closure |
 | — | Codex/GPT | MISSING | usage limit machine-wide until 2026-09-12 06:33 |
 
 The GPT row is recorded as **availability, not substitution**: an exhausted
@@ -193,3 +202,72 @@ found unmapped during that repair and given a drive of its own.
 **Declared for the second leg:** this plan was edited after leg 1 read it. The
 edits are the repairs above plus this section and the cluster-B untested row.
 Leg 2 reads the plan as it now stands, not as leg 1 saw it.
+
+
+## FSM prerequisite test gate recovery — 2026-09-07
+
+This section carries the remaining FSM requirements of the existing change.
+Historical review records above are provenance, not a current passing gate.
+B08/B09 currently discard the response: repairing their assertions is mandatory
+before runtime integration. Both retain all four pinned discovery observations.
+The exact serialized JSON-RPC `error.message` is independently pinned below.
+It includes the existing `Error::Protocol` Display prefix from `error.rs`; the
+inner `NO_SESSION_FOR_STATE` detail omits that prefix:
+
+> Protocol error: The workflow state is per-session, and this connection has no session. MCP 2026-07-28 removed protocol-level sessions; capability visibility is decided by the authorization presented on each request.
+
+| Criterion | Case and level/type | Falsifier | Result |
+|---|---|---|---|
+| MIK-7272.ORDER2.FSM.1 | B08: refusal and unaffected bystander; integration/isolation | Missing write guard or silent successful no-op | Pending repaired-test RED |
+| MIK-7272.ORDER2.FSM.2 | B09: refusal and same caller lists unchanged; integration/sequence | Success response, impossible remediation text, changed membership | Pending repaired-test RED |
+| MIK-7272.ORDER2.FSM.3 | Missing `None` key and empty `Some("")` both refuse with -32600, no result, exact message and no write; integration/boundary | Empty-only guard, missing-key old message, store mutation before refusal | Pending RED |
+| MIK-7272.ORDER2.FSM.4 | Seed an old non-default empty-key entry directly as a fixture; assert it exists, then each of four real discovery calls for None/empty sees the default literal; integration/contaminated-state regression | Delete the read guard while leaving the write guard intact | Pending RED |
+| MIK-7272.ORDER2.FSM.5 | Existing staging control plus non-empty legacy and `stdio-session` callers successfully change their own state and see the non-default literal while another named caller remains default; integration/compatibility | Overbroad refusal/default read; no-op mutator; shared non-empty keys | Pending control |
+
+Seeded old empty-key state is a deliberate test precondition for the read-side
+obligation; it is not reachable through the repaired modern writer and is not
+claimed as public functional driving. Real HTTP driving independently exercises
+FSM.1/.2, the empty-key branch of FSM.3, and the session-bearing control in FSM.5.
+The `None` branch of FSM.3 is N/A to public HTTP driving because the modern router
+passes `Some("")`; it is required component evidence, not a public PASS. The seed-only internal
+part of FSM.4 is N/A to public drive because production exposes no operation to
+create that forbidden state after the fix; its reviewed component evidence is
+required instead. Full default/all-feature invocation and existing profile,
+promotion and state tests provide regression coverage. No network backend needs
+to answer a request for the staged capability listings.
+
+Order: finder confirmation of plan repairs, repaired assertion RED, separate
+review of the tests as tests, minimum runtime guard patch, green/fault/coverage
+and focused self-QA, final dual code review with isolated functional drive.
+The initial CI RED is preserved as baseline evidence and is not falsely reused
+as execution of the new refusal assertions. Source line numbers in old sections
+are historical; this checkpoint binds symbols and exact isolated revisions.
+
+
+### Test finder repair: production caller checks
+
+The five criteria and runtime scope are unchanged. GPT test finder r1 requests
+caller-boundary regressions in addition to the reviewed component cases; the
+coordinator approved this bounded repair. Add one real modern `Router::oneshot`
+state-refusal case (with and without an offered session header), using the
+existing modern-era fixture and exact error/no-result assertions (FSM.3), and
+one `Gateway::dispatch_single` stdio transition sequence proving the previous,
+current and owner values in two successful responses (FSM.5). The stdio helper reaches the production `dispatch_single_with_sink` path.
+GPT finder r2 additionally requires the production `run_stdio` loop and test to
+share one private `STDIO_SESSION_ID` constant, while the test retains its
+independent literal owner assertion. This behavior-preserving extraction makes
+an empty owner falsify the compatibility case; no OS-pipe claim is made.
+These complement the existing modern session-mapping router regression and
+retain all component cases, including None and the contaminated empty-key seed.
+Expected final focused set: eight cases. Both new caller cases must compile;
+modern refusal must assert RED on the base, and the stdio sequence is a positive
+control. Independent public HTTP driving is still a final gate; these automated
+caller checks do not substitute for it. No stdio/A2A transport policy changes.
+
+Current implementation result: `order2-prerequisite-green.log` records eight
+passing cases, actual exit 0; `order2-prerequisite-tests-red-r4.log` records the
+pre-guard five assertion failures and three controls. GPT test finder r3 SHIP
+(actual 0, material c69da711ac4fa284c21357a68e8a0f8c77569e3b4a8294c325631cbf280d8ee0)
+closes the required caller seam; Grok r1 SHIP is retained. All five FSM criteria
+pass at their declared component/caller levels. Independent public driving,
+quantitative and final code-review gates are still pending.

--- a/docs/design/2026-09-06-order-2-per-connection-list-variance.md
+++ b/docs/design/2026-09-06-order-2-per-connection-list-variance.md
@@ -1,16 +1,22 @@
 # ORDER.2 — list results must not vary per connection, nor as a side effect
 
-MIK-7272.ORDER.2a, MIK-7272.ORDER.2b. Design only. No code, no tests.
+MIK-7272.ORDER.2a, MIK-7272.ORDER.2b. This note adds no code and no tests. It is not, however, a design written ahead of all of its subject: two of the three legs below had already landed when it was written (`eb9e537a`, `76b8536c` and the five profile cases are ancestors of the revision under review). For those two legs this note is a POST-HOC RECORD and should be read as one; only the third leg, the FSM workflow-state store, is designed here before it is built. A reviewer judging the closed legs is judging a decision already constrained by its implementation, and saying so is cheaper than implying otherwise.
 
 ## What this note is, and is not
 
 This is a **delta** on `docs/design/2026-08-31-cluster-b-connection-invariance.md`
 (Part I of that note *is* ORDER.2) and its sibling test plan. It does not restate
 the option analysis, the blast radius, or the cases already written there. It
-records two things that note could not: that the profile leg has since been
-**closed in code**, and that the one remaining leg is the `spec-preview`
-promotion store, which cluster-b classified in its §I.2 and explicitly left to
-"whichever ORDER.2 option is chosen".
+records what that note could not: which legs have since **closed in code** and which
+have not. Three legs; the prerequisite checkpoint below measures the committed integration base `0d4df3c0`. Historical citations remain evidence of the original investigation.
+The routing profile is closed and carried by five cases. The `spec-preview`
+promotion store — which cluster-b classified in its §I.2 and explicitly left to
+"whichever ORDER.2 option is chosen" — is closed in code at `eb9e537a`. The sessionless regression in `0527aacc` is external history, not an ancestor or a test present in this isolated base. B-10 is the in-tree promotion regression. The **FSM workflow-state store is the one leg still open
+in committed code**: `76b8536c` converged four discovery entry points onto one
+accessor, which is the precondition for a filter and is not the filter. An earlier
+revision of this paragraph named `spec-preview` as the sole remainder; that was
+written before `eb9e537a` landed and is corrected here rather than left to mislead
+an implementer into repairing the leg that is already done.
 
 ## §P0 SCOPE
 
@@ -53,10 +59,15 @@ in the shape of cluster-b's **option (b)** (profiles do not exist in modern mode
 not the option (a) that note recommended. The mechanism is elimination, not a
 check: with no non-empty key there is no per-connection profile state to vary.
 
-## 2. What remains: the spec-preview promotion store
+## 2. The spec-preview promotion store — closed in code, and now tested
 
-`spec-preview` dynamic promotion (SEP-1862) is the one list-shaping input that
-does **not** pass through `session_key`.
+`spec-preview` dynamic promotion (SEP-1862) was the one list-shaping input that
+did **not** pass through `session_key`. It does now: `promote_tool_for_session`
+takes `Option<&str>` and returns early when `session_key` rejects the caller
+(`src/gateway/meta_mcp/spec_preview.rs:238-241`, landed in `eb9e537a`), and a
+sessionless test was later added in `0527aacc` on another branch. That test has not been replayed into base `0d4df3c0`, so it is not counted here.
+The facts below record the defect as it stood, because the option analysis in
+§4 was written against it.
 
 | # | fact | source |
 |---|---|---|
@@ -66,7 +77,7 @@ does **not** pass through `session_key`.
 | 10 | The router passes `Some(session_id.as_str())` on both the list and the call path, i.e. `Some("")` for a modern connection. | `handlers.rs:971` (`tools/list`), `handlers.rs:1162` (`tools/call`) |
 | 11 | Promoted tools are appended to the assembled list inside `handle_tools_list_for_session`, immediately after the surfaced-tool loop. | `mod.rs:1284-1330`, surfaced loop at `mod.rs:1310` |
 
-**Both clauses fail on this leg.** 2b: a successful `gateway_invoke` changes the
+**Before `eb9e537a`, both clauses failed on this leg.** 2b: a successful `gateway_invoke` changes the
 next `tools/list` on the same connection. 2a: because the key is `""` and every
 sessionless modern caller shares it, the change is visible to *other*
 connections too — a strictly worse failure than the one the criterion names.
@@ -75,7 +86,7 @@ connections too — a strictly worse failure than the one the criterion names.
 set: `Cargo.toml:179` lists `default = ["a2a","webui","config-export",
 "cost-governance","firewall","discovery","semantic-search","tool-profiles",
 "metrics"]`, and `Cargo.toml:193` declares `spec-preview = []`. A default build
-does not compile this path. It is a real defect in the builds that enable the
+does not compile this path. It was a defect in the builds that enabled the
 feature, and the feature is the one this whole protocol effort exists to
 prepare. Whether that lowers the criterion's severity was Q2, answered on
 2026-09-06: it does not (§6). Not a reason to leave it.
@@ -83,8 +94,7 @@ prepare. Whether that lowers the criterion's severity was Q2, answered on
 **Not a discovery.** cluster-b's test plan already specifies this case as
 **B-07** ("a promoted tool must not appear in session A's modern list, nor make
 it differ from B") and **B-06** (B-01 re-run under `--features spec-preview`).
-What is new here is the measurement that the production path is still open and
-that the profile leg around it has closed, which changes which option is cheap.
+This historical measurement motivated the now-landed promotion guards. The FSM leg below is the remaining prerequisite.
 
 ## 2b. A second store with the same defect — the FSM workflow state
 
@@ -129,7 +139,7 @@ reaches list assembly was read:
 | Code Mode | `handlers.rs:497` `code_mode_url_active` | **not a violation** — read from the request's own URL query, per-request input, not connection state |
 | meta-tool set | global configuration | invariant across connections by construction |
 | backend tool cache contents | shared, time-varying | out of scope; cluster-b Part III item 1 |
-| spec-preview promotion | §2 | **a remaining violation** |
+| spec-preview promotion | §2 | closed in code, `eb9e537a`; in-tree B-10 regression; `0527aacc` is external/unreplayed |
 | FSM workflow state, via the discovery surface | §2b, `mod.rs:1688-1696` and `search.rs:161-165` | **a remaining violation**, in the default build |
 
 Other `active_profile` call sites were checked. `invoke.rs:1065` is dispatch.
@@ -175,32 +185,16 @@ and the operator ratified it on 2026-08-31 (cluster-b §4.1, recorded in §5), s
 there is nothing left to decide here — (a) is dead rather than merely expensive.
 
 **(c) Extend the `session_key` discipline to the two raw-id stores — RECOMMENDED.**
-Two writes and two reads — but only **after** a duplication is removed, and that
-removal is part of (c) rather than a tidy-up beside it:
+**Historical implementation sequence.** Promotion guards (`eb9e537a`) and the FSM reader consolidation (`76b8536c`) are already in integration base `0d4df3c0`. The only remaining production edits are the FSM write guard and the one consolidated read guard. The following inventory explains why the original design required consolidation; it does not prescribe repeating that completed work:
 
-| store | write | read |
+| Remaining FSM owner | Required change | Existing consumers |
 |---|---|---|
-| `session_promoted` (§2, feature-gated) | `invoke.rs:1826-1828` | `promoted_tools_for_session`, `mod.rs:1021-1030` — the only reader of the map; `mod.rs:1266`, `mod.rs:1330` and `spec_preview.rs:112` all go through it |
-| `session_state` (§2b, **default build**) | `mod.rs:1689` | `current_search_state`, `search.rs:161-165` — **plus two inlined copies of its body**, `search.rs:581-584` in `list_tools_single_server` and `search.rs:647-650` in `list_tools`, which call `self.session_state.get_state(sid)` directly |
+| `MetaMcp::set_state` | reject missing/empty session key with the ratified protocol error | real `handle_tools_call` dispatch |
+| `MetaMcp::current_search_state` | normalize missing/empty key to the default state | code-mode search, search_tools, list_tools, list_tools_single_server |
 
-The promotion store already has one owner per direction. The FSM store does not:
-the same `map_or_else(DEFAULT_STATE, get_state)` expression is written out three
-times, and `session_key` applied only to `current_search_state` would leave
-`gateway_list_tools` reading the shared entry on both of its paths while
-`gateway_search_tools` and code-mode search were fixed — a guard that holds on
-some surfaces and not others, which is the defect this note is about, one level
-down. So (c) folds `search.rs:581-584` and `search.rs:647-650` into
-`current_search_state` first, and then filters inside it. Three sites become one,
-and the finding stops being restatable rather than being patched three times.
-
-**The filter goes inside the owning function, not at its call sites.** A counted
-list of call sites is a discipline the next caller can skip — which is precisely
-how `list_tools` came to read the FSM store directly while `current_search_state`
-sat one file away. So: inside `promoted_tools_for_session` (`mod.rs:1021-1030`)
-and inside `promote_tool_for_session` (`spec_preview.rs:228`), and inside
-`current_search_state` (`search.rs:161-165`) once the three copies are folded
-into it. Each store then has one accessor and one mutator, both filtering, and a
-future list-shaping caller inherits the guard instead of having to remember it.
+The promotion guards and FSM reader fold have already landed. They are not work
+for this increment. Both remaining guards reuse `session_key`, so future callers
+inherit the invariant at its existing owner rather than repeating call-site checks.
 
 One deliberate exception, because it is the kind that gets "corrected" later: the
 FSM **write** is filtered at the `gateway_set_state` handler (`mod.rs:1689`), not
@@ -299,11 +293,12 @@ Every unknown is resolved with a recorded answer or deferred with four fields.
 
 Nothing in this note's recommendation depends on either deferred item.
 
-## 6. Questions put to the requester — three settled, one open
+## 6. Questions put to the requester — decisions recorded
 
 Recorded here because a question that was asked and answered is evidence; a
-question that quietly stopped being asked is not. Q4 is open and blocks the
-`session_state` half of the implementation, not the note.
+question that quietly stopped being asked is not. Q4 was answered by the operator;
+the recovered answer below removes the decision dependency. Implementation and
+acceptance validation remain separate and pending.
 
 **Q1 is struck.** It asked whether the `gateway_set_profile` refusal was
 intended. The operator answered that on 2026-08-31 in cluster-b Part IV §4.1 —
@@ -330,23 +325,28 @@ and not an escalation to the operator, and it is why nothing in §7 moves. What 
 fixes is where the work lands: the `session_state` half of (c) belongs to ORDER.2
 itself rather than to a sibling criterion, so implementation is one ticket.
 
-**Q4 — OPEN, and it blocks implementation of (c)'s `session_state` half.** After
+**Q4 — RESOLVED: the operator ratified the refusal on 2026-09-06.** After
 (c), `gateway_set_state` **refuses** on a modern HTTP connection, in the
-**default build**, on a tool that succeeds today. §4 prices this; §4 cannot
-ratify it. This is the same shape as cluster-b §4.1, where the operator ratified
-the `gateway_set_profile` refusal before it shipped, and the reason to ask again
-rather than infer from that answer is that the profile refusal shipped behind an
-already-agreed removal while this one is a live tool changing behaviour under
-`default`.
+**default build**, on a tool that previously succeeded. The question explicitly
+named that compatibility cost. Its recorded answer was **"Ratify the refusal
+(recommended)"** at `2026-09-06T11:19:59.466Z`, through `AskUserQuestion`, tool-use
+ID `toolu_01SKMFrjNivV7VaHyKzwEt4c`, session
+`be5177ff-7fa6-4b0c-9c6c-fecc3f7548e1`. The answer was recovered from the actual
+tool result during release takeover, rather than inferred from the implementation
+comment. The design's former OPEN status had not been updated after that answer.
+
+This selects option (c)'s refusal branch and B-08/B-09's refusal-plus-unchanged-list
+assertions. It does not establish that those tests compile or pass, or that the
+implementation is reviewed or delivered.
 
 | answer | what it buys | what it costs |
 |---|---|---|
-| **ratify the refusal** (recommended) | 2a and 2b both closed on modern HTTP by removing state rather than adding checks; `gateway_set_state` behaves exactly as `gateway_set_profile` already does, so the surface stays coherent | a modern client calling `gateway_set_state` starts getting a protocol error where it got a success; if any client depends on it, that client breaks at upgrade |
+| **ratify the refusal** (selected) | 2a and 2b can close on modern HTTP by removing state rather than adding checks; `gateway_set_state` follows `gateway_set_profile`'s session rule | a modern client calling `gateway_set_state` starts getting a protocol error where it got a success; if any client depends on it, that client breaks at upgrade |
 | keep it succeeding, close 2a only | no client-visible break | the tool's effect still leaks to every other sessionless connection, which is the defect — a per-connection tool that is not per-connection |
 
-Recommended: ratify. The tool's current success is not a working feature, it is
-the defect wearing a return value — the state it sets is read by every other
-modern connection on the same gateway.
+The selected refusal prevents a modern caller from writing state that every other
+sessionless connection can read. Existing session-bearing callers retain their
+stateful behavior; the acceptance tests must verify both populations.
 
 ## 7. Test plan — moved to its own document
 
@@ -365,15 +365,28 @@ copy nobody reads is the one that goes stale.
 
 ## 8. What this note does not close
 
-ORDER.2a and ORDER.2b are **not** satisfied by this note. It is design only: no
-code changed, no test was added, and the promotion leg in §2 is open in the
-source as of 682a709a. The ledger rows stay blocking. What has changed is what
+ORDER.2a and ORDER.2b are **not** satisfied by this note. The promotion leg of §2 has since closed —
+guarded in `eb9e537a`, with B-10 as an in-tree regression — and the FSM
+state store of §2b is the one leg still open in isolated base `0d4df3c0`. The additional sessionless test in `0527aacc` is unreplayed external history, not current coverage. The ledger rows stay blocking. What has changed is what
 the evidence cell can now say: the profile leg is closed in code and measured
-here, the remaining defect is **two stores and four call sites** — the
-feature-gated promotion store of §2 and the default-build FSM state store of §2b
-— and the option to close both is chosen and priced. §2b belongs to ORDER.2
+here, the remaining defect is **one store** — the
+default-build FSM state store of §2b; the feature-gated promotion store of §2 is
+closed — and the option to close both is chosen, priced, and ratified by the operator
+on 2026-09-06 (§6 Q4). §2b belongs to ORDER.2
 itself, per Q3's answer of 2026-09-06; it would have been the same defect under
 either reading.
+
+**Disposal of that limit, named rather than defaulted (§P0).** Of the four
+disposals, the one that holds is *write it into the design* — cluster-g's, not this
+note's, because the finding changes what that cluster's convergence point should be
+and its owner is who acts on it. Done on 2026-09-06: a section at the end of
+`docs/design/2026-09-02-cluster-g-stdio-dispatch-parity.md` records the non-empty
+`"stdio-session"` id, the two stores that would have to be re-keyed, and the fact
+that the settlement is a product call rather than a repair. It was **not** filed as a
+ticket: filing is the most expensive disposal, cluster-g already owns a design note
+and a board row, and a new ticket would have added a queue entry without adding a
+decision. What the disposal does not do is build the watcher — that stays cluster-g's
+implementation step and is named as missing there.
 
 One coverage limit, found by review and worth more than the rest of this note:
 **(c) closes both legs on modern HTTP and neither of them on stdio.** stdio
@@ -383,3 +396,207 @@ invoke on a stdio connection can still promote into that connection's next list 
 2b, live, after the recommended fix. §P0 puts transport parity with cluster-g and
 this note does not price it; what this note owes cluster-g is the measurement,
 which is now in §5 rather than sitting in the deferred column as a question.
+
+
+## 9. FSM prerequisite delivery checkpoint — 2026-09-07
+
+**Current increment status:** the two FSM guards are implemented; eight focused
+acceptance/caller cases pass after compiled assertion RED and test-finder closure.
+Formatting passes. Draft publication starts CI in parallel with remaining final
+code review, quantitative checks and independent functional acceptance. No merge
+or complete release acceptance is claimed.
+
+**FOR:** unblocking the 4.0 integration base and configuration PR #483 by closing
+only the sessionless FSM write/read invariant already selected in option (c).
+**OUT:** profile/promotion redesign, stdio/A2A transport policy, notifications,
+cache behavior, unrelated release implementations, and merging or release closure.
+This is the remaining FSM increment of the original ORDER.2 change, not a new
+requirement or a reset of its review history. Historical ledgers stored
+`change_id: null`; the original frozen design receipt remains material
+`5f262fb547766dfac8835f691fe481ff017fdbea709008f78f9bc40522ee3a14`
+(31,167 bytes, Grok `grok-20260906T064155Z-129`). Preserve that lineage rather
+than inventing a previous passing gate. This prerequisite is two steps from the
+configuration implementation (CI selection, then its failing integration base);
+it still serves the user's original 4.0 release delivery objective.
+
+A prepared repair exists in the separate delivery worktree, but its required
+gates are missing. The authoritative later GPT/Grok design/plan findings are
+`gpt-20260906T153954Z-80665` and `grok-20260906T154615Z-96685`, both
+SHIP-WITH-FIXES. They require the ratified refusal assertions, modern-aware error
+text, and an honest distinction between completed promotion work and the two
+remaining FSM guards. Their original differing material hashes are retained;
+they do not constitute a matching final approval. The historical Kimi plan leg
+`synthetic-20260906T080350Z-26796` also returned SHIP-WITH-FIXES, despite the
+older record saying pending. No FSM tests-as-tests closure, final code pair,
+independent functional drive, or quantitative receipt was found in the inherited
+OUT/ledger audit. None is claimed as passed.
+
+### Definition of Ready and validation boundary
+
+- Value/priority: mandated `MIK-7272.ORDER.2a/.2b` release invariance; CI run
+  34062367993 on config SHA `bfa16dc3` compiled 4,058 library cases and returned
+  4,052 passed, two B08/B09 assertion failures, four ignored, exit 101. The same
+  relevant production blobs and test bodies are present in base `0d4df3c0`.
+  The private Spark rebuild now independently confirms B08/B09 assertion RED and one staging control PASS (exit 101); see `order2-prerequisite-base-red-r2.log`.
+- Scope/dependencies: only `MetaMcp::set_state`, its refusal text, and
+  `MetaMcp::current_search_state`; the existing `session_key` helper and four
+  discovery consumers already exist. Tests and these two design files accompany
+  the patch. No new public API, dependency, storage format, crypto, service, or
+  deployment topology. Parent owns TLS; config PR #483 stays separate.
+- Alternatives: reuse the selected owner-level guards; reject a silent store
+  no-op because it hides the refusal, and reject principal re-keying because a
+  caller could still change its own subsequent list. The existing operator Q4
+  answer settles the only product compatibility decision: refuse sessionless
+  state changes; non-empty legacy/stdio session keys retain their behavior.
+- Risks: write-only repair misses already contaminated empty-key state; read-only
+  repair makes the refused mutation appear successful. Separate write/read tests
+  and their falsifiers cover both. Exact error assertions prevent advice to send
+  a session header that modern HTTP ignores. Unchanged non-empty controls detect
+  overbroad normalization.
+- Applicable DoR: CODE/security mandate and existing ticket/criteria; G0-G12,
+  C1-C15 and rollback/test/CI requirements apply. Novelty/NPV/emerging-tech
+  benchmark, new-service SLO, crypto/PQC, AI/ML, residency, device and new-license
+  conditions are N/A because no such surface changes. The existing Rust helper
+  avoids introducing a new abstraction or technology. No new telemetry event is
+  needed for an existing protocol refusal. STRIDE: eliminate shared-state
+  tampering/information influence; no new identity or credential is trusted.
+- Unknowns: Q4 is resolved by the recorded operator answer. Compiled repaired
+  assertions, read-guard falsification, critical coverage/mutation, final review
+  and independent public HTTP behavior are **pending results**, owned by this
+  increment before merge; any failure blocks that gate and is repaired within
+  this same invariant. A full release/transport-wide claim remains out of scope.
+- Quantitative plan: exercise >=95% of changed critical executable lines and
+  catch >=85% of viable focused mutations, including each omitted guard and a
+  silent-success fault. Run default and all-feature affected tests, formatter,
+  Clippy and same-SHA CI. Use a pinned actual CLI HTTP drive with modern and
+  session-bearing controls; the independent driver gets ACs and launch details,
+  no source/diff. No passing score is inferred from old unrelated reviews.
+- Rollback: revert this isolated prerequisite commit; this restores the known
+  shared-state defect, so it is an operational rollback rather than a release
+  acceptance outcome. No migration or data rewrite is required.
+
+The isolated branch starts at `0d4df3c0bd4e3b3ca5afa3f2d63bdb3261b118cf`:
+`codex/v4-order2-prerequisite`. Gate receipts and full command logs are retained
+under the external release evidence directory as `order2-prerequisite-*`.
+
+
+### Complete named DoR gate inventory (finder repair)
+
+This is the security-mandate path, with no claim of financial NPV or novelty.
+The canonical file's enumerated IDs total **72**, although its heading says 84:
+22 G + 5 B + 9 T + 17 C + 8 P + 7 L + 4 O. All 72 named IDs are accounted for
+below; no twelve invented gates are marked complete. Of these, 50 apply and 22
+are N/A. Pending DoD execution is not represented as a passing DoR result.
+
+| IDs | Applicability and readiness evidence |
+|---|---|
+| G0–G5 | Apply: release mandate and CI dependency demonstrated by run 34062367993; Q4 approved. Fixed planning estimate for gate recovery: 220,000 input tokens and 16,000 output tokens, including reviews and validation interpretation; at the canonical $15/M input + $75/M output rates, $3.30 + $1.20 = **$4.50**. Allow 1–2 hours including approximately 15 minutes of context restoration and review handoffs. These are estimates, not measured billing or a claim about actual vendor rates. NPV/ROI dollar calculation is N/A under the security mandate. Minimum repair is two owner guards; no optional redesign. |
+| G6–G12 | Apply: owner guards versus silent no-op/principal re-keying already compared in §4; same-session and cross-session impact plus overbroad legacy refusal identified; the cheapest high-risk assumption is now tested on a rebuilt base: B08/B09 assertion RED, one staging control green, actual exit101 in `order2-prerequisite-base-red-r2.log`. Required runtime dependencies are in base. |
+| G13, G14, G15, G18, G20, G21 | N/A: no novel technology, optimization, emerging-tech bet or moat claim; bounded security repair estimated below four hours, so G15's hotfix exception applies. |
+| G16, G17, G19 | Apply: four primary prior-art sources and the NIH decision are cited in the focused evidence below; reproduce the observed failure rather than invent a new mechanism. Revert is possible without migration. User outcome is stable tool membership and explicit refusal for sessionless clients, measured by all four discovery surfaces. |
+| B1–B5 | Apply: existing MIK-7272, High, 8 points, mcp-gateway project, Mikko team, v4.0.0 milestone, In Progress, prioritized prerequisite for PR483. Coordinator completed and read back Mikko as owner, Bug+mcp-gateway labels, and all five stable FSM criteria in the existing description; `order2-linear-prerequisite-readback.json` retains the full receipt. Original scope and relations are preserved. B2/B4 metadata readiness is verified. This is an increment of that ticket, not a new orphan issue. |
+| T0, T1, T2, T4, T5 | Apply: reliability/security fix in the existing Rust gateway; reuse the proven helper and protocol error type. No technology switch is warranted at a two-guard boundary; it would add deployment/review cost without improving this invariant. Direct callers verified by GitNexus and static source: one write handler and four discovery readers. |
+| T1b, T1c, T3, T6 | N/A: no emerging-tech claim, crypto, framework selection, numeric/collective processing. |
+| C1–C12, C14–C16 | Apply: one existing helper per invariant, no new API/schema/dependency/cycle; the reviewed plan has red drivers and independent read/write falsifiers. Trust boundary is the unauthenticated/sessionless request context; no user label becomes identity. Existing locked session store retains strong per-key ownership for non-empty callers. The compatibility refusal is Q4-approved. Existing protocol envelopes and version routing remain intact; memory/state capacity decreases for forbidden keys. Source delta target is under 400 lines. Pre-existing large parent modules are not expanded with a new production abstraction. |
+| C13, C17 | N/A as readiness gates: C13 explicitly moved to DoD mutation evidence (planned, not passed); no new cross-service failure mechanism or resilience policy. |
+| P1, P2, P4, P6, P7 | Apply: existing observable JSON-RPC refusal/trace path; tested binary rollback planned; no additional stored state, data migration, or capacity dependency; reuse the exact already-reviewed integration-branch CI selector from bfa16dc3 and obtain this PR's own head-bound run. |
+| P3, P5, P8 | N/A: no feature flag or new service/SLO/alert threshold is introduced; this is the operator-ratified invariant at existing endpoints. |
+| L1 | Apply: owned source is PolyForm-Noncommercial-1.0.0, not MIT; preserve each header. Actual header check, current 453-package license inventory, CycloneDX 1.5 SBOM, AGPL scan and identical-lock CI vulnerability audit are recorded below. No new dependency, algorithm or license/patent claim. |
+| L2–L7 | N/A: no new personal data, AI feature, transfer/residency flow, license set, device contribution, or crypto/ML distribution. |
+| O1–O3 | Apply: separate owned worktree, scoped changes, existing design/test-plan SSOT, evidence outside source; owned build artifacts cleaned after handoff. |
+| O4 | N/A: no one-way architectural decision requiring a new ADR; existing option (c) and Q4 decision are retained. |
+
+**DoR summary:** mandate-justified NPV/ROI N/A; estimated recovery cost above;
+72/72 named IDs assessed (50 applicable, 22 N/A; canonical heading says 84).
+Readiness remains **pending GPT finder confirmation** of the remaining G16 arXiv citation and L1 scoped patent-search record; G2/C6 and the other G16/L1 audit items closed in r3; Grok r2 closed its NOW findings with SHIP, actual exit 0. Evidence counts: E1 four declarations (scope, AC contract, rollback, fixed effort/cost estimate); E2 eight citation groups (four prior-art sources, original decisions, reviewer ledgers, live tracker, source owners/callers); E3 nine output groups (four symbol impacts, rebuilt baseline RED, license-header check, current metadata/AGPL inventory, CycloneDX output, identical-lock CI audit); E4 three records (existing design, existing test plan, focused STRIDE/auth/input record below).
+No DoD final approval or functional pass is implied by this readiness inventory.
+
+
+### Focused readiness evidence: G16, C6 and L1
+
+**G16 — prior art and NIH decision (checked 2026-09-07).**
+
+1. [Rust `Option::filter`](https://doc.rust-lang.org/std/option/enum.Option.html#method.filter)
+   specifies preservation of `None` and predicate-based removal of `Some`. This
+   is the existing `session_key` mechanism; no replacement abstraction is needed.
+2. [MCP 2025-11-25 session management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management)
+   specifies server-assigned session identifiers and subsequent client use. It
+   grounds the non-empty legacy compatibility control; it does not establish the
+   newer HTTP decision, which is the separately ratified Q4 contract.
+3. [Pinned gateway prior art at base 0d4df3c0](https://github.com/MikkoParkkola/mcp-gateway/blob/0d4df3c0bd4e3b3ca5afa3f2d63bdb3261b118cf/src/gateway/meta_mcp/mod.rs#L1095)
+   already filters empty keys for neighboring per-session behavior. Reuse that
+   helper in the two FSM owners; existing profile refusal demonstrates the same
+   explicit error boundary. Local pinned source was inspected.
+4. [Calzavara et al., Language-Based Web Session Integrity, arXiv:2001.10405v2](https://arxiv.org/abs/2001.10405v2)
+   studies server-side session integrity with a security type system and real
+   application analyses. It motivates checking both the mutation boundary and
+   discovery observations. The application to these guards is an engineering
+   inference; this increment does not adopt that type system or claim a formal
+   proof. The existing predicate remains the smallest mechanism.
+
+**C6 — security record.** Trust domain: unauthenticated or authenticated request
+contexts may be sessionless; session identifiers are state keys, not principals.
+Existing router authentication/authorization remains authoritative. Inputs are
+optional internal session IDs, the state argument, and protocol/session headers
+already normalized by transport handling. State is local in-process, partition
+handling is unchanged, and the locked per-key store retains strong ownership.
+No crypto algorithm, signature, key exchange, randomness or credential generation
+changes; crypto/PQC applicability is N/A.
+
+| STRIDE concern | Mitigation in this bounded change |
+|---|---|
+| Spoofing | An empty key cannot create a session identity; existing authentication remains unchanged. |
+| Tampering | Reject unkeyed FSM writes and ignore a pre-existing empty-key state on every reader. |
+| Repudiation | Preserve the JSON-RPC request ID and explicit protocol error; never acknowledge a refused state mutation as success. |
+| Information disclosure | Prevent one sessionless caller from changing another caller's discoverable membership; refusal adds no secret data. |
+| Denial of service | Rejected empty-key writes allocate no persistent entry; normalization is one constant-time empty-string check. Existing request limits remain. |
+| Elevation of privilege | Refusal grants no permissions; non-empty state ownership and existing authorization continue unchanged. |
+
+These are design mitigations; their behavioral tests and fault checks are pending,
+not represented as completed security testing.
+
+**L1 — actual audit evidence.** `order2-prerequisite-license-audit.json` binds the
+following artifacts to base `0d4df3c0` and the identical lockfile used in the
+passing CI audit. `bash scripts/ci/check-license-headers.sh` passed (exit 0): all
+first-party headers match the existing per-file license boundary. The affected
+meta-MCP files carry PolyForm-Noncommercial-1.0.0; new tests must preserve it.
+Current `cargo metadata --locked --all-features` succeeded and enumerates 453
+packages: no AGPL expression and no missing dependency license; the only package
+using a license file is this workspace's `LICENSES.md`. The snapshot includes
+existing MPL and optional LGPL alternatives; this increment adds no dependency
+or distribution. `cargo cyclonedx` 0.5.9 with `--all-features --target all --all
+--format json --spec-version 1.5` passed (exit 0), producing a 399-component
+runtime/build dependency SBOM in `order2-prerequisite-bom.json`; the broader
+metadata inventory also covers development dependencies.
+
+[CI audit job 101565032105](https://github.com/MikkoParkkola/mcp-gateway/actions/runs/34062367993/job/101565032105)
+passed against byte-identical Cargo.toml/Cargo.lock, scanning 453 crates using
+1,239 advisories. It reported one allowed, pre-existing warning: **chacha20 0.10.0
+is yanked**. The warning and full log are retained, with no policy change or
+claim of a warning-free audit. A scoped patent search is recorded in `order2-prerequisite-prior-art-search.json`:
+query `site:patents.google.com "session identifier" "empty" session state`.
+[US9058214B2](https://patents.google.com/patent/US9058214B2/en) describes pooling,
+checking out and returning session tokens to reuse established sessions.
+[CN103095859B](https://patents.google.com/patent/CN103095859B/en) describes sharing
+session information across domain names through a synchronization system. These
+technical features are outside the proposed delta: two calls to an existing
+empty-key predicate, a protocol refusal and default reads. No token pool,
+credential exchange, synchronization system or cross-domain session sharing is
+added. This is a scoped technical comparison of the retrieved publications,
+not a conclusion that patents do not exist or a freedom-to-operate opinion.
+No new algorithm or patent/license claim is introduced. The unavailable
+`cargo license` attempt and incomplete offline metadata attempt are superseded
+by the successful current metadata and installed CycloneDX tool, with failures
+retained in the audit receipt. This PR still requires its own CI run before merge.
+
+Evidence locator for this increment: `/Users/mikko/Documents/Codex/2026-09-06/mcp-gateway-v4-scope-review/order2-prerequisite-evidence-index.json`. It names exact artifact paths and SHA-256 values; each review manifest also binds its own immutable material.
+
+
+Readiness closure: GPT r4 SHIP (actual exit 0, material
+`a447e2ffa0668d1464ff3db148cec39fc97b0830afc0b6c52271f50414d2b16b`,
+12,264 bytes) closes the remaining arXiv/patent findings; Grok r2 SHIP is retained.
+`order2-prerequisite-plan-closure.json` preserves each finder and original lineage.
+Test r1 compiled with four assertion failures and two controls passing. Grok
+reviewed those tests SHIP; GPT requested two caller regressions. This adjusts
+only test coverage of the existing FSM.3/.5 contract, with the coordinator's
+approval; the two-owner production repair and all OUT boundaries stay fixed.

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -1104,6 +1104,12 @@ const NO_SESSION_FOR_PROFILE: &str = "Routing profiles are per-session, and this
      MCP 2026-07-28 removed protocol-level sessions; the tool set is decided \
      by the authorization presented on each request.";
 
+/// Sessionless callers cannot change a shared FSM state or recover a session
+/// by supplying a header that their protocol revision no longer uses.
+const NO_SESSION_FOR_STATE: &str = "The workflow state is per-session, and this connection has no session. \
+     MCP 2026-07-28 removed protocol-level sessions; capability visibility is \
+     decided by the authorization presented on each request.";
+
 // ============================================================================
 // MCP protocol handlers — initialize + tools
 // ============================================================================
@@ -1693,10 +1699,8 @@ impl MetaMcp {
     /// Returns the previous state, the new state, and the number of capability
     /// tools visible in the new state (across all capability backends).
     fn set_state(&self, args: &Value, session_id: Option<&str>) -> Result<Value> {
-        let Some(sid) = session_id else {
-            return Err(Error::Protocol(
-                "gateway_set_state requires a session (send Mcp-Session-Id header)".to_string(),
-            ));
+        let Some(sid) = session_key(session_id) else {
+            return Err(Error::Protocol(NO_SESSION_FOR_STATE.to_string()));
         };
 
         let new_state = extract_required_str(args, "state")?;

--- a/src/gateway/meta_mcp/order2_fsm_tests.rs
+++ b/src/gateway/meta_mcp/order2_fsm_tests.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Remaining ORDER.2 FSM refusal, contaminated-state and compatibility cases.
+
+use super::*;
+
+const REFUSAL: &str = "Protocol error: The workflow state is per-session, and this connection has no session. MCP 2026-07-28 removed protocol-level sessions; capability visibility is decided by the authorization presented on each request.";
+
+pub(super) fn assert_refusal(meta: &MetaMcp, response: &JsonRpcResponse) {
+    let error = response
+        .error
+        .as_ref()
+        .expect("state change must be refused");
+    assert_eq!(error.code, -32600);
+    assert_eq!(error.message, REFUSAL);
+    assert!(
+        response.result.is_none(),
+        "refusal must not contain a result"
+    );
+    assert_eq!(meta.session_state.len(), 0, "refusal must not create state");
+}
+
+async fn assert_membership(meta: &MetaMcp, session: Option<&str>, expected: &[&str]) {
+    for (label, value) in [
+        ("list", meta.list_tools(&json!({}), session).await.unwrap()),
+        (
+            "single-server list",
+            meta.list_tools(&json!({"server": "staged"}), session)
+                .await
+                .unwrap(),
+        ),
+        (
+            "search tools",
+            meta.search_tools(&json!({"query": "staged"}), session)
+                .await
+                .unwrap(),
+        ),
+        (
+            "code-mode search",
+            meta.code_mode_search(&json!({"query": "staged"}), session)
+                .await
+                .unwrap(),
+        ),
+    ] {
+        assert_eq!(discovery_names(&value), expected, "{label}, {session:?}");
+    }
+}
+
+/// MIK-7272.ORDER2.FSM.3: neither missing representation may mutate the store.
+#[tokio::test]
+async fn missing_and_empty_keys_are_explicitly_refused() {
+    for session in [None, Some("")] {
+        let meta = meta_with_state_staged_capabilities().await;
+        let response = meta
+            .handle_tools_call(
+                RequestId::Number(31),
+                "gateway_set_state",
+                json!({"state": TARGET_STATE}),
+                session,
+                allow_all_ctx(),
+            )
+            .await;
+        assert_refusal(&meta, &response);
+        assert_membership(&meta, session, STAGED_DEFAULT_TOOLS).await;
+    }
+}
+
+/// MIK-7272.ORDER2.FSM.4: a write guard alone cannot fix old contaminated state.
+#[tokio::test]
+async fn old_empty_key_state_cannot_influence_any_discovery_reader() {
+    let meta = meta_with_state_staged_capabilities().await;
+    // Only this fixture bypasses the writer: the old forbidden entry must exist
+    // independently of the repaired writer so omission of the read guard fails.
+    meta.session_state.set_state("", TARGET_STATE);
+    assert_eq!(meta.session_state.get_state(""), TARGET_STATE);
+    assert_eq!(meta.session_state.len(), 1);
+
+    for session in [None, Some("")] {
+        assert_membership(&meta, session, STAGED_DEFAULT_TOOLS).await;
+    }
+    assert_eq!(meta.session_state.get_state(""), TARGET_STATE);
+}
+
+/// MIK-7272.ORDER2.FSM.5: retain real mutations for legacy and stdio state owners.
+#[tokio::test]
+async fn nonempty_legacy_and_stdio_keys_retain_isolated_state_changes() {
+    for owner in ["legacy-session", "stdio-session"] {
+        let meta = meta_with_state_staged_capabilities().await;
+        assert_membership(&meta, Some(owner), STAGED_DEFAULT_TOOLS).await;
+        let response = meta
+            .handle_tools_call(
+                RequestId::Number(51),
+                "gateway_set_state",
+                json!({"state": TARGET_STATE}),
+                Some(owner),
+                allow_all_ctx(),
+            )
+            .await;
+        assert!(response.error.is_none(), "{owner}: {:?}", response.error);
+        assert!(response.result.is_some());
+        assert_eq!(meta.session_state.get_state(owner), TARGET_STATE);
+        assert_eq!(meta.session_state.len(), 1);
+        assert_membership(&meta, Some(owner), STAGED_OTHER_STATE_TOOLS).await;
+        assert_membership(&meta, Some("other-owner"), STAGED_DEFAULT_TOOLS).await;
+        assert_membership(&meta, Some(""), STAGED_DEFAULT_TOOLS).await;
+    }
+}

--- a/src/gateway/meta_mcp/search.rs
+++ b/src/gateway/meta_mcp/search.rs
@@ -167,7 +167,7 @@ impl MetaMcp {
     /// of this body, so a filter applied here would have left them reading the
     /// store unguarded (`MIK-7272.ORDER.2`, test-plan precondition 1).
     fn current_search_state(&self, session_id: Option<&str>) -> String {
-        session_id.map_or_else(
+        super::session_key(session_id).map_or_else(
             || crate::gateway::state::DEFAULT_STATE.to_string(),
             |sid| self.session_state.get_state(sid),
         )

--- a/src/gateway/meta_mcp/tests.rs
+++ b/src/gateway/meta_mcp/tests.rs
@@ -14,6 +14,9 @@ use crate::protocol::RequestId;
 use super::*;
 use crate::gateway::trace;
 
+#[path = "order2_fsm_tests.rs"]
+mod order2_fsm;
+
 /// The permissive authorizer the helpers below hand out.
 static ALLOW_ALL: crate::gateway::authz::AllowAll = crate::gateway::authz::AllowAll;
 
@@ -4656,7 +4659,9 @@ fn discovery_names(v: &Value) -> Vec<String> {
             // `gateway_search` names a tool `server:tool_name`; the other three
             // readers name it bare. Compare on the bare name so one pinned
             // literal covers all four entry points.
-            raw.rsplit_once(':').map_or(raw, |(_, name)| name).to_string()
+            raw.rsplit_once(':')
+                .map_or(raw, |(_, name)| name)
+                .to_string()
         })
         .collect();
     names.sort();
@@ -4745,11 +4750,8 @@ async fn b08_staging_the_capability_set_moves_with_the_fsm_state() {
 /// when the `set_state` silently did nothing and when a regression moved both
 /// lists in step.
 ///
-/// Q4 — whether `gateway_set_state` is refused outright on a sessionless
-/// modern connection — is with the operator, and the answer decides what the
-/// call's own outcome must be asserted to be. This case asserts only the half
-/// that holds under either answer: the lists. The outcome pin lands when Q4 is
-/// answered.
+/// MIK-7272.ORDER2.FSM.2: Q4 ratified an explicit refusal on modern
+/// sessionless connections; both its response and all four lists are pinned.
 #[tokio::test]
 async fn b09_a_set_state_does_not_change_the_connections_discovery_set() {
     let meta = meta_with_state_staged_capabilities().await;
@@ -4782,7 +4784,7 @@ async fn b09_a_set_state_does_not_change_the_connections_discovery_set() {
     // Driven through the real meta-tool, not `SessionStateStore::set_state`:
     // the defect is the argument passed at `mod.rs:1689`, and a fixture
     // touching the store directly bypasses the line under test.
-    let _ = meta
+    let response = meta
         .handle_tools_call(
             RequestId::Number(1),
             "gateway_set_state",
@@ -4791,6 +4793,7 @@ async fn b09_a_set_state_does_not_change_the_connections_discovery_set() {
             allow_all_ctx(),
         )
         .await;
+    order2_fsm::assert_refusal(&meta, &response);
 
     let list_after = discovery_names(
         &meta
@@ -4849,9 +4852,8 @@ async fn b09_a_set_state_does_not_change_the_connections_discovery_set() {
 /// state A selected. B-09 asserts the same connection is unaffected by its own
 /// call; this asserts a bystander is unaffected by someone else's.
 ///
-/// The Q4 outcome pin — whether A's call is refused outright — is deferred on
-/// the same terms as B-09's: this case asserts the half that holds under
-/// either answer.
+/// MIK-7272.ORDER2.FSM.1: Q4 ratified explicit refusal; the bystander
+/// remains in the default state after that refused mutation.
 #[tokio::test]
 async fn b08_one_connections_set_state_does_not_change_another_connections_set() {
     let meta = meta_with_state_staged_capabilities().await;
@@ -4859,7 +4861,7 @@ async fn b08_one_connections_set_state_does_not_change_another_connections_set()
     // Connection A. Driven through the real meta-tool: the defect is the
     // argument passed at `mod.rs:1689`, and a fixture touching
     // `SessionStateStore::set_state` directly bypasses the line under test.
-    let _ = meta
+    let response = meta
         .handle_tools_call(
             RequestId::Number(1),
             "gateway_set_state",
@@ -4868,6 +4870,7 @@ async fn b08_one_connections_set_state_does_not_change_another_connections_set()
             allow_all_ctx(),
         )
         .await;
+    order2_fsm::assert_refusal(&meta, &response);
 
     // Connection B, which has issued no state change of its own.
     let list = discovery_names(

--- a/src/gateway/router/tests.rs
+++ b/src/gateway/router/tests.rs
@@ -32,6 +32,8 @@ use tower::ServiceExt;
 
 use super::authorization::{ToolTarget, authorize_tool_target, backend_tool_targets_for_call};
 
+mod order2_fsm;
+
 fn test_router_app_state_with_streaming(streaming_config: StreamingConfig) -> Arc<AppState> {
     test_router_app_state_with(streaming_config, crate::config::Config::default())
 }

--- a/src/gateway/router/tests/order2_fsm.rs
+++ b/src/gateway/router/tests/order2_fsm.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+use super::*;
+use pretty_assertions::assert_eq;
+
+/// MIK-7272.ORDER2.FSM.3: the real modern HTTP path must refuse state changes.
+#[tokio::test]
+async fn order2_fsm_modern_http_refuses_state_even_with_an_offered_session() {
+    let router = create_router(modern_router_app_state());
+    for offered_session in [None, Some("client-offered-session")] {
+        let mut request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2026-07-28")
+            .header("mcp-method", "tools/call")
+            .header("mcp-name", "gateway_set_state");
+        if let Some(session) = offered_session {
+            request = request.header("mcp-session-id", session);
+        }
+        let request = request
+            .body(axum::body::Body::from(
+                json!({
+                    "jsonrpc": "2.0", "id": 73, "method": "tools/call",
+                    "params": {
+                        "name": "gateway_set_state", "arguments": {"state": "triage"},
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = router.clone().oneshot(request).await.unwrap();
+        assert!(response.headers().get("mcp-session-id").is_none());
+        let bytes = to_bytes(response.into_body(), 65_536).await.unwrap();
+        let response: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(response["id"], 73);
+        assert_eq!(response["error"]["code"], -32600, "{response}");
+        assert_eq!(
+            response["error"]["message"],
+            "Protocol error: The workflow state is per-session, and this connection has no session. MCP 2026-07-28 removed protocol-level sessions; capability visibility is decided by the authorization presented on each request."
+        );
+        assert!(response.get("result").is_none(), "{response}");
+    }
+}

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -53,6 +53,9 @@ use warmstart::{WarmStartMode, build_warm_start_list, spawn_warm_start_task};
 use support::build_persisted_costs;
 use support::{log_startup_banner, serve_tls, shutdown_signal};
 
+/// State owner for the single client on a long-lived stdio connection.
+const STDIO_SESSION_ID: &str = "stdio-session";
+
 fn expand_home_path(path: &str) -> PathBuf {
     if path == "~" {
         return dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
@@ -1601,7 +1604,7 @@ impl Gateway {
         let mut stdout = stdout;
 
         // Use a fixed session ID for stdio sessions (single client, long-lived)
-        let session_id = "stdio-session";
+        let session_id = STDIO_SESSION_ID;
 
         while let Ok(Some(line)) = reader.next_line().await {
             let line = line.trim().to_string();
@@ -2191,6 +2194,8 @@ mod tests {
         protocol::{JsonRpcResponse, RequestId},
         security::ToolPolicy,
     };
+
+    mod order2_fsm;
 
     fn test_meta_mcp() -> Arc<MetaMcp> {
         Arc::new(MetaMcp::new(Arc::new(BackendRegistry::new())))

--- a/src/gateway/server/tests/order2_fsm.rs
+++ b/src/gateway/server/tests/order2_fsm.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+use super::*;
+
+/// MIK-7272.ORDER2.FSM.5: the shared stdio dispatcher preserves its state owner.
+#[tokio::test]
+async fn order2_fsm_stdio_dispatch_retains_successful_owned_transitions() {
+    let meta = test_meta_mcp();
+    for (id, previous, next) in [(81, "default", "triage"), (82, "triage", "complete")] {
+        let response = Gateway::dispatch_single(
+            &meta,
+            &test_tool_policy(),
+            &test_mtls_policy(),
+            &json!({
+                "jsonrpc": "2.0", "id": id, "method": "tools/call",
+                "params": {"name": "gateway_set_state", "arguments": {"state": next}}
+            }),
+            super::super::STDIO_SESSION_ID,
+        )
+        .await
+        .expect("an identified stdio call returns a response");
+        assert_eq!(response["id"], id);
+        assert!(response.get("error").is_none(), "{response}");
+        let result: serde_json::Value = serde_json::from_str(
+            response["result"]["content"][0]["text"]
+                .as_str()
+                .expect("the successful state tool returns JSON text"),
+        )
+        .unwrap();
+        assert_eq!(result["previous"], previous);
+        assert_eq!(result["current"], next);
+        assert_eq!(result["session_id"], "stdio-session");
+    }
+}


### PR DESCRIPTION
Sessionless `gateway_set_state` calls previously changed the shared empty-key state, altering discovery for modern HTTP callers. This change returns the ratified protocol refusal and makes all four discovery readers ignore existing empty-key state. Nonempty legacy and stdio owners retain their state transitions.

This is the bounded ORDER.2 prerequisite for the 4.0 integration branch. It also enables the existing CI jobs for that exact integration target. The design and test plan preserve the original findings and approved acceptance criteria.

Validation at `d95d0a9640772207d40f8d5fce4d59243a2e943c`:

- Eight acceptance/caller tests pass after five compiled assertion failures and three controls on the pre-guard source. Modern HTTP is exercised with and without an offered session header; the stdio dispatcher test shares the production owner constant and retains an independent literal assertion.
- Default-feature library: 4,021 pass, zero fail, four ignored. All-feature CI library: 4,059 pass, zero fail, four ignored; binary tests: 222 pass.
- All-feature CLI build, all-feature/all-target Clippy with `-D warnings`, and formatting pass.
- Critical guard coverage: 36/37 regions (97.30%); every changed executable guard region is covered. The uncovered region is the existing missing-argument error branch. No OS-pipe coverage is claimed for the mechanical stdio constant extraction.
- `cargo-mutants`: three generated mutations compiled and were caught, zero missed/unviable/timeouts. Separate write-only and read-only guard omissions caused the intended assertion failures; restoring the original bytes restored all eight passing tests.
- Design/test-plan, tests-as-tests, and final GPT/Grok code gates are closed. Final reviews are both SHIP with actual exits 0, identical material SHA `bb57b4c36f0bb42870789f88bba3d1ae49de59168a6d9c397fa77b0e649ebcdd` (28,847 bytes), bound to this commit.

**Merge remains blocked.** [CI run 34066309790](https://github.com/MikkoParkkola/mcp-gateway/actions/runs/34066309790) passes the repaired B08/B09 library cases, then fails the unchanged TASK.1 integration case `tasks::ac_task_1_a_failed_task_reports_its_failure_rather_than_an_absence`: the base returns a string instead of a structured JSON-RPC task error. TASK.1 is a separate release work package. Independent public acceptance now passes on this same pinned executable: one isolated Spark launch, 40 recorded requests, exact fixture readiness, all four discovery surfaces, both modern refusal variants, and two distinct legacy sessions with state-dependent isolation. Internal None/contaminated-state/stdio clauses are mapped to the separately passing component tests; they are not presented as black-box observations. The original failed readiness run is retained. No full Task or release acceptance is inferred. This PR remains draft; no release or ticket closure is claimed.

## KPI Impact

Restores a stable default discovery set for sessionless callers. The eight-case suite covers `MIK-7272.ORDER2.FSM.1` through `.5`, with internal-only observations explicitly separated from public functional acceptance.

Tracks [MIK-7272](https://linear.app/parm/issue/MIK-7272).
