### PR TITLE
fix(mtls): generate certificates accepted by strict clients

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -218,6 +218,52 @@ mtls:
   require_client_cert: true
 ```
 
+### Strict validation and existing certificate generations
+
+Newly generated 4.0 CA certificates include certificate-signing and CRL-signing
+key usage; issued server and client certificates include an Authority Key
+Identifier matching their issuer. These extensions support strict X.509 clients,
+including Python 3.13's default TLS context. Keep certificate and hostname
+verification enabled.
+
+Check a new generation before deploying it:
+
+```bash
+openssl verify -x509_strict -purpose sslserver \
+  -verify_hostname gateway.company.com \
+  -CAfile ./tls-next/ca.crt ./tls-next/server.crt
+openssl verify -x509_strict -purpose sslclient \
+  -CAfile ./tls-next/ca.crt ./tls-next/clients/claude-code-agent.crt
+```
+
+Existing gateway-generated CAs may lack key usage, and existing leaves may lack
+issuer identifiers. A new leaf alone cannot repair a malformed CA. The gateway
+does not replace an existing certificate generation automatically.
+
+For an existing deployment, perform the following rollout during an operator
+chosen maintenance window:
+
+1. Retain the old CA, leaf certificates, private keys, configuration and trust
+   bundles. Generate the replacement CA/server/client material with the commands
+   above in a **new directory**, such as `./tls-next`, rather than in the live
+   certificate directory. Protect and store the new CA key offline after issuance.
+2. Distribute a trust bundle containing both old and new CA certificates to the
+   gateway and clients before switching leaf certificates. The gateway's
+   `mtls.ca_cert` accepts a PEM bundle. Restart it after changing its TLS paths or
+   trust bundle, and verify existing clients still authenticate.
+3. Switch server and client certificate/key paths to the new generation. Restart
+   the gateway and reconnect clients. Verify an actual authenticated MCP
+   initialize/tool-list exchange with the new client certificate, as well as
+   continued operation of supported existing clients. An old malformed chain
+   remains incompatible with strict clients even when both CAs are trusted;
+   enable those clients only after the new server chain is active.
+4. Rehearse rollback in an isolated deployment: restore the retained old
+   certificate/key/configuration paths while keeping overlapping trust, restart,
+   and verify the original client **with its old certificate and key**. This
+   restores prior compatibility; it does not make the old chain strict-valid.
+5. Remove old trust only after every consumer has migrated and the operator has
+   ended the rollback window. Retention and key disposal follow your PKI policy.
+
 ## Reverse Proxy
 
 Bind the gateway to `127.0.0.1` (default) and proxy from the public-facing server. SSE streaming requires disabled response buffering.

--- a/src/mtls/cert_manager.rs
+++ b/src/mtls/cert_manager.rs
@@ -24,8 +24,8 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use rcgen::string::Ia5String;
 use rcgen::{
-    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair, SanType,
-    date_time_ymd,
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose, SanType, date_time_ymd,
 };
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
@@ -200,6 +200,7 @@ impl CertGenerator {
         dn.push(DnType::CommonName, params.cn);
         ca_params.distinguished_name = dn;
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         ca_params.not_after = validity_to_date(params.validity_days)?;
 
         let ca_cert = ca_params
@@ -244,6 +245,7 @@ impl CertGenerator {
         }
         leaf_params.distinguished_name = dn;
         leaf_params.not_after = validity_to_date(params.validity_days)?;
+        leaf_params.use_authority_key_identifier_extension = true;
 
         // Add SANs — rcgen 0.14 uses Ia5String (from rcgen::string) for DNS and URI SAN types
         let mut sans: Vec<SanType> = Vec::new();

--- a/tests/generated_tls_strict.rs
+++ b/tests/generated_tls_strict.rs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! MIK-7212.TLSCERT.1–2: inspect actual generated X.509 extensions.
+
+use mcp_gateway::mtls::{CaParams, CertGenerator, GeneratedCert, LeafCertParams};
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyIdMethod, KeyPair,
+    KeyUsagePurpose,
+};
+use x509_parser::extensions::{GeneralName, ParsedExtension};
+use x509_parser::oid_registry::{
+    OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER, OID_X509_EXT_SUBJECT_KEY_IDENTIFIER,
+};
+use x509_parser::pem::parse_x509_pem;
+use x509_parser::prelude::{FromDer, X509Certificate};
+
+fn inspect<T>(pem: &str, check: impl FnOnce(&X509Certificate<'_>) -> T) -> T {
+    let (remaining, pem) = parse_x509_pem(pem.as_bytes()).expect("certificate PEM");
+    assert!(remaining.iter().all(u8::is_ascii_whitespace));
+    let (remaining, cert) = X509Certificate::from_der(&pem.contents).expect("certificate DER");
+    assert!(remaining.is_empty(), "unparsed certificate bytes");
+    check(&cert)
+}
+
+fn generated_ca() -> GeneratedCert {
+    CertGenerator::init_ca(&CaParams {
+        cn: "TLSCERT regression CA",
+        validity_days: 30,
+    })
+    .unwrap()
+}
+
+fn issuer_key_id(ca: &GeneratedCert) -> Vec<u8> {
+    inspect(&ca.cert_pem, |cert| {
+        let extension = cert
+            .get_extension_unique(&OID_X509_EXT_SUBJECT_KEY_IDENTIFIER)
+            .unwrap()
+            .expect("issuer must carry SKI");
+        match extension.parsed_extension() {
+            ParsedExtension::SubjectKeyIdentifier(id) => id.0.to_vec(),
+            other => panic!("malformed issuer SKI: {other:?}"),
+        }
+    })
+}
+
+fn external_ca() -> GeneratedCert {
+    let key = KeyPair::generate().unwrap();
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, "External TLSCERT CA");
+    let expected_id = vec![0xa7; 20];
+    let mut params = CertificateParams::default();
+    params.distinguished_name = dn;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    // Deliberately differs from rcgen's default public-key digest.
+    params.key_identifier_method = KeyIdMethod::PreSpecified(expected_id.clone());
+    let ca = GeneratedCert {
+        cert_pem: params.self_signed(&key).unwrap().pem(),
+        key_pem: key.serialize_pem(),
+    };
+    assert_eq!(
+        issuer_key_id(&ca),
+        expected_id,
+        "external fixture precondition"
+    );
+    ca
+}
+
+fn check_leaf(ca: &GeneratedCert, server: bool) {
+    let expected_id = issuer_key_id(ca);
+    assert!(!expected_id.is_empty());
+    let params = LeafCertParams {
+        cn: if server {
+            "localhost"
+        } else {
+            "tls-test-agent"
+        },
+        ou: Some("engineering"),
+        san_dns: if server {
+            vec!["localhost".into()]
+        } else {
+            vec![]
+        },
+        san_uris: if server {
+            vec![]
+        } else {
+            vec!["spiffe://tlscert.test/agent".into()]
+        },
+        validity_days: 7,
+    };
+    let leaf = CertGenerator::issue_leaf(&params, &ca.cert_pem, &ca.key_pem).unwrap();
+    inspect(&leaf.cert_pem, |cert| {
+        assert_eq!(
+            cert.subject()
+                .iter_common_name()
+                .next()
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            params.cn
+        );
+        assert_eq!(
+            cert.subject()
+                .iter_organizational_unit()
+                .next()
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "engineering"
+        );
+        let sans = &cert
+            .subject_alternative_name()
+            .unwrap()
+            .unwrap()
+            .value
+            .general_names;
+        let expected_sans = if server {
+            vec![GeneralName::DNSName("localhost")]
+        } else {
+            vec![GeneralName::URI("spiffe://tlscert.test/agent")]
+        };
+        assert_eq!(*sans, expected_sans, "leaf identity must be preserved");
+        let extension = cert
+            .get_extension_unique(&OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER)
+            .unwrap()
+            .expect("MIK-7212.TLSCERT.2: CA-issued leaf is missing AKI");
+        assert!(!extension.critical, "AKI must be noncritical");
+        match extension.parsed_extension() {
+            ParsedExtension::AuthorityKeyIdentifier(id) => {
+                assert_eq!(
+                    id.key_identifier.as_ref().expect("AKI keyIdentifier").0,
+                    expected_id,
+                    "AKI must reuse this issuer's actual SKI"
+                );
+            }
+            other => panic!("malformed leaf AKI: {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn generated_ca_has_critical_certificate_and_crl_signing_usage() {
+    // MIK-7212.TLSCERT.1
+    inspect(&generated_ca().cert_pem, |cert| {
+        let usage = cert
+            .key_usage()
+            .unwrap()
+            .expect("MIK-7212.TLSCERT.1: generated CA is missing key usage");
+        assert!(usage.critical, "CA key usage must be critical");
+        assert!(usage.value.key_cert_sign());
+        assert!(usage.value.crl_sign());
+        assert_eq!(usage.value.flags, 0x60, "do not grant unrelated key usages");
+        assert!(cert.basic_constraints().unwrap().unwrap().value.ca);
+    });
+}
+
+#[test]
+fn generated_ca_server_leaf_has_issuer_bound_noncritical_aki() {
+    check_leaf(&generated_ca(), true);
+}
+
+#[test]
+fn generated_ca_client_leaf_has_issuer_bound_noncritical_aki() {
+    check_leaf(&generated_ca(), false);
+}
+
+#[test]
+fn external_ca_server_leaf_reuses_prespecified_issuer_ski() {
+    check_leaf(&external_ca(), true);
+}
+
+#[test]
+fn external_ca_client_leaf_reuses_prespecified_issuer_ski() {
+    check_leaf(&external_ca(), false);
+}


### PR DESCRIPTION
Strict X.509 clients reject gateway-generated chains because the CA lacks signing key usages and issued leaves lack Authority Key Identifiers. Enable those existing rcgen options for new certificates and document an overlapping-trust rollout and rollback. Existing keys and trust are retained.

The generator and five DER regression tests are byte-identical to the reviewed 4.0 fix. Validation already includes those five tests plus 67 existing mTLS tests, clean all-target Clippy, two final code approvals, both changed lines covered, two viable generated mutants caught, four targeted faults caught, and independent strict mTLS/rollout checks. Two generated mutants were unviable. CI will validate this main-based revision before merge.

This standalone fix targets green main so it can land independently of unfinished 4.0 task implementation. It carries only certificate generation, regression tests and deployment instructions; the agreed 4.0 scope remains unchanged. Refs MIK-7212.TLSCERT.1–4 and release-branch PR485.
