### PR TITLE
docs(release): accept integrated publishing gate

### DIFF
--- a/docs/release/v4.0.0-scope-contract-validation.md
+++ b/docs/release/v4.0.0-scope-contract-validation.md
@@ -62,4 +62,10 @@ Whole-checker mutation testing used the original 286 candidates with no exclusio
 
 Earlier valid results (214/286, 224/286 and 230/286) and all surviving candidates remain recorded. Two intermediate attempts receive no credit: one lost cache inventory consistency after a concurrent tool inspection, and one rejected an unsupported CLI option before running mutations. The final runner recalibrates baseline timing, requires evidence that each mutation actually executed, and asserts all 286 inventory entries remain present.
 
-No product acceptance criterion is closed by these tooling results. The 25 baseline blockers and 31 supplemental criteria still require their own integrated evidence.
+The tooling criterion `NFR.RELEASEGATE.1` is accepted against the merged implementation and successful post-merge checks below. The 25 baseline blockers and 30 other supplemental criteria remain open; these tooling results do not grade their product behavior.
+
+## Release-owner acceptance — 2026-09-08
+
+[PR497](https://github.com/MikkoParkkola/mcp-gateway/pull/497) merged at `424f997eb06f0590d31dc604c52c5dbe536db318` after all 18 applicable checks passed on `315f100d` (two skipped). [Post-merge CI](https://github.com/MikkoParkkola/mcp-gateway/actions/runs/34187040999) and [post-merge Docker](https://github.com/MikkoParkkola/mcp-gateway/actions/runs/34187040990) both succeeded on that merge commit.
+
+The scope tests prove consistent pending plans pass `--check` while `--release` refuses unresolved criteria, decisions and baseline blockers. Missing/duplicate IDs, malformed or missing evidence and publishing-context version inputs are covered with positive controls. The CI, Docker and release workflows invoke the checker in publishing mode and make their publication chains depend on its gate. This is tooling acceptance; no release publication was attempted while product acceptance remains pending.

--- a/docs/requirements/RELEASE-4.0.0-scope-status.json
+++ b/docs/requirements/RELEASE-4.0.0-scope-status.json
@@ -171,9 +171,16 @@
     },
     {
       "id": "NFR.RELEASEGATE.1",
-      "status": "pending",
-      "evidence": [],
-      "note": "Checker and publishing workflow connections implemented locally in the scope-contract worktree. Local negative/positive tests pass; target-branch integration and CI execution still need release-owner acceptance."
+      "status": "met",
+      "evidence": [
+        "docs/release/v4.0.0-scope-contract-validation.md",
+        ".github/workflows/ci.yml",
+        ".github/workflows/docker.yml",
+        ".github/workflows/release.yml",
+        "scripts/release/test_scope_acceptance.py",
+        "scripts/release/test_scope_contract_interface.py"
+      ],
+      "note": "Integrated by PR497 at424f997eb06f0590d31dc604c52c5dbe536db318. All18 applicable pre-merge checks and post-merge CI34187040999/Docker34187040990 passed.44 scope tests,100% native checker line coverage and90.21% mutation score; publishing paths enforce complete baseline/supplemental acceptance and decisions. This closes the tooling criterion only."
     },
     {
       "id": "NFR.DEMO.1",
@@ -192,7 +199,7 @@
     {
       "id": "reference_personal_account_journey",
       "status": "resolved",
-      "selection": "Open WebUI on Spark → gateway → Google Workspace",
+      "selection": "Open WebUI on Spark \u2192 gateway \u2192 Google Workspace",
       "evidence": [
         "docs/requirements/RELEASE-4.0.0-scope-decisions-2026-09-06.md"
       ]


### PR DESCRIPTION
Mark NFR.RELEASEGATE.1 met after PR497 merged at424f997e and both post-merge CI34187040999 and Docker34187040990 passed. Link the implementation, tests and evidence; leave25 baseline blockers and30 other supplemental criteria open.

Validation: the plan checker passes with31 criteria and30 pending; release mode still correctly exits1 for the remaining acceptance gaps. The accepted gate is no longer listed as pending. Diff checks pass. This changes only the ledger and its evidence document; no runtime code changed or Rust tests rerun.
