### PR TITLE
Enforce account admission before stdio serves requests

### DIFF
--- a/docs/design/2026-09-08-rest-multiuser-guard.md
+++ b/docs/design/2026-09-08-rest-multiuser-guard.md
@@ -1,0 +1,13 @@
+# Account-bound multi-user REST guard repair
+
+Scope: permit managed/external descriptor-bound calls for verified callers while preserving legacy/shared OAuth isolation. Stdio installation, bridge projection and consent UI are separate release work.
+
+Measured RED: 18 REST cases pass, three multi-user cases fail; two return the legacy -32001 refusal and the MetaMcp case reaches only the initial credential release. The prior tests never enabled multi_user.
+
+The backend validates personal ownership, path selectors and schema before new custody acquisition. It then prepares/revalidates the account context through the existing executor helper, evaluates OAuth isolation, and passes that same context into execution. Existing inner-cache and egress rechecks remain. Unbound legacy guard behavior is retained.
+
+The guard exception requires a prepared credential, exact capability descriptor and auth-key matches, and exact VerifiedIdentity.stable_actor_id equality with the prepared actor. GrantSubject is not account identity. A shared descriptor yields no prepared credential and retains legacy isolation. Missing identity, strategy, expired credential or revoked lease refuses before cache/HTTP.
+
+Rejected: blanket auth.account exception, rewriting shared_account, duplicate resolver, reminting a carried credential, extending credential expiry, and acquiring custody before invalid backend arguments are rejected.
+
+Grok design review initially failed for unspecified schema ordering and actor matching. Both requirements are explicitly incorporated above. Regression plan covers production backend and MetaMcp multi-user dispatch, real warm hit, Alice/Bob isolation, absent identity/strategy, revocation, legacy/shared isolation, mismatched carried credentials and no acquisition for invalid arguments. Existing shared_account and personal legacy positive controls remain. Implementation and confirmation review are pending; this receipt is not a release approval.

--- a/src/capability/backend.rs
+++ b/src/capability/backend.rs
@@ -473,11 +473,18 @@ impl CapabilityBackend {
             .get(name)
             .ok_or_else(|| crate::Error::Config(format!("Capability not found: {name}")))?;
         validate_personal_capability_identity(&capability, &context)?;
-        validate_oauth_isolation(
-            &capability,
-            &context,
-            self.multi_user.load(std::sync::atomic::Ordering::Relaxed),
-        )?;
+
+        let multi_user = self.multi_user.load(std::sync::atomic::Ordering::Relaxed);
+        // A capability bound to an account descriptor is the one shape whose
+        // per-user OAuth isolation cannot be decided before the account is
+        // resolved: whether a per-caller credential exists at all is the
+        // registry's answer, not the YAML's. Every OTHER shape keeps the guard
+        // exactly where it has always been — first, ahead of argument
+        // validation — so no unbound call's error changes or moves.
+        let descriptor_bound = capability.auth.account.is_some();
+        if !(multi_user && descriptor_bound) {
+            validate_oauth_isolation(&capability, &context, multi_user)?;
+        }
 
         // Selector values choose an outbound URL path, so preserve their
         // declared string type instead of allowing generic schema coercion
@@ -505,6 +512,33 @@ impl CapabilityBackend {
                 is_error: true,
             });
         }
+
+        // THE ACCOUNT IS RESOLVED ONLY ONCE THE CALL IS OTHERWISE WELL FORMED.
+        //
+        // Both checks above reject without side effects, and acquiring a
+        // custody lease for a call that is about to be rejected for a bad path
+        // selector or an unknown argument would consume a real credential for a
+        // request that never happens. So the resolve happens HERE: after the
+        // arguments are known good, before the isolation guard, and through the
+        // SAME `prepare_account_context` the executor uses — a carried
+        // credential is rechecked against the live registry rather than
+        // re-minted, and a `shared` descriptor still resolves to the legacy
+        // credential and therefore still faces the unchanged guard below.
+        //
+        // The returned context is the one that is executed under, so the
+        // credential the guard consented to is the credential the inner cache
+        // key and the egress headers speak about. The executor's own resolve,
+        // inner-cache lookup and egress recheck are untouched.
+        let context = if multi_user && descriptor_bound {
+            let context = self
+                .executor
+                .prepare_account_context(&capability, context)
+                .await?;
+            validate_oauth_isolation(&capability, &context, multi_user)?;
+            context
+        } else {
+            context
+        };
 
         // Use the coerced arguments (e.g., "123" → 123 for integer fields).
         // The executor records transport health (success/failure) at the HTTP

--- a/src/capability/backend.rs
+++ b/src/capability/backend.rs
@@ -30,7 +30,8 @@ use super::hash::compute_capability_hash;
 use super::schema_validator::validate_arguments;
 use super::{
     CapabilityDefinition, CapabilityExecutionContext, CapabilityExecutor, CapabilityLoader,
-    validate_oauth_isolation, validate_personal_capability_identity,
+    validate_capability_account_binding, validate_oauth_isolation,
+    validate_personal_capability_identity,
 };
 use crate::Result;
 use crate::protocol::{Content, Tool, ToolsCallResult};
@@ -114,6 +115,19 @@ impl IndexedCapabilities {
 // ============================================================================
 // CapabilityBackend
 // ============================================================================
+
+/// The outcome of loading one capability directory.
+///
+/// `rejected` holds one rendered refusal per capability the account admission
+/// gate turned away, so a caller that must not serve a partially admitted
+/// catalogue can fail instead of only logging.
+#[derive(Debug, Default, Clone)]
+pub struct DirectoryLoad {
+    /// Capabilities that entered the tool surface.
+    pub admitted: usize,
+    /// `"<capability>: <error>"` for each refused capability, in load order.
+    pub rejected: Vec<String>,
+}
 
 /// Backend that exposes capabilities as MCP tools
 ///
@@ -264,8 +278,28 @@ impl CapabilityBackend {
     ///
     /// Returns an error if the directory cannot be loaded.
     pub async fn load_from_directory(&self, path: &str) -> Result<usize> {
+        Ok(self.load_from_directory_reporting(path).await?.admitted)
+    }
+
+    /// Load a directory and REPORT, rather than only log, every capability the
+    /// account admission gate refused.
+    ///
+    /// `load_from_directory` keeps its log-and-drop behaviour for the hot-reload
+    /// and account-less paths. Startup uses this variant so an invalid
+    /// `auth.account` binding present in the INITIAL catalogue can be turned
+    /// into a startup failure instead of a warning behind a serving listener.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory itself cannot be loaded. A refused
+    /// capability is not an error here — it is reported in
+    /// [`DirectoryLoad::rejected`] so the caller decides.
+    pub async fn load_from_directory_reporting(&self, path: &str) -> Result<DirectoryLoad> {
         let loaded = CapabilityLoader::load_directory(path).await?;
-        let count = loaded.len();
+        let mut report = DirectoryLoad {
+            admitted: loaded.len(),
+            rejected: Vec::new(),
+        };
 
         // Register directory for future hot-reloads.
         {
@@ -275,17 +309,27 @@ impl CapabilityBackend {
             }
         }
 
-        // Upsert each capability into the indexed store.
+        // Upsert each capability into the indexed store, through the account
+        // admission gate. A refused capability is LOGGED and dropped rather
+        // than published: the operator gets a named error, and no caller gets a
+        // tool whose account reference cannot resolve.
         for cap in loaded {
-            {
-                let mut caps = self.capabilities.write();
-                caps.upsert(cap);
+            let capability = cap.name.clone();
+            if let Err(error) = self.register_capability(cap) {
+                warn!(
+                    backend = %self.name,
+                    capability = %capability,
+                    error = %error,
+                    "Capability refused: its account binding does not resolve"
+                );
+                report.admitted -= 1;
+                report.rejected.push(format!("{capability}: {error}"));
             }
             tokio::task::yield_now().await;
         }
 
-        info!(backend = %self.name, count = count, path = path, "Loaded capabilities");
-        Ok(count)
+        info!(backend = %self.name, count = report.admitted, path = path, "Loaded capabilities");
+        Ok(report)
     }
 
     /// Reload all capabilities from registered directories
@@ -319,11 +363,28 @@ impl CapabilityBackend {
             }
         }
 
+        // The same admission gate the initial load applies.
+        let mut admitted = Vec::with_capacity(all_caps.len());
+        for cap in all_caps {
+            match validate_capability_account_binding(&cap, self.executor.account_strategies()) {
+                Ok(()) => admitted.push(cap),
+                Err(error) => {
+                    total -= 1;
+                    warn!(
+                        backend = %self.name,
+                        capability = %cap.name,
+                        error = %error,
+                        "Capability refused on reload: its account binding does not resolve"
+                    );
+                }
+            }
+        }
+
         // Atomic swap: rebuild index and tool cache in one write lock, then
         // bump the shared policy epoch while that lock is still held.
         {
             let mut caps = self.capabilities.write();
-            caps.replace_all(all_caps);
+            caps.replace_all(admitted);
             self.executor.bump_policy_epoch();
         }
 
@@ -455,6 +516,22 @@ impl CapabilityBackend {
             .await?;
 
         Ok(build_success_tool_result(&capability, result))
+    }
+
+    /// Register one capability through the account-binding admission gate.
+    ///
+    /// A capability whose `auth.account` does not name a configured descriptor,
+    /// or whose `auth.key` is not `oauth:<descriptor.provider>`, never enters
+    /// the tool surface. Descriptorless capabilities are unaffected.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::Config`] naming the unresolved reference, or the key the
+    /// descriptor's provider requires.
+    pub fn register_capability(&self, capability: CapabilityDefinition) -> Result<()> {
+        validate_capability_account_binding(&capability, self.executor.account_strategies())?;
+        self.capabilities.write().upsert(capability);
+        Ok(())
     }
 
     /// Check if a capability exists — O(1) via the name index.

--- a/src/capability/execution_context.rs
+++ b/src/capability/execution_context.rs
@@ -1,12 +1,21 @@
 // SPDX-FileCopyrightText: 2026 Mikko Parkkola
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+use std::sync::Arc;
+
 use crate::capability::CapabilityDefinition;
 use crate::identity_grants::{CapabilityExposure, GrantSubject};
+use crate::identity_propagation::{AccountStrategyRegistry, PreparedAccountCredential};
+use crate::key_server::oidc::VerifiedIdentity;
 use crate::security::validate_url_not_ssrf;
 use crate::{Error, Result};
 
 /// Request-scoped execution metadata for a capability call.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+///
+/// `PartialEq`/`Eq` are hand-written rather than derived: `VerifiedIdentity`
+/// implements neither, and deriving over it would compare `email`, `name` and
+/// `groups` — mutable display labels that must never decide whether two
+/// requests are the same principal.
+#[derive(Debug, Clone, Default)]
 pub struct CapabilityExecutionContext {
     /// Verified caller subject associated with this request, when available.
     pub caller_identity: Option<GrantSubject>,
@@ -38,6 +47,58 @@ pub struct CapabilityExecutionContext {
     /// propagation) before dispatch. Copied, never re-resolved, never
     /// re-hashed. `None` is the public/anonymous namespace.
     pub cache_binding: Option<String>,
+    /// The VERIFIED end-user identity this call is made as.
+    ///
+    /// The verification-context seam for `auth.account`: the account key is
+    /// built from a verified ISSUER and SUBJECT, and this is the only field on
+    /// this context that carries both. [`Self::caller_identity`] is a
+    /// `GrantSubject` — an authorization handle whose authority is not an OAuth
+    /// issuer — so it can never stand in for this one. `None` means the request
+    /// carries no verified identity, and a managed or external account
+    /// reference then refuses.
+    pub verified_identity: Option<Arc<VerifiedIdentity>>,
+    /// The account credential this dispatch already resolved, when the caller
+    /// resolved one before its OWN cache lookup.
+    ///
+    /// The invoke path resolves the capability's `auth.account` reference
+    /// BEFORE the outer response cache is consulted — a key built before the
+    /// account is known cannot name the account holder — and carries the answer
+    /// here so the inner capability cache and the egress headers speak about
+    /// that same credential instead of minting a second one. `None` means
+    /// nothing was resolved yet: the executor then resolves it itself, before
+    /// its own cache lookup, and never serves a cached entry for an account it
+    /// has not resolved.
+    ///
+    /// Crate-visible because a prepared credential is not something an embedder
+    /// may fabricate: the only producer is
+    /// [`crate::identity_propagation::AccountStrategyRegistry::resolve`].
+    pub(crate) account_credential: Option<Arc<PreparedAccountCredential>>,
+}
+
+impl PartialEq for CapabilityExecutionContext {
+    fn eq(&self, other: &Self) -> bool {
+        self.caller_identity == other.caller_identity
+            && self.allow_loopback_egress == other.allow_loopback_egress
+            && self.policy_epoch == other.policy_epoch
+            && self.protocol_revision == other.protocol_revision
+            && self.routing_profile == other.routing_profile
+            && self.cache_binding == other.cache_binding
+            && verified_binding(self.verified_identity.as_deref())
+                == verified_binding(other.verified_identity.as_deref())
+            // Compared on the opaque binding only: a prepared credential's
+            // headers are live token material and are never compared, logged
+            // or ordered.
+            && self.account_binding() == other.account_binding()
+    }
+}
+
+impl Eq for CapabilityExecutionContext {}
+
+/// The only part of a verified identity two contexts are compared on: the
+/// issuer+subject pair, via the same length-prefixed derivation the account key
+/// and the governance audit use.
+fn verified_binding(identity: Option<&VerifiedIdentity>) -> Option<String> {
+    identity.map(VerifiedIdentity::stable_actor_id)
 }
 
 impl CapabilityExecutionContext {
@@ -51,13 +112,53 @@ impl CapabilityExecutionContext {
             protocol_revision: None,
             routing_profile: None,
             cache_binding: None,
+            verified_identity: None,
+            account_credential: None,
         }
+    }
+
+    /// The opaque binding of the already-resolved account credential, if this
+    /// context carries one.
+    pub(crate) fn account_binding(&self) -> Option<&str> {
+        self.account_credential
+            .as_deref()
+            .map(PreparedAccountCredential::cache_binding)
+    }
+
+    /// TEST SEAM: carry a credential resolved EARLIER, as the invoke path does.
+    ///
+    /// The gateway resolves the account once in the invoke path and hands the
+    /// prepared credential down; the executor then rechecks it instead of
+    /// re-minting. A test that needs to prove a revocation committed AFTER that
+    /// resolve is refused has to reproduce exactly that carrying step, because
+    /// re-resolving would refuse at the mint and never exercise the recheck.
+    /// `cfg(test)` only, and it grants nothing: everything the field is used for
+    /// is revalidated against the live registry before a cache lookup or egress.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_account_credential(
+        mut self,
+        credential: Arc<PreparedAccountCredential>,
+    ) -> Self {
+        self.account_credential = Some(credential);
+        self
     }
 
     /// Return this context with isolated loopback egress enabled.
     #[must_use]
     pub const fn with_isolated_loopback_egress(mut self) -> Self {
         self.allow_loopback_egress = true;
+        self
+    }
+
+    /// Return this context carrying the verified end-user identity.
+    ///
+    /// The value must come from an actual verification (the gateway's
+    /// `MetaMcpCallerContext`), never from a grant subject, an API key name or
+    /// a display name.
+    #[must_use]
+    pub fn with_verified_identity(mut self, identity: Arc<VerifiedIdentity>) -> Self {
+        self.verified_identity = Some(identity);
         self
     }
 }
@@ -130,6 +231,53 @@ pub(crate) fn validate_oauth_isolation(
             capability.name, auth.key
         ),
     ))
+}
+
+/// Refuse a capability whose `auth.account` does not resolve, or whose
+/// `auth.key` is not this descriptor's `oauth:<provider>`.
+///
+/// THE REGISTRATION BOUNDARY, and re-checked at execution for a capability that
+/// was registered dynamically. Admitting an unresolvable reference would publish
+/// a tool that can only fail — and the failure would be found by a caller at
+/// dispatch rather than by an operator at load.
+///
+/// `registry = None` is a standalone executor with no account catalogue at all.
+/// Registration is then unchanged (there is nothing to check against) and the
+/// EXECUTION path fails closed instead: it never falls through to the
+/// gateway-held `oauth:<provider>` token.
+///
+/// # Errors
+///
+/// [`Error::Config`] naming the unresolved reference or the key the
+/// descriptor's provider requires.
+pub(crate) fn validate_capability_account_binding(
+    capability: &CapabilityDefinition,
+    registry: Option<&AccountStrategyRegistry>,
+) -> Result<()> {
+    let Some(account) = capability.auth.account.as_deref() else {
+        return Ok(());
+    };
+    let Some(registry) = registry else {
+        return Ok(());
+    };
+    let Some(declared) = registry.declared(account) else {
+        return Err(Error::Config(format!(
+            "Capability '{}' references account '{account}', which is not a key in \
+             accounts.descriptors. The reference is the descriptor map key (the account's \
+             logical id) — never the provider id, an email or a display name.",
+            capability.name
+        )));
+    };
+    let expected = AccountStrategyRegistry::expected_auth_key(&declared.provider);
+    if capability.auth.key != expected {
+        return Err(Error::Config(format!(
+            "Capability '{}' references account '{account}' but declares auth.key '{}'. That \
+             descriptor's provider requires '{expected}'; a capability is never joined to an \
+             account by provider name alone.",
+            capability.name, capability.auth.key
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_personal_capability_identity(

--- a/src/capability/execution_context.rs
+++ b/src/capability/execution_context.rs
@@ -219,6 +219,9 @@ pub(crate) fn validate_oauth_isolation(
     {
         return Ok(());
     }
+    if account_credential_is_this_callers(capability, context) {
+        return Ok(());
+    }
 
     Err(Error::json_rpc(
         -32001,
@@ -231,6 +234,51 @@ pub(crate) fn validate_oauth_isolation(
             capability.name, auth.key
         ),
     ))
+}
+
+/// THE ONE NARROW EXCEPTION to the guard above: this dispatch already holds an
+/// account credential that is THIS capability's own, minted for THIS verified
+/// caller.
+///
+/// The premise of the refusal is that an `oauth:<provider>` key names one
+/// gateway-held login served to whoever calls. That premise is false exactly
+/// when the account registry has already minted a per-caller credential for the
+/// capability's `auth.account` descriptor: the credential on the wire is then
+/// the caller's own, and refusing would deny the very deployment the account
+/// binding exists for. Every conjunct is required:
+///
+/// * a credential was actually PREPARED — a `shared` descriptor resolves to
+///   [`crate::identity_propagation::AccountCredential::Legacy`] and therefore
+///   carries none, so it keeps facing the unchanged guard;
+/// * it was minted for THIS capability's descriptor reference, so one
+///   capability's account credential can never excuse another's;
+/// * it was minted under THIS capability's `auth.key`, so a re-pointed provider
+///   cannot ride an old mint;
+/// * and its actor is EXACTLY this request's
+///   [`VerifiedIdentity::stable_actor_id`] — the issuer+subject pair. A missing
+///   verified identity is a refusal, never a wildcard.
+///
+/// [`CapabilityExecutionContext::caller_identity`] is a `GrantSubject`: an
+/// authorization handle whose authority is not an OAuth issuer. It is
+/// deliberately not consulted here and can never establish account authority.
+/// Nothing here inspects `auth.shared_account`, extends an expiry, or mints:
+/// the credential was produced and rechecked by
+/// [`crate::capability::CapabilityExecutor::prepare_account_context`] against
+/// the live registry before this function ever sees it.
+fn account_credential_is_this_callers(
+    capability: &CapabilityDefinition,
+    context: &CapabilityExecutionContext,
+) -> bool {
+    let (Some(account), Some(prepared), Some(identity)) = (
+        capability.auth.account.as_deref(),
+        context.account_credential.as_deref(),
+        context.verified_identity.as_deref(),
+    ) else {
+        return false;
+    };
+    prepared.descriptor_id == account
+        && prepared.auth_key == capability.auth.key
+        && prepared.actor_id == identity.stable_actor_id()
 }
 
 /// Refuse a capability whose `auth.account` does not resolve, or whose

--- a/src/capability/executor/credentials.rs
+++ b/src/capability/executor/credentials.rs
@@ -12,28 +12,200 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::{info, warn};
 
+use crate::capability::CapabilityExecutionContext;
+use crate::identity_propagation::AccountCredential;
 use crate::oauth::TokenInfo;
+use crate::personal_accounts::config::DescriptorMode;
 use crate::{Error, Result};
 
 use super::CapabilityExecutor;
 
 impl CapabilityExecutor {
     /// Fetch credential from secure storage.
-    pub(super) async fn fetch_credential(&self, auth: &super::super::AuthConfig) -> Result<String> {
+    /// Resolve a capability's `auth.account` reference into outbound headers.
+    ///
+    /// `Ok(None)` means there is nothing to resolve — no reference, or an
+    /// explicit `shared` descriptor whose existing static behaviour must be
+    /// preserved byte for byte. Everything else is either headers minted for
+    /// the verified caller by the shared strategy, or a refusal.
+    ///
+    /// # Errors
+    ///
+    /// Every refusal from [`crate::identity_propagation::AccountStrategyRegistry::resolve`],
+    /// plus the no-catalogue case. None of them falls through to a legacy
+    /// lookup.
+    pub(super) async fn resolve_account_headers(
+        &self,
+        auth: &super::super::AuthConfig,
+        context: &CapabilityExecutionContext,
+    ) -> Result<Option<Vec<(String, String)>>> {
+        let Some(account) = auth.account.as_deref() else {
+            return Ok(None);
+        };
+        let registry = self.require_account_catalogue(auth, account)?;
+        // The dispatch already resolved this account before its first cache
+        // lookup. Recheck it against the SAME registry here — the last point
+        // before the credential goes on the wire — and then present the headers
+        // it minted verbatim. Re-minting instead would mean the value that
+        // selected the cache entry and the value on the wire were two different
+        // credentials, which is exactly the drift the MCP route's
+        // resolve-once-reuse-verbatim rule exists to prevent.
+        if let Some(prepared) = context.account_credential.as_deref() {
+            Self::assert_prepared_matches(prepared, auth, account)?;
+            registry
+                .revalidate(prepared, context.verified_identity.as_deref())
+                .await?;
+            return Ok(Some(prepared.headers().to_vec()));
+        }
+        match registry
+            .resolve(account, &auth.key, context.verified_identity.as_deref())
+            .await?
+        {
+            AccountCredential::Legacy => Ok(None),
+            AccountCredential::Prepared(prepared) => Ok(Some(prepared.headers().to_vec())),
+        }
+    }
+
+    /// Resolve the capability's PRIMARY `auth.account` reference and publish
+    /// its binding onto the context, BEFORE the caller consults any cache.
+    ///
+    /// Returns the context to execute under. Unchanged for a capability with no
+    /// account reference and for an explicit `shared` descriptor — both keep
+    /// the existing cache key and the existing static credential path.
+    ///
+    /// When the invoke path already resolved a credential for this dispatch it
+    /// is RECHECKED against the registry rather than re-minted, so one dispatch
+    /// consumes exactly one credential; when nothing was carried (a standalone
+    /// executor, or any caller that did not prepare one) the account is
+    /// resolved here instead. There is no third case, and in particular no case
+    /// in which a cache is consulted for an account that was never resolved.
+    ///
+    /// # Errors
+    ///
+    /// Every refusal from
+    /// [`crate::identity_propagation::AccountStrategyRegistry::resolve`] and
+    /// [`crate::identity_propagation::AccountStrategyRegistry::revalidate`],
+    /// plus the no-catalogue case and a carried credential that does not belong
+    /// to this capability's reference. None of them falls back to a legacy
+    /// lookup and none of them degrades into a cache miss.
+    pub(super) async fn prepare_account_context(
+        &self,
+        capability: &super::super::CapabilityDefinition,
+        mut context: CapabilityExecutionContext,
+    ) -> Result<CapabilityExecutionContext> {
+        let auth = &capability.auth;
+        let Some(account) = auth.account.as_deref() else {
+            return Ok(context);
+        };
+        let registry = self.require_account_catalogue(auth, account)?;
+
+        if let Some(prepared) = context.account_credential.clone() {
+            Self::assert_prepared_matches(&prepared, auth, account)?;
+            registry
+                .revalidate(&prepared, context.verified_identity.as_deref())
+                .await?;
+            context.cache_binding = Some(prepared.cache_binding().to_owned());
+            return Ok(context);
+        }
+
+        match registry
+            .resolve(account, &auth.key, context.verified_identity.as_deref())
+            .await?
+        {
+            // A `shared` descriptor is not an account credential at all: the
+            // deployment already serves it statically, and its cache namespace
+            // must stay exactly what it was.
+            AccountCredential::Legacy => Ok(context),
+            AccountCredential::Prepared(prepared) => {
+                // The strategy's own opaque binding — the five-field account
+                // digest widened with the grant generation, authorization
+                // epoch, token revision and descriptor revision. Copied, never
+                // re-hashed: a re-authorized, rotated or revoked account
+                // publishes a different binding and therefore a different key.
+                context.cache_binding = Some(prepared.cache_binding().to_owned());
+                context.account_credential = Some(prepared);
+                Ok(context)
+            }
+        }
+    }
+
+    /// The account catalogue, or the no-catalogue refusal.
+    ///
+    /// A standalone executor has no catalogue, and a capability naming an
+    /// account must fail CLOSED there rather than resolving the gateway-held
+    /// `oauth:<provider>` token.
+    fn require_account_catalogue(
+        &self,
+        auth: &super::super::AuthConfig,
+        account: &str,
+    ) -> Result<&crate::identity_propagation::AccountStrategyRegistry> {
+        self.account_strategies().ok_or_else(|| {
+            Error::Config(format!(
+                "capability auth references account '{account}' but this executor has no \
+                 account catalogue; refusing rather than falling back to the gateway-held \
+                 credential for '{}'.",
+                auth.key
+            ))
+        })
+    }
+
+    /// A carried credential must be the one THIS capability's reference asks
+    /// for. A credential prepared for another descriptor or another auth key
+    /// belongs to another capability's account boundary and is refused rather
+    /// than reused.
+    fn assert_prepared_matches(
+        prepared: &crate::identity_propagation::PreparedAccountCredential,
+        auth: &super::super::AuthConfig,
+        account: &str,
+    ) -> Result<()> {
+        if prepared.descriptor_id == account && prepared.auth_key == auth.key {
+            return Ok(());
+        }
+        Err(Error::Config(format!(
+            "capability auth references account '{account}' but the credential resolved for \
+             this dispatch was minted for a different account reference; refusing rather than \
+             presenting one capability's account credential for another."
+        )))
+    }
+
+    /// Whether `account` is an explicit `shared` descriptor, whose credential
+    /// is the existing gateway-held one.
+    ///
+    /// Answers from the DECLARED catalogue and never mints: asking this question
+    /// must not consume a custody lease.
+    fn account_is_shared(&self, account: &str) -> bool {
+        self.account_strategies().is_some_and(|registry| {
+            registry
+                .declared(account)
+                .is_some_and(|declared| declared.mode == DescriptorMode::Shared)
+        })
+    }
+
+    /// Fetch credential from secure storage.
+    pub(super) async fn fetch_credential(
+        &self,
+        auth: &super::super::AuthConfig,
+        _context: &CapabilityExecutionContext,
+    ) -> Result<String> {
         let key = &auth.key;
 
-        // A recognized `auth.account` names a managed personal account, whose
-        // credential lives in custody and is bound to a VERIFIED caller
-        // identity. This path has no verified identity to bind to — REST
-        // verified-identity propagation is a later step — so it refuses
-        // BEFORE any legacy lookup. Falling through would resolve the
-        // gateway-held `oauth:<provider>` token from the shared TokenStorage
-        // and present one person's login as another's, which is precisely
-        // what the account reference exists to prevent.
-        if let Some(account) = auth.account.as_deref() {
+        // A managed or external account's credential is a per-caller HEADER
+        // minted by the shared resolver, not an opaque secret this function can
+        // return: the provider's own `token_type` and any additional header
+        // would be lost, and the caller of this function may be about to put
+        // the value in a URL query parameter. `inject_auth` is the one place
+        // that may resolve one. Everything else refuses BEFORE any legacy
+        // lookup — falling through would resolve the gateway-held
+        // `oauth:<provider>` token from the shared TokenStorage and present one
+        // person's login as another's. An explicit `shared` descriptor is not
+        // an account credential at all and continues below, unchanged.
+        if let Some(account) = auth.account.as_deref()
+            && !self.account_is_shared(account)
+        {
             return Err(Error::Config(format!(
-                "capability auth references managed account '{account}', but REST capability \
-                 execution cannot yet bind a verified caller identity to it. Refusing rather \
+                "capability auth references account '{account}', whose credential is a \
+                 per-caller header minted by the shared identity resolver; it cannot be \
+                 injected as a query parameter or rewritten with a prefix. Refusing rather \
                  than falling back to the gateway-held credential for '{key}'."
             )));
         }
@@ -407,6 +579,7 @@ mod tests {
             health: crate::failsafe::HealthTracker::new("test"),
             env: Arc::new(crate::config::LiveEnv::default()),
             policy_epoch: None,
+            account_strategies: None,
         }
     }
 
@@ -420,6 +593,7 @@ mod tests {
             health: crate::failsafe::HealthTracker::new("test"),
             env: Arc::new(crate::config::LiveEnv::default()),
             policy_epoch: None,
+            account_strategies: None,
         }
     }
 

--- a/src/capability/executor/credentials.rs
+++ b/src/capability/executor/credentials.rs
@@ -88,7 +88,15 @@ impl CapabilityExecutor {
     /// plus the no-catalogue case and a carried credential that does not belong
     /// to this capability's reference. None of them falls back to a legacy
     /// lookup and none of them degrades into a cache miss.
-    pub(super) async fn prepare_account_context(
+    ///
+    /// # Visibility
+    ///
+    /// Visible to the whole `capability` module (not just the executor) because
+    /// [`crate::capability::CapabilityBackend::call_tool_with_context`] must
+    /// resolve the account BEFORE it evaluates per-user OAuth isolation on a
+    /// multi-user gateway. It is deliberately not `pub(crate)` and not public:
+    /// this is the ONE existing resolver, reused, not a second entry point.
+    pub(in crate::capability) async fn prepare_account_context(
         &self,
         capability: &super::super::CapabilityDefinition,
         mut context: CapabilityExecutionContext,

--- a/src/capability/executor/graphql.rs
+++ b/src/capability/executor/graphql.rs
@@ -226,7 +226,7 @@ impl ProtocolExecutor for GraphqlExecutor<'_> {
         // Inject auth if configured on the capability
         if ctx.capability.auth.required && ctx.capability.auth.param.is_none() {
             self.executor
-                .inject_auth(&mut headers, &ctx.capability.auth)
+                .inject_auth(&mut headers, &ctx.capability.auth, &ctx.context)
                 .await?;
         }
 

--- a/src/capability/executor/jsonrpc.rs
+++ b/src/capability/executor/jsonrpc.rs
@@ -170,7 +170,7 @@ impl ProtocolExecutor for JsonRpcExecutor<'_> {
         // Inject auth if configured on the capability
         if ctx.capability.auth.required && ctx.capability.auth.param.is_none() {
             self.executor
-                .inject_auth(&mut headers, &ctx.capability.auth)
+                .inject_auth(&mut headers, &ctx.capability.auth, &ctx.context)
                 .await?;
         }
 

--- a/src/capability/executor/mod.rs
+++ b/src/capability/executor/mod.rs
@@ -73,6 +73,15 @@ pub struct CapabilityExecutor {
     /// Shared authorization-policy generation. Bumpers clone this Arc;
     /// readers use the `u64` snapshot on [`CapabilityExecutionContext`].
     pub(super) policy_epoch: Option<Arc<std::sync::atomic::AtomicU64>>,
+    /// The gateway's per-descriptor account strategies, when this executor
+    /// belongs to a gateway.
+    ///
+    /// `None` for a standalone executor: there is then no account catalogue,
+    /// and a capability naming one fails CLOSED at execution rather than
+    /// resolving the gateway-held `oauth:<provider>` token. This is a handle on
+    /// the ONE registry the shared installer wrote to — not a second store.
+    pub(super) account_strategies:
+        Option<Arc<crate::identity_propagation::AccountStrategyRegistry>>,
 }
 
 /// Maximum number of send attempts (1 initial + 2 retries) for transient
@@ -215,6 +224,7 @@ impl CapabilityExecutor {
             health: crate::failsafe::HealthTracker::new("capabilities"),
             env: Arc::new(crate::config::LiveEnv::default()),
             policy_epoch: None,
+            account_strategies: None,
         }
     }
 
@@ -245,6 +255,44 @@ impl CapabilityExecutor {
         self
     }
 
+    /// Resolve `auth.account` references against the gateway's per-descriptor
+    /// account strategies.
+    ///
+    /// The SAME registry the shared installer wrote to, so a REST capability
+    /// and an MCP backend naming one descriptor reach one strategy instance.
+    #[must_use]
+    pub(crate) fn with_account_strategies(
+        mut self,
+        registry: Arc<crate::identity_propagation::AccountStrategyRegistry>,
+    ) -> Self {
+        self.account_strategies = Some(registry);
+        self
+    }
+
+    /// TEST SEAM: swap the outbound HTTP client.
+    ///
+    /// The production client pins DNS, which a fixture's `localhost` endpoint
+    /// cannot satisfy. Swapping the CLIENT — the same thing the existing
+    /// `cacheable_counting_executor` fixture does by writing the field directly
+    /// — is what lets a warm-cache test run WITHOUT `allow_loopback_egress`,
+    /// which disables caching outright. This relaxes no SSRF check: the URL
+    /// still goes through `validate_capability_url_for_context`, and the flag
+    /// that opens IP-literal egress is untouched. `cfg(test)` only, so no
+    /// production path can reach it.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_test_http_client(mut self, client: Client) -> Self {
+        self.client = client;
+        self
+    }
+
+    /// The account catalogue this executor validates and resolves against.
+    pub(crate) fn account_strategies(
+        &self,
+    ) -> Option<&crate::identity_propagation::AccountStrategyRegistry> {
+        self.account_strategies.as_deref()
+    }
+
     /// Whether outbound transport is currently considered healthy.
     #[must_use]
     pub fn is_healthy(&self) -> bool {
@@ -273,6 +321,7 @@ impl CapabilityExecutor {
             health: crate::failsafe::HealthTracker::new("capabilities"),
             env: Arc::new(crate::config::LiveEnv::default()),
             policy_epoch: None,
+            account_strategies: None,
         }
     }
 
@@ -332,6 +381,21 @@ impl CapabilityExecutor {
         let provider = capability
             .primary_provider()
             .ok_or_else(|| Error::Config("No primary provider configured".to_string()))?;
+
+        // THE ACCOUNT IS RESOLVED BEFORE ANY CACHE IS CONSULTED.
+        //
+        // A cache key built before the account is known cannot name the account
+        // holder, so the first caller's cached result would be handed to the
+        // next one. This resolves the capability's PRIMARY `auth.account`
+        // reference — carrying the credential the invoke path already resolved
+        // when there is one, and rechecking it against the same registry either
+        // way — and publishes its opaque binding onto the context the key below
+        // is built from. A capability with no account reference, and an explicit
+        // `shared` descriptor, are untouched: both keep the existing key and the
+        // existing static credential path. Every other refusal returns HERE,
+        // before a lookup, so a request that may not have this account can
+        // neither be served from cache nor reach the wire.
+        let context = self.prepare_account_context(capability, context).await?;
 
         // Check cache first. Loopback-relaxed fetches never enter the store.
         // The key uses the invoke-path snapshot on `context` (revision, profile,
@@ -466,7 +530,9 @@ impl CapabilityExecutor {
 
         // Add headers; skip Authorization when auth.param is set (credential
         // goes as a query param instead of a header).
-        let headers = self.build_headers(config, &capability.auth, params).await?;
+        let headers = self
+            .build_headers(config, &capability.auth, params, context)
+            .await?;
         request = request.headers(headers);
 
         // Inject auth credential as a query parameter when auth.param is specified
@@ -474,7 +540,7 @@ impl CapabilityExecutor {
         if let Some(ref param_name) = capability.auth.param
             && capability.auth.required
         {
-            let credential = self.fetch_credential(&capability.auth).await?;
+            let credential = self.fetch_credential(&capability.auth, context).await?;
             request = request.query(&[(param_name.as_str(), credential.as_str())]);
         }
 
@@ -578,6 +644,7 @@ impl CapabilityExecutor {
         config: &RestConfig,
         auth: &super::AuthConfig,
         params: &Value,
+        context: &CapabilityExecutionContext,
     ) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
 
@@ -599,7 +666,7 @@ impl CapabilityExecutor {
 
         // Skip header injection when auth.param is set (credential goes as query param).
         if auth.required && auth.param.is_none() {
-            self.inject_auth(&mut headers, auth).await?;
+            self.inject_auth(&mut headers, auth, context).await?;
         }
 
         Ok(headers)
@@ -615,8 +682,30 @@ impl CapabilityExecutor {
         &self,
         headers: &mut HeaderMap,
         auth: &super::AuthConfig,
+        context: &CapabilityExecutionContext,
     ) -> Result<()> {
-        let credential = self.fetch_credential(auth).await?;
+        // A recognized `auth.account` is resolved through the SHARED identity
+        // resolver — the same strategy instance an MCP backend bound to that
+        // descriptor holds — and its headers go on the wire VERBATIM: the
+        // provider's own `token_type` is authority this executor must not
+        // reformat, and a strategy may mint more than one header. `Ok(None)`
+        // means either no account reference or an explicit `shared` descriptor,
+        // both of which continue on the existing static path below. Any refusal
+        // returns here and never reaches it.
+        if let Some(account_headers) = self.resolve_account_headers(auth, context).await? {
+            for (name, value) in account_headers {
+                let header_name: HeaderName = name.parse().map_err(|_| {
+                    Error::Config("Invalid account credential header name".to_string())
+                })?;
+                let header_value: HeaderValue = value
+                    .parse()
+                    .map_err(|_| Error::Config("Invalid credential format".to_string()))?;
+                headers.insert(header_name, header_value);
+            }
+            return Ok(());
+        }
+
+        let credential = self.fetch_credential(auth, context).await?;
 
         let header_name: HeaderName = auth
             .header

--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -47,15 +47,15 @@ mod schema_validator;
 pub mod validator;
 mod watcher;
 
-pub use backend::{CapabilityBackend, CapabilityBackendStatus, RugPullRecord};
+pub use backend::{CapabilityBackend, CapabilityBackendStatus, DirectoryLoad, RugPullRecord};
 pub use definition::ProtocolConfig;
 pub use definition::*;
 #[cfg(feature = "discovery")]
 pub use discovery::{DiscoveryEngine, DiscoveryOptions, DiscoveryResult};
 pub use execution_context::CapabilityExecutionContext;
 pub(crate) use execution_context::{
-    validate_capability_url_for_context, validate_oauth_isolation,
-    validate_personal_capability_identity,
+    validate_capability_account_binding, validate_capability_url_for_context,
+    validate_oauth_isolation, validate_personal_capability_identity,
 };
 pub use executor::CapabilityExecutor;
 pub use executor::graphql::GraphqlExecutor;

--- a/src/config/account_bindings.rs
+++ b/src/config/account_bindings.rs
@@ -159,25 +159,7 @@ fn compile_one(
         DescriptorMode::PersonalManaged => {
             validate_managed_consumer(name, reference, backend)?;
             let account = account_key_descriptor(name, reference, descriptor)?;
-            let propagation = IdentityPropagationConfig {
-                // The EXISTING kind, not a new one: managed custody dispatches
-                // through the same `IdentityPropagation` trait every other
-                // strategy does.
-                strategy: PropagationStrategyKind::Vault,
-                // The descriptor's own RFC 8707 resource is the audience the
-                // credential is scoped to; it is also half of the account key,
-                // so cache isolation and custody addressing cannot drift.
-                audience: account.resource.clone(),
-                // A managed account is one person's credential. There is no
-                // best-effort mode: without the account there is nothing to
-                // downgrade to that would still be that person.
-                required: true,
-                // A backend that answered as one user must not reuse that
-                // session for the next one (IDP.7).
-                session_mode: SessionMode::PerUser,
-                token_exchange_endpoint: None,
-                token_exchange_scope: None,
-            };
+            let propagation = managed_propagation(&account);
             (Some(propagation), Some(account))
         }
         DescriptorMode::External => {
@@ -288,4 +270,208 @@ fn validate_managed_consumer(name: &str, reference: &str, backend: &BackendConfi
         )));
     }
     Ok(())
+}
+
+/// The propagation a `personal_managed` descriptor compiles to.
+///
+/// ONE function, because there are now two consumers of that compilation — the
+/// backend reference above and the descriptor itself below — and a second copy
+/// of the audience, the required flag or the session mode would be a second
+/// policy nobody validated.
+fn managed_propagation(account: &AccountKeyDescriptor) -> IdentityPropagationConfig {
+    IdentityPropagationConfig {
+        // The EXISTING kind, not a new one: managed custody dispatches
+        // through the same `IdentityPropagation` trait every other
+        // strategy does.
+        strategy: PropagationStrategyKind::Vault,
+        // The descriptor's own RFC 8707 resource is the audience the
+        // credential is scoped to; it is also half of the account key,
+        // so cache isolation and custody addressing cannot drift.
+        audience: account.resource.clone(),
+        // A managed account is one person's credential. There is no
+        // best-effort mode: without the account there is nothing to
+        // downgrade to that would still be that person.
+        required: true,
+        // A backend that answered as one user must not reuse that
+        // session for the next one (IDP.7).
+        session_mode: SessionMode::PerUser,
+        token_exchange_endpoint: None,
+        token_exchange_scope: None,
+    }
+}
+
+/// One configured descriptor, compiled WITHOUT reference to any backend.
+///
+/// A REST capability names a descriptor MAP KEY directly and may be that
+/// account's only consumer, so installation cannot be conditional on some MCP
+/// backend also naming it.
+#[derive(Clone, Debug)]
+pub(crate) struct CompiledDescriptor {
+    /// The `accounts.descriptors` map key.
+    pub(crate) descriptor_id: String,
+    /// The descriptor's logical OAuth provider id.
+    pub(crate) provider: String,
+    /// The declared mode, as written.
+    pub(crate) mode: DescriptorMode,
+    /// `None` for `shared`: existing static behaviour is preserved exactly.
+    pub(crate) propagation: Option<IdentityPropagationConfig>,
+    /// The five-field account-key descriptor, for `personal_managed` only.
+    pub(crate) account: Option<AccountKeyDescriptor>,
+}
+
+/// Compile every declared descriptor, or refuse.
+///
+/// # Errors
+///
+/// [`Error::ConfigValidation`] for a managed descriptor missing the
+/// resource/issuer the account key is built from, or an external descriptor
+/// with no `external_strategy`. `validate_descriptors` refuses both earlier;
+/// this re-checks rather than unwrapping, because a compile that panicked on an
+/// unvalidated `Config` would turn an operator error into a crash.
+pub(crate) fn compile_descriptors(config: &Config) -> Result<Vec<CompiledDescriptor>> {
+    let Some(descriptors) = config
+        .accounts
+        .as_ref()
+        .and_then(|accounts| accounts.descriptors.as_ref())
+    else {
+        return Ok(Vec::new());
+    };
+    descriptors
+        .iter()
+        .map(|(id, descriptor)| compile_descriptor(id, descriptor))
+        .collect()
+}
+
+/// Compile one declared descriptor.
+fn compile_descriptor(id: &str, descriptor: &AccountDescriptor) -> Result<CompiledDescriptor> {
+    let (propagation, account) = match descriptor.mode {
+        DescriptorMode::PersonalManaged => {
+            let (Some(resource), Some(issuer)) =
+                (descriptor.resource.as_deref(), descriptor.issuer.as_deref())
+            else {
+                return Err(Error::ConfigValidation(format!(
+                    "personal_managed account descriptor '{id}' is missing the resource/issuer \
+                     the account key is built from"
+                )));
+            };
+            let account = AccountKeyDescriptor {
+                descriptor_id: id.to_string(),
+                provider: descriptor.provider.clone(),
+                resource: resource.to_string(),
+                issuer: issuer.to_string(),
+            };
+            (Some(managed_propagation(&account)), Some(account))
+        }
+        DescriptorMode::External => {
+            let strategy = descriptor.external_strategy.clone().ok_or_else(|| {
+                Error::ConfigValidation(format!(
+                    "external account descriptor '{id}' declares no external_strategy"
+                ))
+            })?;
+            (Some(strategy), None)
+        }
+        // Existing shared behaviour, preserved verbatim.
+        DescriptorMode::Shared => (None, None),
+    };
+    Ok(CompiledDescriptor {
+        descriptor_id: id.to_string(),
+        provider: descriptor.provider.clone(),
+        mode: descriptor.mode,
+        propagation,
+        account,
+    })
+}
+
+/// The backend configurations a gateway actually runs with, keyed by registry
+/// name.
+///
+/// The reload path constructs replacement backends from whatever config it is
+/// handed, so it must be handed THIS one. A bound backend rebuilt from the raw
+/// config carries no `identity_propagation` at all, which is not a downgrade to
+/// a shared credential but the absence of any credential — discovered by a
+/// caller, at dispatch.
+///
+/// An unresolvable reference yields no binding and therefore the raw config.
+/// That is not a fallback: `Config::validate_with_env` refuses such a file
+/// before it is published, and a backend that still reached dispatch with an
+/// unresolved reference is refused by `refuse_unbound_account_backend`.
+pub(crate) fn effective_backends(config: &Config) -> BTreeMap<String, BackendConfig> {
+    let bound = compile(config).unwrap_or_default();
+    config
+        .backends
+        .iter()
+        .map(|(name, backend)| {
+            let effective = bound
+                .get(name)
+                .map_or_else(|| backend.clone(), |bound| bound.effective(backend));
+            (name.clone(), effective)
+        })
+        .collect()
+}
+
+/// Why a reload must not apply an account-binding change in place.
+///
+/// Returns `Some(reason)` when applying the file live would let a running
+/// backend keep credentials that no longer describe its account. Changing a
+/// descriptor's authority, resource, issuer, client id or requested scopes
+/// changes the descriptor revision every existing lease was minted under, and
+/// repointing a backend at another account is a different person's credential.
+///
+/// Eager metadata/authority replacement is NOT implemented in this slice. The
+/// honest answer is therefore the existing restart-required posture applied as
+/// a fail-closed guard BEFORE any registry mutation — not a live replacement
+/// that quietly keeps the old credentials.
+///
+/// `None` for an unchanged binding and for any edit that leaves every
+/// referenced descriptor identical, so ordinary reloads are unaffected.
+pub(crate) fn reload_binding_refusal(old: &Config, new: &Config) -> Option<String> {
+    let old_descriptors = old
+        .accounts
+        .as_ref()
+        .and_then(|accounts| accounts.descriptors.as_ref());
+    let new_descriptors = new
+        .accounts
+        .as_ref()
+        .and_then(|accounts| accounts.descriptors.as_ref());
+
+    let mut names: Vec<&String> = old.backends.keys().chain(new.backends.keys()).collect();
+    names.sort();
+    names.dedup();
+
+    for name in names {
+        let before = old.backends.get(name).and_then(|b| b.account.as_deref());
+        let after = new.backends.get(name).and_then(|b| b.account.as_deref());
+        if before != after {
+            return Some(format!(
+                "backend '{name}' changes its account binding (from '{}' to '{}'). The installed \
+                 strategy is built from the descriptor it was bound to, so applying this live \
+                 would either keep the previous account's credential or dispatch with none. \
+                 Restart to apply it.",
+                before.unwrap_or("none"),
+                after.unwrap_or("none")
+            ));
+        }
+        let Some(reference) = after else {
+            continue;
+        };
+        let unchanged = match (
+            old_descriptors.and_then(|d| d.get(reference)),
+            new_descriptors.and_then(|d| d.get(reference)),
+        ) {
+            (Some(before), Some(after)) => before == after,
+            // Unresolved on both sides is not this guard's refusal to make:
+            // `Config::validate_with_env` refuses that file outright.
+            (None, None) => true,
+            _ => false,
+        };
+        if !unchanged {
+            return Some(format!(
+                "account descriptor '{reference}', which backend '{name}' is bound to, changed. \
+                 Its authority, resource, issuer, client id and requested scopes define the \
+                 account key and the descriptor revision every existing lease was minted under, \
+                 so those credentials cannot be reused. Restart to apply it."
+            ));
+        }
+    }
+    None
 }

--- a/src/config_reload/account_reload_guard_tests.rs
+++ b/src/config_reload/account_reload_guard_tests.rs
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! The fail-closed reload guard for changed account bindings — STAGE B.
+//!
+//! WHY A SEPARATE FILE FROM `account_reload_tests`. That file compiles against
+//! the frozen snapshot and produces a behavioural RED. This one names a symbol
+//! the snapshot does not have, so registering it turns the build red. Keeping
+//! them apart is what lets the supervisor observe an honest behavioural failure
+//! first and a compile boundary second, instead of one indistinguishable "it
+//! did not build".
+//!
+//! WHAT IT PINS. A descriptor's authority, resource, issuer, scopes or a
+//! backend's account reference cannot change under a running gateway and have
+//! the old credentials keep flowing. Eager metadata/authority replacement is NOT
+//! implemented in this slice, so the honest answer is a refusal that mutates
+//! nothing — the existing restart-required posture, applied before `apply_patch`
+//! stops or starts anything.
+//!
+//! The three positive controls matter as much as the refusal: a reload that
+//! refused every account configuration would be indistinguishable from one that
+//! works, and would be reverted by the first operator who hit it.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+
+use crate::config::account_bindings::reload_binding_refusal;
+use crate::config::{BackendConfig, Config, TransportConfig};
+use crate::personal_accounts::config::{
+    AccountDescriptor, AccountsConfig, AccountsLimits, DescriptorMode,
+};
+
+const WORK: &str = "work-gmail";
+const RESOURCE: &str = "https://www.googleapis.invalid/drive/v3";
+const ISSUER: &str = "https://accounts.google.invalid";
+
+fn descriptor(issuer: &str, resource: &str, scopes: &[&str]) -> AccountDescriptor {
+    AccountDescriptor {
+        mode: DescriptorMode::PersonalManaged,
+        provider: "google".to_string(),
+        resource: Some(resource.to_string()),
+        issuer: Some(issuer.to_string()),
+        authorization_endpoint: Some(format!("{issuer}/o/oauth2/v2/auth")),
+        token_endpoint: Some(format!("{issuer}/token")),
+        revocation_endpoint: None,
+        client_id: Some("synthetic-google-client".to_string()),
+        client_secret_ref: Some("env:FIXTURE_ACCOUNT_CLIENT_SECRET".to_string()),
+        redirect_uri: Some("https://gateway.example.invalid/oauth/callback".to_string()),
+        scopes: Some(scopes.iter().map(|s| (*s).to_string()).collect()),
+        send_resource_parameter: Some(false),
+        external_strategy: None,
+    }
+}
+
+fn default_descriptor() -> AccountDescriptor {
+    descriptor(
+        ISSUER,
+        RESOURCE,
+        &["https://www.googleapis.com/auth/drive.readonly"],
+    )
+}
+
+fn config(reference: Option<&str>, id: &str, descriptor: AccountDescriptor) -> Config {
+    let mut backends = HashMap::new();
+    backends.insert(
+        "drive".to_string(),
+        BackendConfig {
+            enabled: true,
+            account: reference.map(str::to_string),
+            transport: TransportConfig::Http {
+                http_url: "https://drive.invalid/mcp".to_string(),
+                streamable_http: true,
+                protocol_version: None,
+            },
+            ..BackendConfig::default()
+        },
+    );
+    Config {
+        backends,
+        accounts: Some(AccountsConfig {
+            schema_version: "accounts.v1".to_string(),
+            enabled: true,
+            deployment: "single_process".to_string(),
+            instance_id: "reload-guard-tests".to_string(),
+            store_dir: PathBuf::from("/synthetic/fixture/accounts/records"),
+            authority_dir: PathBuf::from("/synthetic/fixture/accounts/authority"),
+            current_key_id: "current".to_string(),
+            keys: BTreeMap::from([(
+                "current".to_string(),
+                "env:FIXTURE_ACCOUNT_STORE_KEY".to_string(),
+            )]),
+            descriptors: Some([(id.to_string(), descriptor)].into_iter().collect()),
+            limits: AccountsLimits::default(),
+        }),
+        ..Config::default()
+    }
+}
+
+fn bound(descriptor: AccountDescriptor) -> Config {
+    config(Some(WORK), WORK, descriptor)
+}
+
+/// POSITIVE CONTROL — an unchanged binding is not refused.
+#[test]
+fn an_unchanged_binding_is_not_refused() {
+    assert!(
+        reload_binding_refusal(&bound(default_descriptor()), &bound(default_descriptor()))
+            .is_none(),
+        "an unchanged account binding must reload normally; refusing it would make the guard \
+         indistinguishable from a broken reload"
+    );
+}
+
+/// POSITIVE CONTROL — a change that touches no bound descriptor is not refused.
+#[test]
+fn an_unrelated_edit_beside_an_unchanged_binding_is_not_refused() {
+    let mut edited = bound(default_descriptor());
+    edited
+        .backends
+        .get_mut("drive")
+        .expect("fixture backend")
+        .headers
+        .insert("X-Trace".to_string(), "on".to_string());
+
+    assert!(
+        reload_binding_refusal(&bound(default_descriptor()), &edited).is_none(),
+        "an edit that leaves every referenced descriptor identical must not be refused"
+    );
+}
+
+/// A CHANGED ISSUER CANNOT REUSE THE OLD CREDENTIALS.
+#[test]
+fn a_changed_descriptor_issuer_is_refused() {
+    let refusal = reload_binding_refusal(
+        &bound(default_descriptor()),
+        &bound(descriptor(
+            "https://accounts.evil.invalid",
+            RESOURCE,
+            &["https://www.googleapis.com/auth/drive.readonly"],
+        )),
+    )
+    .expect("a new trusted issuer invalidates every lease minted under the old one");
+    assert!(
+        refusal.contains(WORK),
+        "the refusal must name the descriptor: {refusal}"
+    );
+}
+
+/// A CHANGED RESOURCE CANNOT REUSE THE OLD CREDENTIALS.
+///
+/// The resource is half of the five-field account key and the audience the
+/// credential is scoped to, so reusing a lease across it would address a
+/// different account with the same handle.
+#[test]
+fn a_changed_descriptor_resource_is_refused() {
+    assert!(
+        reload_binding_refusal(
+            &bound(default_descriptor()),
+            &bound(descriptor(
+                ISSUER,
+                "https://www.googleapis.invalid/gmail/v1",
+                &["https://www.googleapis.com/auth/drive.readonly"],
+            )),
+        )
+        .is_some(),
+        "the account key's resource changed; the old lease addresses a different account"
+    );
+}
+
+/// CHANGED REQUESTED SCOPES CANNOT REUSE THE OLD CREDENTIALS.
+#[test]
+fn changed_descriptor_scopes_are_refused() {
+    assert!(
+        reload_binding_refusal(
+            &bound(default_descriptor()),
+            &bound(descriptor(
+                ISSUER,
+                RESOURCE,
+                &[
+                    "https://www.googleapis.com/auth/drive.readonly",
+                    "https://www.googleapis.com/auth/drive",
+                ],
+            )),
+        )
+        .is_some(),
+        "a broader scope set is a different authorization, not a refreshed token"
+    );
+}
+
+/// A CHANGED ACCOUNT REFERENCE IS REFUSED.
+///
+/// Repointing a live backend at a different account is a different person's
+/// credential. The installed strategy is keyed by the descriptor it was built
+/// from, so a silent repoint would either keep the old account or dispatch with
+/// none.
+#[test]
+fn a_changed_account_reference_is_refused() {
+    let old = bound(default_descriptor());
+    let mut new = bound(default_descriptor());
+    new.backends
+        .get_mut("drive")
+        .expect("fixture backend")
+        .account = Some("personal-gmail".to_string());
+
+    assert!(
+        reload_binding_refusal(&old, &new).is_some(),
+        "a backend repointed at another account must not keep dispatching with the old one"
+    );
+}
+
+/// BINDING A PREVIOUSLY UNBOUND BACKEND IS REFUSED.
+///
+/// Nothing installed a strategy for it, so the reload would leave a backend that
+/// declares a managed account and cannot serve one. Refusing before any registry
+/// mutation is the only outcome that leaves the running gateway coherent.
+#[test]
+fn newly_binding_a_backend_to_an_account_is_refused() {
+    assert!(
+        reload_binding_refusal(
+            &config(None, WORK, default_descriptor()),
+            &bound(default_descriptor())
+        )
+        .is_some(),
+        "a binding added by a reload has no installed strategy behind it"
+    );
+}
+
+/// REMOVING A REFERENCED DESCRIPTOR IS REFUSED.
+#[test]
+fn removing_a_referenced_descriptor_is_refused() {
+    assert!(
+        reload_binding_refusal(
+            &bound(default_descriptor()),
+            &config(Some(WORK), "personal-gmail", default_descriptor()),
+        )
+        .is_some(),
+        "a bound backend whose descriptor disappeared must not keep its old credentials"
+    );
+}

--- a/src/config_reload/account_reload_tests.rs
+++ b/src/config_reload/account_reload_tests.rs
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Reload of `accounts.descriptors` bindings — STAGE A, behavioural RED.
+//!
+//! WHY THIS FILE COMPILES AGAINST THE FROZEN SNAPSHOT. Every symbol used here
+//! already exists (`compute_diff`, `LiveConfig`, `Config`, the
+//! `personal_accounts::config` DTOs). Registering this module ALONE therefore
+//! produces an honest behavioural RED — two failing assertions on a build that
+//! succeeds — rather than a compile error. No production edit is needed to make
+//! it fail, and nothing here fakes the failure.
+//!
+//! WHAT IT PINS.
+//!
+//! 1. A reload must rebuild a bound backend from the EFFECTIVE compiled
+//!    configuration. Today `classify_backends` copies the RAW `BackendConfig`,
+//!    so a managed backend re-registered by a reload loses the
+//!    `identity_propagation` its descriptor compiled to and dispatches with no
+//!    per-user credential at all. That is the silent loss of managed
+//!    propagation.
+//!
+//! 2. A change to a descriptor a live backend is bound to must be VISIBLE to
+//!    the reload machinery. `accounts` is absent from both `MetaFields` and
+//!    `tracked_sections`, so today an issuer swap on a referenced descriptor is
+//!    invisible: no diff, no restart notice, and the old credentials keep being
+//!    reused under a descriptor that no longer describes them.
+//!
+//! The third test is the POSITIVE CONTROL: two identical configurations must
+//! stay an empty patch with nothing pending, so tests 1 and 2 cannot pass by
+//! making every reload look dirty.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+
+use crate::config::{BackendConfig, Config, TransportConfig};
+use crate::config_reload::{LiveConfig, compute_diff};
+use crate::identity_propagation::PropagationStrategyKind;
+use crate::personal_accounts::config::{
+    AccountDescriptor, AccountsConfig, AccountsLimits, DescriptorMode,
+};
+
+/// The descriptor id both the MCP backend and (in the sibling REST suite) a
+/// capability reference. Synthetic.
+const WORK: &str = "work-gmail";
+const OAUTH_ISSUER: &str = "https://accounts.google.invalid";
+const OTHER_ISSUER: &str = "https://accounts.evil.invalid";
+const RESOURCE: &str = "https://www.googleapis.invalid/drive/v3";
+
+/// A structurally complete `personal_managed` descriptor. `issuer` is a
+/// parameter because an issuer swap is the exact change test 2 drives.
+fn descriptor(issuer: &str) -> AccountDescriptor {
+    AccountDescriptor {
+        mode: DescriptorMode::PersonalManaged,
+        provider: "google".to_string(),
+        resource: Some(RESOURCE.to_string()),
+        issuer: Some(issuer.to_string()),
+        authorization_endpoint: Some(format!("{issuer}/o/oauth2/v2/auth")),
+        token_endpoint: Some(format!("{issuer}/token")),
+        revocation_endpoint: None,
+        client_id: Some("synthetic-google-client".to_string()),
+        client_secret_ref: Some("env:FIXTURE_ACCOUNT_CLIENT_SECRET".to_string()),
+        redirect_uri: Some("https://gateway.example.invalid/oauth/callback".to_string()),
+        scopes: Some(vec![
+            "https://www.googleapis.com/auth/drive.readonly".to_string(),
+        ]),
+        send_resource_parameter: Some(false),
+        external_strategy: None,
+    }
+}
+
+/// Synthetic store settings. Nothing here opens them: the reload diff reads the
+/// `descriptors` map only.
+fn accounts(issuer: &str) -> AccountsConfig {
+    AccountsConfig {
+        schema_version: "accounts.v1".to_string(),
+        enabled: true,
+        deployment: "single_process".to_string(),
+        instance_id: "reload-tests".to_string(),
+        store_dir: PathBuf::from("/synthetic/fixture/accounts/records"),
+        authority_dir: PathBuf::from("/synthetic/fixture/accounts/authority"),
+        current_key_id: "current".to_string(),
+        keys: BTreeMap::from([(
+            "current".to_string(),
+            "env:FIXTURE_ACCOUNT_STORE_KEY".to_string(),
+        )]),
+        descriptors: Some(
+            BTreeMap::from([(WORK.to_string(), descriptor(issuer))])
+                .into_iter()
+                .collect(),
+        ),
+        limits: AccountsLimits::default(),
+    }
+}
+
+fn bound_backend() -> BackendConfig {
+    BackendConfig {
+        enabled: true,
+        account: Some(WORK.to_string()),
+        transport: TransportConfig::Http {
+            http_url: "https://drive.invalid/mcp".to_string(),
+            streamable_http: true,
+            protocol_version: None,
+        },
+        ..BackendConfig::default()
+    }
+}
+
+/// A configuration declaring the descriptor, with or without the backend bound
+/// to it.
+fn config(issuer: &str, with_backend: bool) -> Config {
+    let mut backends = HashMap::new();
+    if with_backend {
+        backends.insert("drive".to_string(), bound_backend());
+    }
+    Config {
+        backends,
+        accounts: Some(accounts(issuer)),
+        ..Config::default()
+    }
+}
+
+/// RED 1 — the reload must hand `apply_patch` the EFFECTIVE configuration.
+///
+/// `apply_patch` constructs the replacement `Backend` straight from the config
+/// in the patch. If that config is the raw one, the rebuilt backend carries no
+/// `identity_propagation`, the managed descriptor compiled to nothing on the
+/// wire, and the account holder's credential is simply absent from the call the
+/// gateway then makes. The assertion is on the compiled `Vault` strategy and on
+/// the descriptor's own resource as the audience — the two fields custody
+/// addressing and cache isolation are both derived from.
+#[test]
+fn reload_patch_carries_the_effective_compiled_backend_config() {
+    let old = config(OAUTH_ISSUER, false);
+    let new = config(OAUTH_ISSUER, true);
+
+    let patch = compute_diff(&old, &new);
+
+    let (name, cfg) = patch
+        .backends_added
+        .iter()
+        .find(|(name, _)| name == "drive")
+        .expect("the newly bound backend must appear in the patch");
+    assert_eq!(name, "drive");
+
+    // The raw reference survives — this half passes today and is here so the
+    // failure below cannot be read as "the reference was dropped".
+    assert_eq!(
+        cfg.account.as_deref(),
+        Some(WORK),
+        "the descriptor reference must survive the diff verbatim"
+    );
+
+    let propagation = cfg.identity_propagation.as_ref().expect(
+        "a reload that rebuilds a bound backend from the RAW config silently loses managed \
+         propagation: the replacement would dispatch with no per-user credential at all",
+    );
+    assert_eq!(
+        propagation.strategy,
+        PropagationStrategyKind::Vault,
+        "personal_managed compiles to the EXISTING Vault kind, not a new enum"
+    );
+    assert_eq!(
+        propagation.audience, RESOURCE,
+        "the audience must be the descriptor's own resource, or custody addressing and the \
+         strategy's audience check disagree"
+    );
+    assert!(
+        propagation.required,
+        "a managed account has no best-effort mode"
+    );
+}
+
+/// RED 2 — an issuer swap on a REFERENCED descriptor must be visible.
+///
+/// The backends map is byte-identical across the two configurations; only the
+/// descriptor changed. `accounts` is not a tracked section today, so the reload
+/// reports nothing at all and the running process keeps serving credentials
+/// minted under the previous issuer. Reporting it as restart-pending is the
+/// fail-closed answer this slice implements — eager authority replacement is
+/// NOT implemented, and pretending otherwise is the failure mode this pins.
+#[test]
+fn a_changed_descriptor_issuer_is_reported_as_pending_restart() {
+    let live = LiveConfig::new(config(OAUTH_ISSUER, true));
+    live.set(config(OTHER_ISSUER, true));
+
+    let pending = live.pending_restart_fields();
+    assert!(
+        pending.contains(&"accounts"),
+        "an issuer change on a descriptor a live backend is bound to must not be invisible to \
+         the reload; pending fields were {pending:?}"
+    );
+    assert!(
+        live.restart_required(),
+        "the descriptor authority changed, so the running process has NOT applied the file"
+    );
+}
+
+/// POSITIVE CONTROL — an unchanged binding stays quiet.
+///
+/// Without this, both assertions above could be satisfied by a change that
+/// marks every reload dirty, which would make `restart_required` meaningless
+/// and train operators to ignore it.
+#[test]
+fn an_unchanged_account_binding_is_neither_diffed_nor_pending() {
+    let live = LiveConfig::new(config(OAUTH_ISSUER, true));
+    live.set(config(OAUTH_ISSUER, true));
+
+    assert!(
+        live.pending_restart_fields().is_empty(),
+        "an unchanged accounts block must not ask for a restart"
+    );
+    assert!(
+        compute_diff(&config(OAUTH_ISSUER, true), &config(OAUTH_ISSUER, true)).is_empty(),
+        "two identical configurations must produce an empty patch"
+    );
+}

--- a/src/config_reload/mod.rs
+++ b/src/config_reload/mod.rs
@@ -356,6 +356,14 @@ pub fn compute_diff(old: &Config, new: &Config) -> ConfigPatch {
 }
 
 #[cfg(test)]
+#[path = "account_reload_tests.rs"]
+mod account_reload_tests;
+
+#[cfg(test)]
+#[path = "account_reload_guard_tests.rs"]
+mod account_reload_guard_tests;
+
+#[cfg(test)]
 mod restart_required_tests {
     use super::LiveConfig;
     use crate::config::Config;
@@ -650,6 +658,13 @@ fn tracked_sections(running: &Config, wanted: &Config) -> Vec<(&'static str, boo
         "cache" => cache,
         "runtime" => runtime,
         "tasks" => tasks,
+        // Fail-closed on purpose. Eager replacement of a descriptor's authority,
+        // resource, issuer or scopes is NOT implemented, so an `accounts` edit
+        // is reported as outstanding until a restart rather than claimed as
+        // applied. A field wrongly counted tells an operator to restart when
+        // they need not; the reverse tells them a change took effect when it
+        // did not.
+        "accounts" => accounts,
         #[cfg(feature = "cost-governance")]
         "cost_governance" => cost_governance,
     ]
@@ -753,6 +768,11 @@ struct MetaFields {
     #[cfg(feature = "cost-governance")]
     cost_governance: String,
     tasks: String,
+    /// The `accounts` block. Absent from this comparison, an accounts-only edit
+    /// — a descriptor's issuer, resource or scopes — produced no diff at all,
+    /// so the reload reported nothing and the running gateway kept minting
+    /// under a descriptor the file had already replaced.
+    accounts: String,
 }
 
 impl MetaFields {
@@ -781,22 +801,32 @@ impl MetaFields {
             #[cfg(feature = "cost-governance")]
             cost_governance: canonical_json(&c.cost_governance),
             tasks: canonical_json(&c.tasks),
+            accounts: canonical_json(&c.accounts),
         }
     }
 }
 
 /// Partition backends into added / removed / modified buckets.
+///
+/// Compared and carried as EFFECTIVE configurations — what a bound backend
+/// actually runs with, from `config::account_bindings::effective_backends`.
+/// `apply_patch` constructs the replacement `Backend` straight from what it is
+/// handed, so a raw config here would drop the `identity_propagation` a managed
+/// descriptor compiled to and leave the replacement dispatching with no
+/// per-user credential at all. Comparing effective configs also means an
+/// unchanged binding stays byte-identical across a reload instead of appearing
+/// modified.
 fn classify_backends(old: &Config, new: &Config, patch: &mut ConfigPatch) {
     let runtime_changed = canonical_json(&old.runtime) != canonical_json(&new.runtime);
-    let old_enabled: std::collections::HashMap<&str, &BackendConfig> = old
-        .backends
+    let old_effective = crate::config::account_bindings::effective_backends(old);
+    let new_effective = crate::config::account_bindings::effective_backends(new);
+    let old_enabled: std::collections::HashMap<&str, &BackendConfig> = old_effective
         .iter()
         .filter(|(_, c)| c.enabled)
         .map(|(k, v)| (k.as_str(), v))
         .collect();
 
-    let new_enabled: std::collections::HashMap<&str, &BackendConfig> = new
-        .backends
+    let new_enabled: std::collections::HashMap<&str, &BackendConfig> = new_effective
         .iter()
         .filter(|(_, c)| c.enabled)
         .map(|(k, v)| (k.as_str(), v))
@@ -1715,6 +1745,23 @@ impl ReloadContext {
                 "{POSTURE_REFUSED_PREFIX} {} No backend was started or stopped, \
                  and no configuration was published. {restart}",
                 refusal.reason
+            ));
+        }
+
+        // A changed account binding cannot reuse the credentials minted under
+        // the descriptor it replaces: the descriptor's authority, resource,
+        // issuer, client id and requested scopes define the account key and the
+        // descriptor revision every existing lease carries. Eager replacement
+        // of those is not implemented in this slice, so this refuses and
+        // mutates nothing rather than pretending a live replacement happened.
+        // Compared against what is RUNNING, so it stays true until a restart.
+        if let Some(reason) = crate::config::account_bindings::reload_binding_refusal(
+            self.live_config.running(),
+            &new_config,
+        ) {
+            return Err(format!(
+                "{POSTURE_REFUSED_PREFIX} {reason} No backend was started or stopped, and no \
+                 configuration was published."
             ));
         }
 

--- a/src/gateway/meta_mcp/account_rest_fixture.rs
+++ b/src/gateway/meta_mcp/account_rest_fixture.rs
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Fixture for the REST managed-account consumer tests.
+//!
+//! REUSES THE PROVEN CUSTODY, ADDS ONLY A NETWORK. Every account primitive here
+//! comes from `account_resolver_fixture`: the REAL sealed store in a `TempDir`,
+//! the REAL `CustodyHandle` with its two exclusive locks, the REAL five-field
+//! account key, and the one faked seam (`ScriptedProvider`) that stands in for a
+//! network issuer. This module adds exactly two things the REST path needs and
+//! the MCP path did not: an isolated loopback HTTP capture endpoint, and the
+//! capability backend that dispatches to it.
+//!
+//! THE PRODUCTION INSTALLER, NOT AN INVENTED ONE. Strategies are installed by
+//! `gateway::server::account_bindings::install_account_strategies` — the same
+//! call `Gateway::start` makes — against a real `Config` whose `accounts` block
+//! declares the descriptors. Nothing here constructs a `VaultStrategy`, and
+//! nothing here compiles a propagation config of its own.
+//!
+//! THE ONE EXPLICIT SEAM. `CapabilityExecutionContext::verified_identity` is
+//! handed the fixture principal directly in the executor-level cases. That is
+//! the verification-context seam the increment adds; the MetaMcp control in the
+//! sibling test file is what proves the gateway actually fills it from
+//! `MetaMcpCallerContext` rather than from a `GrantSubject`, an API key or a
+//! display name.
+//!
+//! WHAT IS REAL ON THE WIRE. The capture endpoint is a real `axum` server bound
+//! to an ephemeral `127.0.0.1` port, reached by the production
+//! `CapabilityExecutor` HTTP client. An IP literal needs no DNS, so the client's
+//! `PinningResolver` is not in the way; the SSRF guard is opened for it by the
+//! EXISTING `allow_loopback_egress` flag, which is exactly the isolated-runtime
+//! escape hatch it was added for. A refusal is proved by ZERO recorded requests
+//! — an observed absence, not an unread buffer.
+//!
+//! NO SLEEPS, NO ENV READS, NO REAL PROVIDER. Every token, key and host here is
+//! synthetic and every `.invalid` host is unroutable by construction.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+
+use crate::backend::BackendRegistry;
+use crate::capability::{
+    CapabilityBackend, CapabilityDefinition, CapabilityExecutionContext, CapabilityExecutor,
+    parse_capability,
+};
+use crate::config::Config;
+use crate::gateway::meta_mcp::{MetaMcp, MetaMcpCallerContext};
+use crate::gateway::oauth::GatewayKeyPair;
+use crate::gateway::server::account_bindings::{
+    declare_account_descriptors, install_account_strategies,
+};
+use crate::identity_propagation::AccountStrategyRegistry;
+use crate::key_server::oidc::VerifiedIdentity;
+use crate::personal_accounts::config::{AccountsConfig, AccountsLimits, DescriptorMode};
+
+use super::account_resolver_fixture::{descriptor, identity};
+
+/// The capability backend name. The MetaMcp control addresses it as the server
+/// half of a `server:tool` reference, exactly as a client would.
+pub(super) const CAPABILITIES: &str = "capabilities";
+/// The one capability every case invokes. ONE tool and ONE argument set for
+/// every principal: identical requests are what make a crossed credential
+/// observable rather than inferred.
+pub(super) const TOOL: &str = "drive_read";
+
+// ── Capture endpoint ─────────────────────────────────────────────────────────
+
+/// Every request the capture endpoint saw, in order.
+///
+/// Records the `Authorization` header VALUE because that is the assertion: a
+/// crossed credential is only visible if the value is compared. Nothing else is
+/// kept, and the record never leaves the test process.
+#[derive(Default)]
+pub(super) struct Captured {
+    seen: Mutex<Vec<Option<String>>>,
+}
+
+impl Captured {
+    pub(super) fn count(&self) -> usize {
+        self.seen.lock().len()
+    }
+
+    pub(super) fn authorizations(&self) -> Vec<Option<String>> {
+        self.seen.lock().clone()
+    }
+
+    /// The single request a positive case expects; panics loudly on any other
+    /// count so "reached the endpoint" is never assumed.
+    pub(super) fn only(&self) -> String {
+        let seen = self.authorizations();
+        assert_eq!(seen.len(), 1, "expected exactly one captured request");
+        seen.into_iter()
+            .next()
+            .expect("checked above")
+            .expect("the captured request must carry an Authorization header")
+    }
+}
+
+async fn capture_handler(
+    axum::extract::State(state): axum::extract::State<Arc<Captured>>,
+    headers: axum::http::HeaderMap,
+) -> axum::Json<Value> {
+    let authorization = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let mut seen = state.seen.lock();
+    seen.push(authorization.clone());
+    // The body ECHOES the credential and a per-request sequence number, so a
+    // cache assertion can be made on the RESPONSE and not only on a counter: two
+    // dispatches can never produce the same body, and a body carrying another
+    // principal's credential is a crossed entry stated outright rather than
+    // inferred from a count.
+    axum::Json(json!({
+        "ok": true,
+        "seq": seen.len(),
+        "authorization": authorization,
+    }))
+}
+
+/// Bind a real HTTP endpoint on an ephemeral loopback port and start serving.
+///
+/// Returns the port so the capability's `base_url` names the endpoint that was
+/// actually bound — no fixed port, so parallel tests cannot collide.
+pub(super) async fn capture_endpoint() -> (u16, Arc<Captured>) {
+    let captured = Arc::new(Captured::default());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("the capture endpoint must bind a loopback port");
+    let port = listener
+        .local_addr()
+        .expect("the bound endpoint must report its address")
+        .port();
+    let router = axum::Router::new()
+        .route("/read", axum::routing::get(capture_handler))
+        .with_state(Arc::clone(&captured));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    (port, captured)
+}
+
+// ── Configuration and installation ───────────────────────────────────────────
+
+/// A durable audit sink. A managed descriptor compiles to `required: true`, and
+/// the mint path refuses to hand out a credential with no durable audit record,
+/// so every managed fixture needs one. Leaked for the process, as the existing
+/// propagation fixtures do.
+fn leaked_transparency_logger() -> Arc<crate::security::TransparencyLogger> {
+    use crate::security::TransparencyLogger;
+    use crate::security::transparency_log::TransparencyLogConfig;
+
+    let file = tempfile::NamedTempFile::new().expect("tempfile");
+    let path = file.path().to_string_lossy().to_string();
+    std::mem::forget(file);
+    Arc::new(
+        TransparencyLogger::open(Arc::new(TransparencyLogConfig {
+            enabled: true,
+            path,
+            key_id: "test".to_string(),
+            shared_secret: String::new(),
+        }))
+        .expect("logger opens"),
+    )
+}
+
+/// The `accounts` block. Store settings are SYNTHETIC and nothing here opens
+/// them: declaration and installation read the `descriptors` map, and the
+/// custody handed in is the separately started real fixture custody.
+///
+/// `overrides` lets a case replace a descriptor wholesale — the external and
+/// shared cases do exactly that, so mixed modes come from one code path.
+pub(super) fn rest_config(
+    descriptors: &[(&str, crate::personal_accounts::config::AccountDescriptor)],
+) -> Config {
+    Config {
+        backends: HashMap::new(),
+        accounts: Some(AccountsConfig {
+            schema_version: "accounts.v1".to_string(),
+            enabled: true,
+            deployment: "single_process".to_string(),
+            instance_id: "gateway-rest-consumer-tests".to_string(),
+            store_dir: PathBuf::from("/synthetic/fixture/accounts/records"),
+            authority_dir: PathBuf::from("/synthetic/fixture/accounts/authority"),
+            current_key_id: "current".to_string(),
+            keys: [(
+                "current".to_string(),
+                "env:FIXTURE_ACCOUNT_STORE_KEY".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            descriptors: Some(
+                descriptors
+                    .iter()
+                    .map(|(id, descriptor)| ((*id).to_string(), descriptor.clone()))
+                    .collect(),
+            ),
+            limits: AccountsLimits::default(),
+        }),
+        ..Config::default()
+    }
+}
+
+/// A `personal_managed` descriptor under `id`, straight from the proven fixture.
+pub(super) fn managed(id: &str) -> crate::personal_accounts::config::AccountDescriptor {
+    descriptor(id)
+}
+
+/// An `external` descriptor reusing the EXISTING `IdentityPropagationConfig`
+/// shape with `required: true`, as the contract restricts external mode to.
+pub(super) fn external(id: &str) -> crate::personal_accounts::config::AccountDescriptor {
+    let mut descriptor = descriptor(id);
+    descriptor.mode = DescriptorMode::External;
+    descriptor.external_strategy = Some(crate::identity_propagation::IdentityPropagationConfig {
+        strategy: crate::identity_propagation::PropagationStrategyKind::SignedAssertion,
+        audience: "https://partner.invalid/".to_string(),
+        required: true,
+        session_mode: crate::identity_propagation::SessionMode::Stateless,
+        token_exchange_endpoint: None,
+        token_exchange_scope: None,
+    });
+    descriptor
+}
+
+/// A `shared` descriptor: the deployment already serves this account
+/// statically, so nothing is installed and the legacy path must be preserved
+/// byte for byte.
+pub(super) fn shared(id: &str) -> crate::personal_accounts::config::AccountDescriptor {
+    let mut descriptor = descriptor(id);
+    descriptor.mode = DescriptorMode::Shared;
+    descriptor
+}
+
+/// A gateway whose account strategies were installed by the PRODUCTION
+/// installer, with the transparency log the mint path requires.
+///
+/// Returns the `MetaMcp` (the MetaMcp control needs it) and the registry both
+/// consumers share. The registry is the SAME object the installer wrote to and
+/// the same one the executor reads, so an MCP backend and a REST capability
+/// naming one descriptor hold one strategy instance, not two.
+pub(super) fn installed_gateway(
+    descriptors: &[(&str, crate::personal_accounts::config::AccountDescriptor)],
+    custody: &Arc<dyn crate::personal_accounts::AccountCustody>,
+) -> (Arc<MetaMcp>, Arc<AccountStrategyRegistry>) {
+    let mut meta = MetaMcp::new(Arc::new(BackendRegistry::new()));
+    meta.enable_transparency_log(leaked_transparency_logger());
+    let gateway_key = Arc::new(GatewayKeyPair::generate().expect("keygen"));
+    let config = rest_config(descriptors);
+    install_account_strategies(&config, Some(custody), &gateway_key, &meta)
+        .expect("the shared installer must accept the fixture configuration");
+    let registry = meta.account_strategies();
+    (Arc::new(meta), registry)
+}
+
+/// A registry that has DECLARED the descriptors but installed no strategy for
+/// them — the state a reload leaves behind when a binding is dropped between
+/// compilation and installation. Registration must still admit a capability
+/// naming a declared descriptor; DISPATCH is what must refuse.
+pub(super) fn declared_only(
+    descriptors: &[(&str, crate::personal_accounts::config::AccountDescriptor)],
+) -> Arc<AccountStrategyRegistry> {
+    let registry = Arc::new(AccountStrategyRegistry::default());
+    declare_account_descriptors(&rest_config(descriptors), &registry);
+    registry
+}
+
+// ── The capability under test ────────────────────────────────────────────────
+
+/// One REST capability. `account` names an `accounts.descriptors` map key and
+/// `key` is `oauth:<provider>`; both are parameters so a mismatch case states
+/// its mismatch instead of hiding it in a helper.
+pub(super) fn capability(base_url: &str, key: &str, account: Option<&str>) -> CapabilityDefinition {
+    let account_line = account.map_or_else(String::new, |id| format!("  account: {id}\n"));
+    parse_capability(&format!(
+        "name: {TOOL}\n\
+         description: Read one folder through a personal account\n\
+         auth:\n\
+         \x20 required: true\n\
+         \x20 type: bearer\n\
+         \x20 key: {key}\n\
+         {account_line}\
+         providers:\n\
+         \x20 primary:\n\
+         \x20   service: rest\n\
+         \x20   config:\n\
+         \x20     base_url: {base_url}\n\
+         \x20     path: /read\n\
+         \x20     method: GET\n"
+    ))
+    .expect("fixture capability must parse")
+}
+
+/// The capability backend a dispatch actually goes through, with the shared
+/// registry wired into its executor exactly as gateway startup wires it.
+///
+/// Registration goes through the production `register_capability`, so an
+/// unresolved account reference or a provider mismatch is refused HERE — at the
+/// real registration boundary — and the returned `Result` is the oracle.
+pub(super) fn backend_with(
+    registry: &Arc<AccountStrategyRegistry>,
+    capability: CapabilityDefinition,
+) -> crate::Result<Arc<CapabilityBackend>> {
+    let executor =
+        Arc::new(CapabilityExecutor::new().with_account_strategies(Arc::clone(registry)));
+    let backend = Arc::new(CapabilityBackend::new(CAPABILITIES, executor));
+    backend.register_capability(capability)?;
+    Ok(backend)
+}
+
+/// The SAME capability, made cacheable with an EXPLICIT positive TTL.
+///
+/// Without a `cache` block `is_cacheable()` is false and every "second call did
+/// not re-dispatch" assertion would be vacuous. Sixty seconds is far longer than
+/// any case here takes, so no test depends on wall-clock timing and none sleeps.
+pub(super) fn cacheable_capability(
+    base_url: &str,
+    key: &str,
+    account: Option<&str>,
+) -> CapabilityDefinition {
+    let account_line = account.map_or_else(String::new, |id| format!("  account: {id}\n"));
+    parse_capability(&format!(
+        "name: {TOOL}\n\
+         description: Read one folder through a personal account\n\
+         cache:\n\
+         \x20 ttl: 60\n\
+         \x20 strategy: memory\n\
+         auth:\n\
+         \x20 required: true\n\
+         \x20 type: bearer\n\
+         \x20 key: {key}\n\
+         {account_line}\
+         providers:\n\
+         \x20 primary:\n\
+         \x20   service: rest\n\
+         \x20   config:\n\
+         \x20     base_url: {base_url}\n\
+         \x20     path: /read\n\
+         \x20     method: GET\n"
+    ))
+    .expect("fixture cacheable capability must parse")
+}
+
+/// The base URL a CACHING case must use.
+///
+/// `allow_loopback_egress` is what lets the other cases reach an IP literal —
+/// and it also disables the response cache by design, so a warm-cache test
+/// cannot use it. `localhost` is a NAME, so it clears the SSRF guard on its own
+/// and the enforcing (uncached-flag-free) context applies. Only DNS pinning is
+/// then in the way, which is why these cases swap the client below.
+pub(super) fn cacheable_base_url(port: u16) -> String {
+    format!("http://localhost:{port}")
+}
+
+/// Finite-timeout client for the swapped-client caching fixtures, mirroring
+/// `capability::executor_tests::finite_http_client`: a bare client has no
+/// request timeout and a hung listener would stall the suite.
+fn finite_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("the fixture HTTP client must build")
+}
+
+/// An executor whose response cache is LIVE for these dispatches.
+///
+/// `legacy_token` seeds the gateway-held `oauth:google` login — the TRAP. It is
+/// the credential a fallback would reach for, so a refusal that leaves it
+/// unused and unrecorded at the endpoint is what proves nothing fell back.
+pub(super) fn caching_executor(
+    registry: &Arc<AccountStrategyRegistry>,
+    legacy_token: Option<(&str, &tempfile::TempDir)>,
+) -> CapabilityExecutor {
+    let executor = match legacy_token {
+        Some((token, dir)) => {
+            let storage = Arc::new(
+                crate::oauth::TokenStorage::new(dir.path().to_path_buf())
+                    .expect("token storage opens"),
+            );
+            let executor = CapabilityExecutor::with_token_storage(storage);
+            executor.set_oauth_token(
+                "google",
+                crate::oauth::TokenInfo {
+                    expires_at: Some(u64::MAX),
+                    ..crate::oauth::TokenInfo::from_response(
+                        token.to_string(),
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                },
+            );
+            executor
+        }
+        None => CapabilityExecutor::new(),
+    };
+    executor
+        .with_account_strategies(Arc::clone(registry))
+        .with_test_http_client(finite_http_client())
+}
+
+/// The context a CACHING dispatch carries: verified identity, no loopback
+/// relaxation (so the cache is live), no invoke snapshot (a standalone executor
+/// keys without one).
+pub(super) fn caching_context(subject: &str) -> CapabilityExecutionContext {
+    CapabilityExecutionContext::default().with_verified_identity(Arc::new(identity(subject)))
+}
+
+/// Resolve the account NOW and carry the result, exactly as the invoke path
+/// does before the executor is entered. Returns the context the executor will
+/// then RECHECK — which is the only way to place a revocation strictly between
+/// the resolve and the cache lookup.
+pub(super) async fn prepared_caching_context(
+    registry: &Arc<AccountStrategyRegistry>,
+    subject: &str,
+    account: &str,
+    key: &str,
+) -> CapabilityExecutionContext {
+    let verified = Arc::new(identity(subject));
+    match registry
+        .resolve(account, key, Some(verified.as_ref()))
+        .await
+        .expect("the account must resolve while the grant is still current")
+    {
+        crate::identity_propagation::AccountCredential::Prepared(prepared) => {
+            CapabilityExecutionContext::default()
+                .with_verified_identity(verified)
+                .with_account_credential(prepared)
+        }
+        crate::identity_propagation::AccountCredential::Legacy => {
+            panic!("the fixture descriptor is managed, not shared")
+        }
+    }
+}
+
+// ── Already-expired external strategy ────────────────────────────────────────
+
+/// An external strategy whose issuer publishes an expiry ALREADY IN THE PAST.
+///
+/// This is the shape of a real external credential that came back stale: the
+/// mint succeeds, the headers are usable, and only `expires_at` says it must not
+/// be used. Nothing else about it is unusual, which is precisely why it has to
+/// be refused on the expiry alone.
+struct AlreadyExpiredStrategy {
+    audience: String,
+}
+
+#[async_trait::async_trait]
+impl crate::identity_propagation::IdentityPropagation for AlreadyExpiredStrategy {
+    async fn propagate(
+        &self,
+        identity: &VerifiedIdentity,
+        _backend: &crate::identity_propagation::BackendDescriptor,
+    ) -> std::result::Result<
+        crate::identity_propagation::PropagatedCredential,
+        crate::identity_propagation::PropagationError,
+    > {
+        let subject_key = identity.stable_actor_id();
+        Ok(crate::identity_propagation::PropagatedCredential {
+            headers: vec![(
+                "Authorization".to_string(),
+                format!("Bearer {EXPIRED_EXTERNAL_TOKEN}"),
+            )],
+            // One hour in the past. Not zero, not "unset": a concrete, published
+            // expiry that has demonstrably passed.
+            expires_at: chrono::Utc::now().timestamp() - 3600,
+            cache_binding: format!("expired-external|{subject_key}"),
+            subject_key,
+            audience: self.audience.clone(),
+            scopes: Vec::new(),
+        })
+    }
+}
+
+/// The token the expired external strategy would have put on the wire. A
+/// refusal must never carry it and the endpoint must never see it.
+pub(super) const EXPIRED_EXTERNAL_TOKEN: &str = "synthetic-expired-external-token-4b7e";
+
+/// Declare and install an `external` descriptor backed by the already-expired
+/// strategy above.
+///
+/// Installed through the SAME `AccountStrategyRegistry::install` the production
+/// installer calls, with `managed: None` — which is what an external descriptor
+/// compiles to and what makes this the real external code path rather than a
+/// managed one with a flag flipped. `required` is false only so the case needs
+/// no transparency log; the expiry is the subject.
+pub(super) fn installed_expired_external(id: &str) -> Arc<AccountStrategyRegistry> {
+    let registry = Arc::new(AccountStrategyRegistry::default());
+    let audience = "https://partner.invalid/".to_string();
+    let strategy: Arc<dyn crate::identity_propagation::IdentityPropagation> =
+        Arc::new(AlreadyExpiredStrategy {
+            audience: audience.clone(),
+        });
+    registry.install(
+        crate::identity_propagation::InstalledAccount {
+            descriptor_id: id.to_string(),
+            provider: "google".to_string(),
+            audience,
+            required: false,
+            token_exchange_endpoint: None,
+            token_exchange_scope: None,
+            strategy,
+            managed: None,
+        },
+        DescriptorMode::External,
+    );
+    registry
+}
+
+/// The request-scoped context a dispatch carries.
+///
+/// `allow_loopback_egress` is the EXISTING isolated-runtime flag and is what
+/// lets the production client reach the capture endpoint's IP literal; it is
+/// never set by general capability execution. `verified_identity` is the seam
+/// under test.
+pub(super) fn context(subject: Option<&str>) -> CapabilityExecutionContext {
+    let context = CapabilityExecutionContext::default().with_isolated_loopback_egress();
+    match subject {
+        Some(subject) => context.with_verified_identity(Arc::new(identity(subject))),
+        None => context,
+    }
+}
+
+/// Invoke the capability through the backend, with no arguments.
+pub(super) async fn call(
+    backend: &CapabilityBackend,
+    subject: Option<&str>,
+) -> crate::Result<crate::protocol::ToolsCallResult> {
+    backend
+        .call_tool_with_context(TOOL, json!({}), context(subject))
+        .await
+}
+
+// ── MetaMcp threading control ────────────────────────────────────────────────
+
+static ALLOW_ALL: crate::gateway::authz::AllowAll = crate::gateway::authz::AllowAll;
+
+fn caller(verified_identity: Option<&VerifiedIdentity>) -> MetaMcpCallerContext<'_> {
+    MetaMcpCallerContext {
+        task: None,
+        signing: None,
+        execution: None,
+        credential_principal: None,
+        is_modern: false,
+        // The legacy fixture negotiates the current published revision so the
+        // revision-keyed caches behave as they do for a real session.
+        protocol_revision: Some(crate::protocol::PROTOCOL_VERSION),
+        authorizer: &ALLOW_ALL,
+        verified_identity,
+        api_key_name: None,
+        agent_id: None,
+        grant_subject: None,
+        is_admin: false,
+        input_capabilities: crate::protocol::meta::Declared::NONE,
+        retry: &crate::protocol::mrtr::NO_RETRY,
+        confirmation: crate::gateway::destructive_confirmation::ConfirmationChannel::Unavailable,
+    }
+}
+
+/// THE MetaMcp action: the real Code Mode dispatch entry, which routes through
+/// `invoke_tool` and reaches the capability backend exactly as production
+/// traffic does. The identity handed in is a fixture principal; what the control
+/// proves is that the gateway carries THAT value to the executor rather than
+/// inventing one from a grant subject or an API key name.
+pub(super) async fn meta_execute(meta: &MetaMcp, subject: Option<&str>) -> crate::Result<Value> {
+    let verified = subject.map(identity);
+    let context = caller(verified.as_ref());
+    let args = json!({
+        "tool": format!("{CAPABILITIES}:{TOOL}"),
+        "arguments": {},
+    });
+    meta.code_mode_execute(&args, Some("rest-fixture-session"), &context)
+        .await
+}

--- a/src/gateway/meta_mcp/account_rest_fixture.rs
+++ b/src/gateway/meta_mcp/account_rest_fixture.rs
@@ -293,6 +293,46 @@ pub(super) fn capability(base_url: &str, key: &str, account: Option<&str>) -> Ca
     .expect("fixture capability must parse")
 }
 
+/// The SAME account-bound capability, with ONE genuinely required argument.
+///
+/// The default fixture capability declares no schema, so every dispatch of it
+/// is well formed and no case could state what happens to a MALFORMED one.
+/// A single required string is the smallest schema that makes `json!({})` an
+/// invalid call — and the resulting rejection is the production
+/// `validate_arguments` refusal, not a test-only branch.
+pub(super) fn capability_requiring_argument(
+    base_url: &str,
+    key: &str,
+    account: Option<&str>,
+) -> CapabilityDefinition {
+    let account_line = account.map_or_else(String::new, |id| format!("  account: {id}\n"));
+    parse_capability(&format!(
+        "name: {TOOL}\n\
+         description: Read one named folder through a personal account\n\
+         schema:\n\
+         \x20 input:\n\
+         \x20   type: object\n\
+         \x20   properties:\n\
+         \x20     folder:\n\
+         \x20       type: string\n\
+         \x20       description: The folder to read\n\
+         \x20   required: [folder]\n\
+         auth:\n\
+         \x20 required: true\n\
+         \x20 type: bearer\n\
+         \x20 key: {key}\n\
+         {account_line}\
+         providers:\n\
+         \x20 primary:\n\
+         \x20   service: rest\n\
+         \x20   config:\n\
+         \x20     base_url: {base_url}\n\
+         \x20     path: /read\n\
+         \x20     method: GET\n"
+    ))
+    .expect("fixture capability with a required argument must parse")
+}
+
 /// The capability backend a dispatch actually goes through, with the shared
 /// registry wired into its executor exactly as gateway startup wires it.
 ///
@@ -400,6 +440,30 @@ pub(super) fn caching_executor(
     executor
         .with_account_strategies(Arc::clone(registry))
         .with_test_http_client(finite_http_client())
+}
+
+/// A CACHING capability backend that declares itself MULTI-USER, exactly as
+/// `MetaMcp::set_multi_user`/`set_capabilities` declare it at gateway startup.
+///
+/// Nothing here is a test-only posture: `set_multi_user(true)` is the same
+/// production setter `Gateway::start` calls once
+/// `AuthConfig::implies_multi_user` is true, and the executor is the EXISTING
+/// [`caching_executor`] — so the live response cache, the account registry and
+/// the seeded legacy `oauth:google` trap are all the ones the sibling
+/// single-user caching cases already use. The ONLY difference from those cases
+/// is the multi-user declaration and the fact that the dispatch goes through
+/// `CapabilityBackend::call_tool_with_context`, which is where the
+/// per-user OAuth isolation guard runs.
+pub(super) fn multi_user_caching_backend(
+    registry: &Arc<AccountStrategyRegistry>,
+    legacy_token: Option<(&str, &tempfile::TempDir)>,
+    capability: CapabilityDefinition,
+) -> crate::Result<Arc<CapabilityBackend>> {
+    let executor = Arc::new(caching_executor(registry, legacy_token));
+    let backend = Arc::new(CapabilityBackend::new(CAPABILITIES, executor));
+    backend.register_capability(capability)?;
+    backend.set_multi_user(true);
+    Ok(backend)
 }
 
 /// The context a CACHING dispatch carries: verified identity, no loopback

--- a/src/gateway/meta_mcp/account_rest_tests.rs
+++ b/src/gateway/meta_mcp/account_rest_tests.rs
@@ -29,14 +29,15 @@ use crate::identity_propagation::AccountStrategyRegistry;
 use crate::personal_accounts::AccountCustody;
 
 use super::account_resolver_fixture::{
-    ALICE_WORK_TOKEN, BOB_WORK_TOKEN, PERSONAL, STATIC_FALLBACK, WORK, account_key, custody_with,
-    grant,
+    ALICE_PERSONAL_TOKEN, ALICE_WORK_TOKEN, BOB_WORK_TOKEN, PERSONAL, STATIC_FALLBACK, WORK,
+    account_key, custody_with, grant, identity,
 };
 use super::account_rest_fixture::{
-    Captured, EXPIRED_EXTERNAL_TOKEN, backend_with, cacheable_base_url, cacheable_capability,
-    caching_context, caching_executor, call, capability, capture_endpoint, context, declared_only,
-    external, installed_expired_external, installed_gateway, managed, meta_execute,
-    prepared_caching_context, shared,
+    Captured, EXPIRED_EXTERNAL_TOKEN, TOOL, backend_with, cacheable_base_url, cacheable_capability,
+    caching_context, caching_executor, call, capability, capability_requiring_argument,
+    capture_endpoint, context, declared_only, external, installed_expired_external,
+    installed_gateway, managed, meta_execute, multi_user_caching_backend, prepared_caching_context,
+    shared,
 };
 
 /// The gateway-held login a fallback would reach for. Seeded in the caching
@@ -713,4 +714,560 @@ async fn an_executor_with_no_account_catalogue_refuses_a_managed_capability() {
         .expect_err("an undeclared account reference has nothing to resolve against");
 
     assert_no_credential_leaked(&error, &captured);
+}
+
+// ── Multi-user gateways ──────────────────────────────────────────────────────
+//
+// EVERY CASE ABOVE RUNS ON A BACKEND THAT NEVER DECLARED ITSELF MULTI-USER.
+// `CapabilityBackend::multi_user` defaults to false, so
+// `call_tool_with_context` never reaches the per-user OAuth isolation guard
+// (`capability::execution_context::validate_oauth_isolation`) in any of them —
+// which means none of them says anything about the deployment this whole
+// account boundary exists for: the one that serves Alice AND Bob.
+//
+// A real gateway sets that flag through `MetaMcp::set_multi_user` /
+// `set_capabilities` as soon as `AuthConfig::implies_multi_user` is true (see
+// `gateway::server`), and the guard then runs BEFORE the executor. It decides on
+// `auth.key`, `auth.shared_account` and `metadata.exposure` alone — it never
+// looks at `auth.account` — so a capability bound to a managed descriptor, whose
+// credential IS minted per verified caller by the account registry, is refused
+// with JSON-RPC -32001 before custody is ever consulted.
+//
+// The cases below declare the multi-user posture with the PRODUCTION setter and
+// change nothing else. NOTHING here sets `auth.shared_account = true` and
+// NOTHING marks a capability `exposure: personal`: either would silence the
+// guard and hide the defect instead of stating it. The descriptorless control at
+// the end pins the guard's genuine job so a fix cannot be a deletion.
+
+/// THE HEADLINE MULTI-USER CASE.
+///
+/// Byte for byte the setup of
+/// `alice_and_bob_receive_their_own_account_credentials_from_one_rest_capability`,
+/// with ONE addition: `set_multi_user(true)`. The credential each principal gets
+/// is minted from their own grant under real custody, so per-user isolation is
+/// already structurally guaranteed here — this is precisely the deployment the
+/// account binding was built for, and it is the one where the dispatch is
+/// currently refused before the executor runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn alice_and_bob_receive_their_own_account_credentials_on_a_multi_user_gateway() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[
+        (account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH)),
+        (account_key("bob", WORK), grant(BOB_WORK_TOKEN, FRESH)),
+    ]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("a capability naming a declared descriptor with a matching provider must register");
+    // The production setter, the same one gateway startup calls.
+    backend.set_multi_user(true);
+
+    call(&backend, Some("alice"))
+        .await
+        .expect("Alice's dispatch must reach the endpoint on a multi-user gateway");
+    call(&backend, Some("bob"))
+        .await
+        .expect("Bob's dispatch must reach the endpoint on a multi-user gateway");
+
+    let seen = captured.authorizations();
+    assert_eq!(seen.len(), 2, "both dispatches must reach the endpoint");
+    assert_eq!(
+        seen[0].as_deref(),
+        Some(format!("Bearer {ALICE_WORK_TOKEN}").as_str()),
+        "Alice must be served her own account's credential"
+    );
+    assert_eq!(
+        seen[1].as_deref(),
+        Some(format!("Bearer {BOB_WORK_TOKEN}").as_str()),
+        "Bob must be served his own account's credential, not Alice's"
+    );
+    assert_eq!(
+        custody.releases(),
+        6,
+        "each dispatch releases once resolving the account for the isolation guard, then \
+         rechecks in the executor's own preparation and again before egress — three per \
+         dispatch, one more than the single-user sibling's two, and every one of them a real \
+         custody recheck rather than a second mint"
+    );
+}
+
+/// THE MetaMcp MULTI-USER THREADING CASE.
+///
+/// The sibling control
+/// (`meta_mcp_capability_dispatch_carries_the_verified_identity_to_the_account_boundary`)
+/// proves the gateway carries the verified identity to the account boundary on a
+/// single-user gateway. This drives the SAME real Code Mode entry with
+/// `MetaMcp::set_multi_user(true)` — which propagates the posture to the
+/// registered capability backend — against the same unroutable host, so the wire
+/// is irrelevant and custody is the observable.
+///
+/// The anonymous run must still refuse and never reach custody. The verified run
+/// must reach custody and pass the real release recheck, with the SAME release
+/// count the single-user control records: multi-user changes who may call, never
+/// how a verified caller's own credential is released.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn meta_mcp_multi_user_dispatch_reaches_the_account_boundary_for_a_verified_caller() {
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(UNROUTABLE, "oauth:google", Some(WORK)),
+    )
+    .expect("the capability must register");
+    meta.set_capabilities(Arc::clone(&backend));
+    // Set AFTER `set_capabilities`: one of the two startup orders the production
+    // setters are documented to keep in sync.
+    meta.set_multi_user(true);
+
+    let anonymous = meta_execute(&meta, None)
+        .await
+        .expect_err("an unverified caller must not reach a managed account");
+    assert!(
+        !anonymous.to_string().contains(ALICE_WORK_TOKEN),
+        "the refusal must not carry the account token"
+    );
+    assert_eq!(
+        custody.releases(),
+        0,
+        "an unverified Code Mode dispatch must never reach custody"
+    );
+
+    let _ = meta_execute(&meta, Some("alice")).await;
+    assert_eq!(
+        custody.releases(),
+        4,
+        "the invoke path mints once; the multi-user isolation guard then RECHECKS that same \
+         carried credential rather than minting a second one, and the executor's preparation \
+         and pre-egress recheck follow — one more recheck than the single-user control's \
+         three, and no additional mint"
+    );
+    assert_eq!(
+        custody.refreshes(),
+        0,
+        "the seeded grant is fresh, so nothing may hit the refresh provider"
+    );
+}
+
+/// ALICE'S IDENTICAL SECOND REQUEST IS SERVED FROM THE WARM CACHE ON A
+/// MULTI-USER GATEWAY, AND THE LEGACY LOGIN IS NEVER TOUCHED.
+///
+/// Same shape as `an_identical_second_request_from_alice_is_served_from_the_warm_cache`
+/// — explicit positive TTL, `localhost` base URL, no loopback relaxation so the
+/// cache is live — but dispatched through the multi-user `CapabilityBackend`,
+/// which is where the isolation guard sits. A valid gateway-held `oauth:google`
+/// token is seeded as the TRAP: it is exactly the credential the guard exists to
+/// keep out of a second caller's hands, and a descriptor-bound dispatch must
+/// never present it, cached or not.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn alices_second_identical_request_hits_the_warm_cache_on_a_multi_user_gateway() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let backend = multi_user_caching_backend(
+        &registry,
+        Some((LEGACY_TRAP_TOKEN, &dir)),
+        cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("a capability naming a declared descriptor must register");
+
+    let first = backend
+        .call_tool_with_context(TOOL, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice's first dispatch must reach the endpoint on a multi-user gateway");
+    assert!(!first.is_error, "the first dispatch must not be an error");
+    assert_eq!(
+        captured.count(),
+        1,
+        "the first dispatch must actually go on the wire and prime the cache"
+    );
+    assert_eq!(
+        captured.authorizations()[0].as_deref(),
+        Some(format!("Bearer {ALICE_WORK_TOKEN}").as_str()),
+        "Alice must be served her own account's credential, never the seeded legacy trap"
+    );
+
+    let second = backend
+        .call_tool_with_context(TOOL, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice's identical second dispatch must succeed");
+
+    assert_eq!(
+        captured.count(),
+        1,
+        "the identical second request must be served from cache: the endpoint's request count \
+         must not move"
+    );
+    // `ToolsCallResult` carries no `PartialEq`, so its serialized form is what is
+    // compared. That form includes the per-request sequence number the endpoint
+    // stamps, which a re-dispatch could not reproduce.
+    let (first, second) = (
+        serde_json::to_value(&first).expect("a tool result serializes"),
+        serde_json::to_value(&second).expect("a tool result serializes"),
+    );
+    assert_eq!(
+        first, second,
+        "a warm cache hit must return the stored body verbatim, sequence number included"
+    );
+    assert!(
+        !second.to_string().contains(LEGACY_TRAP_TOKEN),
+        "no dispatch on this path may present the gateway-held legacy login"
+    );
+    assert_eq!(
+        custody.releases(),
+        5,
+        "the cold dispatch releases three times (guard resolve, executor preparation recheck, \
+         pre-egress recheck) and the warm hit twice (guard resolve, executor preparation \
+         recheck) — the cache is consulted only AFTER custody has re-consented, so a \
+         revocation can never be papered over by a warm entry"
+    );
+}
+
+/// NO VERIFIED IDENTITY STILL REFUSES ON A MULTI-USER GATEWAY.
+///
+/// A change that admits descriptor-bound capabilities must not admit a caller
+/// the gateway never verified. Refusal, zero requests at the endpoint, and no
+/// credential released — stated without naming WHICH refusal, so the case holds
+/// whether the isolation guard or the account boundary is what fails closed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_request_with_no_verified_identity_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("registration is unaffected by the absence of a caller");
+    backend.set_multi_user(true);
+
+    let error = call(&backend, None)
+        .await
+        .expect_err("a managed account cannot be resolved without a verified caller");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "no credential may be released for a caller the gateway has not verified"
+    );
+}
+
+/// A DECLARED DESCRIPTOR WITH NO INSTALLED STRATEGY STILL REFUSES ON A
+/// MULTI-USER GATEWAY.
+///
+/// The reload gap, under the posture that matters most: with no strategy there
+/// is no per-user credential to mint, so admitting the dispatch could only mean
+/// falling through to the gateway-held login — the exact leak. Registration is
+/// still admitted; DISPATCH must fail closed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_declared_account_with_no_installed_strategy_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let registry = declared_only(&[(WORK, managed(WORK))]);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("a declared descriptor is a valid reference at registration time");
+    backend.set_multi_user(true);
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("no installed strategy means no credential, and no substitute");
+
+    assert_no_credential_leaked(&error, &captured);
+}
+
+/// A REVOKED GRANT STILL REFUSES ON A MULTI-USER GATEWAY.
+///
+/// The revocation is applied through the REAL `CustodyHandle`, so what refuses
+/// is the production recheck. Admitting descriptor-bound capabilities must not
+/// weaken it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_revoked_grant_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let alice = account_key("alice", WORK);
+    let custody = custody_with(&[(alice.clone(), grant(ALICE_WORK_TOKEN, FRESH))]);
+    custody
+        .handle
+        .invalidate(&alice)
+        .await
+        .expect("revocation must be applied");
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("registration does not consult grant state");
+    backend.set_multi_user(true);
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("a revoked account has no credential to serve");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "the release observer must record no successful release"
+    );
+}
+
+/// THE GUARD'S GENUINE JOB IS UNCHANGED.
+///
+/// A capability with NO `auth.account` on `oauth:google` has exactly one
+/// credential available to it: the single gateway-held login, served to whoever
+/// calls. That is the cross-user leak the isolation guard closes, and it must go
+/// on refusing with JSON-RPC -32001 on a multi-user gateway — verified caller or
+/// not. A change that admits descriptor-bound capabilities by relaxing or
+/// deleting the guard fails HERE.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_gateway_still_refuses_a_capability_with_no_account_reference() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    // No `account:` line at all — the legacy gateway-held OAuth shape.
+    let backend = backend_with(&registry, capability(&base_url(port), "oauth:google", None))
+        .expect("a capability with no account reference registers as it always has");
+    backend.set_multi_user(true);
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("a gateway-held OAuth login is not isolated per user");
+    let text = error.to_string();
+    assert!(
+        text.contains("not isolated per user"),
+        "the refusal must be the per-user OAuth isolation guard: {text}"
+    );
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "an unbound capability must never reach custody"
+    );
+}
+
+/// A `shared` DESCRIPTOR STILL FACES THE UNCHANGED GUARD.
+///
+/// This is the case that separates "the account boundary minted a per-caller
+/// credential" from "the capability merely NAMES an account". A `shared`
+/// descriptor resolves to `AccountCredential::Legacy` — there is no per-caller
+/// credential, only the gateway-held login again — so the dispatch must be
+/// refused with the SAME -32001 an unbound capability gets. A fix that keyed the
+/// exception on `auth.account` being present, rather than on a credential
+/// actually having been prepared for this caller, fails HERE.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_shared_descriptor_is_still_refused_by_the_isolation_guard() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(
+        account_key("alice", PERSONAL),
+        grant(ALICE_PERSONAL_TOKEN, FRESH),
+    )]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(PERSONAL, shared(PERSONAL))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(PERSONAL)),
+    )
+    .expect("a shared descriptor is a declared descriptor and registers normally");
+    backend.set_multi_user(true);
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("a shared descriptor serves the gateway-held login, which is not isolated");
+    let text = error.to_string();
+    assert!(
+        text.contains("not isolated per user"),
+        "the refusal must be the unchanged per-user OAuth isolation guard: {text}"
+    );
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "a shared descriptor has no custody requirement and must not consult it"
+    );
+}
+
+/// A GRANT SUBJECT IS NOT AN ACCOUNT IDENTITY, ON A MULTI-USER GATEWAY EITHER.
+///
+/// `caller_identity` is a `GrantSubject`: an authorization handle whose
+/// authority is not an OAuth issuer. The request below carries one and carries
+/// NO `VerifiedIdentity`, so there is no issuer+subject pair from which a
+/// managed account key could be built. Admitting it would mean minting — or
+/// worse, falling back — for a principal the gateway never verified.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_grant_subject_alone_does_not_authorize_a_managed_account() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("the capability must register");
+    backend.set_multi_user(true);
+
+    let grant_subject_only = crate::capability::CapabilityExecutionContext::with_caller_identity(
+        crate::identity_grants::GrantSubject::new("cloudflare_access", "alice", None),
+    )
+    .with_isolated_loopback_egress();
+
+    let error = backend
+        .call_tool_with_context(TOOL, json!({}), grant_subject_only)
+        .await
+        .expect_err("a grant subject cannot stand in for a verified end-user identity");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "no credential may be released for a principal the gateway has not verified"
+    );
+}
+
+/// A CARRIED CREDENTIAL MINTED FOR ANOTHER DESCRIPTOR IS REFUSED BEFORE HTTP.
+///
+/// The credential is genuine, current, and belongs to this very caller — it is
+/// simply the wrong ACCOUNT. Presenting it would serve Alice's personal mailbox
+/// credential to a capability bound to her work account, so the exception must
+/// turn on the descriptor the credential was minted for and not merely on the
+/// presence of one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_carried_credential_for_another_descriptor_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[
+        (account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH)),
+        (
+            account_key("alice", PERSONAL),
+            grant(ALICE_PERSONAL_TOKEN, FRESH),
+        ),
+    ]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(
+        &[(WORK, managed(WORK)), (PERSONAL, managed(PERSONAL))],
+        &installed,
+    );
+    let backend = multi_user_caching_backend(
+        &registry,
+        None,
+        cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("the work-bound capability must register");
+    // Minted for PERSONAL, carried into a dispatch of the WORK-bound capability.
+    let wrong_account =
+        prepared_caching_context(&registry, "alice", PERSONAL, "oauth:google").await;
+
+    let error = backend
+        .call_tool_with_context(TOOL, json!({}), wrong_account)
+        .await
+        .expect_err("one capability's account credential must never excuse another's");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert!(
+        !error.to_string().contains(ALICE_PERSONAL_TOKEN),
+        "the refusal must not carry the mismatched account's token"
+    );
+    assert_eq!(
+        custody.releases(),
+        1,
+        "only the fixture's own mint for PERSONAL may appear; the dispatch must consume no \
+         further custody"
+    );
+}
+
+/// A CARRIED CREDENTIAL MINTED FOR ANOTHER CALLER IS REFUSED BEFORE HTTP.
+///
+/// The descriptor and the auth key both match; only the ACTOR differs. This is
+/// the exact substitution the exception's `stable_actor_id` conjunct exists to
+/// stop — Bob presenting a request that carries Alice's prepared credential —
+/// and it must be refused by the live registry recheck, before any cache lookup
+/// and before the wire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_carried_credential_for_another_caller_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = multi_user_caching_backend(
+        &registry,
+        None,
+        cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("the capability must register");
+    // Alice's real credential, presented under Bob's verified identity.
+    let alices_credential_bobs_request =
+        prepared_caching_context(&registry, "alice", WORK, "oauth:google")
+            .await
+            .with_verified_identity(Arc::new(identity("bob")));
+
+    let error = backend
+        .call_tool_with_context(TOOL, json!({}), alices_credential_bobs_request)
+        .await
+        .expect_err("a credential minted for Alice must not be served for Bob");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        1,
+        "only the fixture's own mint for Alice may appear; the mismatched dispatch must consume \
+         no further custody"
+    );
+}
+
+/// AN INVALID CALL ACQUIRES NO CREDENTIAL AT ALL.
+///
+/// Resolving the account is not free: it takes a real custody lease and burns a
+/// release against the account's audit record. A call that is about to be
+/// rejected for a missing required argument never happens, so it must never
+/// consume one. This pins the ORDER — path selector and schema validation
+/// strictly before any custody work — which is otherwise invisible, because a
+/// resolve-then-reject implementation returns the very same error to the caller.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_multi_user_dispatch_with_invalid_arguments_acquires_no_credential() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability_requiring_argument(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("the capability must register");
+    backend.set_multi_user(true);
+
+    // `folder` is required, and this verified caller COULD have resolved her
+    // account — so a release here would be an acquisition made for nothing.
+    let result = call(&backend, Some("alice"))
+        .await
+        .expect("a schema violation is reported as a tool error, not a transport failure");
+
+    assert!(
+        result.is_error,
+        "a call missing a required argument must be rejected"
+    );
+    assert_eq!(
+        captured.count(),
+        0,
+        "an invalid call must never reach the endpoint"
+    );
+    assert_eq!(
+        custody.releases(),
+        0,
+        "an invalid call must never acquire, release or recheck an account credential"
+    );
+    assert!(
+        !serde_json::to_string(&result)
+            .expect("a tool result serializes")
+            .contains(ALICE_WORK_TOKEN),
+        "a validation error must not carry account credential material"
+    );
 }

--- a/src/gateway/meta_mcp/account_rest_tests.rs
+++ b/src/gateway/meta_mcp/account_rest_tests.rs
@@ -1,0 +1,716 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! REST capabilities dispatching through the ONE account credential boundary.
+//!
+//! THE CLAIM UNDER TEST. A REST capability whose `auth.account` names an
+//! `accounts.descriptors` map key executes as the VERIFIED caller, using the
+//! same `IdentityPropagation` strategy instance the shared installer built for
+//! that descriptor — the same custody, the same five-field account key, the same
+//! mandatory release recheck an MCP backend gets. Not a second store, not a
+//! second auth enum, not a managed-token branch beside the resolver.
+//!
+//! THE REFUSALS ARE PROVED BY ABSENCE. Every negative case asserts ZERO requests
+//! at the real capture endpoint. That is what "before HTTP and before the legacy
+//! operator OAuth lookup" means operationally: the endpoint would have recorded
+//! a call, and the legacy path would have produced the gateway-held token, so a
+//! recorded count of zero and an error that does not carry a token is the only
+//! outcome that can pass.
+//!
+//! THE POSITIVE CONTROL IS FIRST. If the endpoint were unreachable every
+//! refusal test would pass vacuously, so the Alice/Bob case establishes that the
+//! very same capability, arguments and backend DO reach the wire.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::capability::CapabilityExecutor;
+use crate::identity_propagation::AccountStrategyRegistry;
+use crate::personal_accounts::AccountCustody;
+
+use super::account_resolver_fixture::{
+    ALICE_WORK_TOKEN, BOB_WORK_TOKEN, PERSONAL, STATIC_FALLBACK, WORK, account_key, custody_with,
+    grant,
+};
+use super::account_rest_fixture::{
+    Captured, EXPIRED_EXTERNAL_TOKEN, backend_with, cacheable_base_url, cacheable_capability,
+    caching_context, caching_executor, call, capability, capture_endpoint, context, declared_only,
+    external, installed_expired_external, installed_gateway, managed, meta_execute,
+    prepared_caching_context, shared,
+};
+
+/// The gateway-held login a fallback would reach for. Seeded in the caching
+/// cases as a TRAP: it is a perfectly valid legacy `oauth:google` token, so a
+/// refusal that leaves it unused is a refusal that chose to fail closed with a
+/// working alternative in hand.
+const LEGACY_TRAP_TOKEN: &str = "synthetic-operator-legacy-trap-token-3d0a";
+
+/// Never-expiring, so no case takes the refresh path by accident.
+const FRESH: u64 = u64::MAX;
+
+fn base_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}")
+}
+
+/// A host that cannot resolve. Used where the assertion is that resolution
+/// refused BEFORE the wire; if a refusal ever regressed into a dispatch, the
+/// failure would be a transport error, not a silent pass.
+const UNROUTABLE: &str = "https://rest-account-control.invalid";
+
+fn assert_no_credential_leaked(error: &crate::Error, captured: &Captured) {
+    let text = error.to_string();
+    assert!(
+        !text.contains(ALICE_WORK_TOKEN)
+            && !text.contains(BOB_WORK_TOKEN)
+            && !text.contains(STATIC_FALLBACK),
+        "a refusal must carry neither an account token nor a static credential: {text}"
+    );
+    assert_eq!(
+        captured.count(),
+        0,
+        "the refusal must happen before any HTTP request reaches the backend"
+    );
+}
+
+/// THE POSITIVE CONTROL AND THE HEADLINE CASE.
+///
+/// One capability, one argument set, two principals. Alice must receive her own
+/// account's token and Bob his own. The tokens are distinct per principal in the
+/// seeded store, so a crossed credential is visible in the assertion rather than
+/// inferred, and both descriptors share ONE resource so the descriptor id and
+/// the verified subject are the only fields that differ.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn alice_and_bob_receive_their_own_account_credentials_from_one_rest_capability() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[
+        (account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH)),
+        (account_key("bob", WORK), grant(BOB_WORK_TOKEN, FRESH)),
+    ]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("a capability naming a declared descriptor with a matching provider must register");
+
+    call(&backend, Some("alice"))
+        .await
+        .expect("Alice's dispatch must reach the endpoint");
+    call(&backend, Some("bob"))
+        .await
+        .expect("Bob's dispatch must reach the endpoint");
+
+    let seen = captured.authorizations();
+    assert_eq!(seen.len(), 2, "both dispatches must reach the endpoint");
+    assert_eq!(
+        seen[0].as_deref(),
+        Some(format!("Bearer {ALICE_WORK_TOKEN}").as_str()),
+        "Alice must be served her own account's credential"
+    );
+    assert_eq!(
+        seen[1].as_deref(),
+        Some(format!("Bearer {BOB_WORK_TOKEN}").as_str()),
+        "Bob must be served his own account's credential, not Alice's"
+    );
+    assert_eq!(
+        custody.releases(),
+        4,
+        "each dispatch releases during preparation and rechecks before egress"
+    );
+}
+
+/// NO VERIFIED IDENTITY, NO CREDENTIAL — AND NO FALLBACK.
+///
+/// The capability is the same one that just worked, so the only difference is
+/// the missing identity. Falling through here would resolve the gateway-held
+/// `oauth:google` token from the legacy `TokenStorage` and present one person's
+/// login as another's, which is exactly what the account reference exists to
+/// prevent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_request_with_no_verified_identity_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("registration is unaffected by the absence of a caller");
+
+    let error = call(&backend, None)
+        .await
+        .expect_err("a managed account cannot be resolved without a verified caller");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "no credential may be released for a caller the gateway has not verified"
+    );
+}
+
+/// A DECLARED DESCRIPTOR WITH NO INSTALLED STRATEGY REFUSES.
+///
+/// This is the state a reload leaves behind when a binding is dropped between
+/// compilation and installation. The capability is admitted at registration —
+/// the descriptor IS declared — and the dispatch is what must fail closed,
+/// rather than borrowing an unrelated strategy or the legacy token.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_declared_account_with_no_installed_strategy_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let registry = declared_only(&[(WORK, managed(WORK))]);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("a declared descriptor is a valid reference at registration time");
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("no installed strategy means no credential, and no substitute");
+
+    assert_no_credential_leaked(&error, &captured);
+}
+
+/// A REVOKED GRANT REFUSES AT THE RELEASE RECHECK, BEFORE THE WIRE.
+///
+/// The revocation is applied through the REAL `CustodyHandle` the fixture
+/// started, so what refuses is the production recheck, not a fixture flag.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_revoked_grant_refuses_before_http() {
+    let (port, captured) = capture_endpoint().await;
+    let alice = account_key("alice", WORK);
+    let custody = custody_with(&[(alice.clone(), grant(ALICE_WORK_TOKEN, FRESH))]);
+    custody
+        .handle
+        .invalidate(&alice)
+        .await
+        .expect("revocation must be applied");
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("registration does not consult grant state");
+
+    let error = call(&backend, Some("alice"))
+        .await
+        .expect_err("a revoked account has no credential to serve");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "the release observer must record no successful release"
+    );
+}
+
+/// AN UNKNOWN REFERENCE IS REFUSED AT REGISTRATION.
+///
+/// `auth.account` names a descriptor MAP KEY. A name that is not a key is an
+/// operator error, and admitting the capability would leave a tool in the
+/// surface that can only ever fail — or, worse, fall back.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_unknown_account_reference_is_refused_at_registration() {
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+
+    // `.err().expect(..)` rather than `expect_err`: the Ok half is a production
+    // backend that deliberately carries no `Debug`.
+    let error = backend_with(
+        &registry,
+        capability(UNROUTABLE, "oauth:google", Some("no-such-account")),
+    )
+    .err()
+    .expect("an unresolved account reference must not enter the tool surface");
+    let text = error.to_string();
+    assert!(
+        text.contains("no-such-account"),
+        "the refusal must name the unresolved reference: {text}"
+    );
+}
+
+/// A PROVIDER MISMATCH IS REFUSED AT REGISTRATION AND, INDEPENDENTLY, AT
+/// EXECUTION.
+///
+/// `auth.key` must be `oauth:<descriptor.provider>`. A capability keyed
+/// `oauth:slack` pointing at a `google` descriptor is a refusal, never a
+/// best-effort lookup and never a join by provider name. The execution half
+/// covers a capability registered dynamically, past the registration boundary.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_provider_mismatch_is_refused_at_registration_and_at_execution() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let mismatched = capability(&base_url(port), "oauth:slack", Some(WORK));
+
+    let registration = backend_with(&registry, mismatched.clone())
+        .err()
+        .expect("a provider mismatch must not enter the tool surface");
+    assert!(
+        registration.to_string().contains("oauth:google"),
+        "the refusal must state the key the descriptor's provider requires: {registration}"
+    );
+
+    // The execution guard, reached directly so the registration boundary is not
+    // what refuses: this is the protection for a dynamically registered
+    // capability.
+    let executor = CapabilityExecutor::new().with_account_strategies(Arc::clone(&registry));
+    let error = executor
+        .execute_with_context(&mismatched, json!({}), context(Some("alice")))
+        .await
+        .expect_err("execution must refuse the mismatch independently of registration");
+
+    assert_no_credential_leaked(&error, &captured);
+    assert_eq!(
+        custody.releases(),
+        0,
+        "a mismatched capability must never reach custody"
+    );
+}
+
+/// SHARED AND DESCRIPTORLESS LEGACY BEHAVIOUR IS PRESERVED.
+///
+/// A `shared` descriptor names an account the deployment already serves
+/// statically. Binding one must not tighten a configuration that never opted
+/// into per-user credentials, so the gateway-held token is still what goes on
+/// the wire — unchanged, and explicitly not routed through custody.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_shared_descriptor_keeps_the_legacy_gateway_held_token() {
+    const LEGACY_TOKEN: &str = "synthetic-operator-shared-token-9f1c";
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(PERSONAL, shared(PERSONAL))], &installed);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage = Arc::new(
+        crate::oauth::TokenStorage::new(dir.path().to_path_buf()).expect("token storage opens"),
+    );
+    let executor = CapabilityExecutor::with_token_storage(storage)
+        .with_account_strategies(Arc::clone(&registry));
+    executor.set_oauth_token(
+        "google",
+        crate::oauth::TokenInfo {
+            expires_at: Some(u64::MAX),
+            ..crate::oauth::TokenInfo::from_response(
+                LEGACY_TOKEN.to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+        },
+    );
+
+    executor
+        .execute_with_context(
+            &capability(&base_url(port), "oauth:google", Some(PERSONAL)),
+            json!({}),
+            context(Some("alice")),
+        )
+        .await
+        .expect("a shared descriptor keeps the existing static path");
+
+    assert_eq!(
+        captured.only(),
+        format!("Bearer {LEGACY_TOKEN}"),
+        "a shared descriptor must serve the existing gateway-held login unchanged"
+    );
+    assert_eq!(
+        custody.releases(),
+        0,
+        "shared mode has no custody requirement and must not consult it"
+    );
+}
+
+/// MIXED MODES COEXIST WITHOUT SUBSTITUTION.
+///
+/// One installer, one registry, two descriptors: an external one reusing the
+/// configured `signed_assertion` strategy with `required: true`, and a managed
+/// one under vault custody. Each capability must get the credential ITS
+/// descriptor compiled to — the whole reason strategies are installed per
+/// descriptor rather than once per process.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_external_descriptor_and_a_managed_one_coexist_without_substitution() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(
+        &[(WORK, managed(WORK)), (PERSONAL, external(PERSONAL))],
+        &installed,
+    );
+
+    let vault_backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(WORK)),
+    )
+    .expect("the managed capability must register");
+    let external_backend = backend_with(
+        &registry,
+        capability(&base_url(port), "oauth:google", Some(PERSONAL)),
+    )
+    .expect("the external capability must register");
+
+    call(&vault_backend, Some("alice"))
+        .await
+        .expect("the managed dispatch must reach the endpoint");
+    call(&external_backend, Some("alice"))
+        .await
+        .expect("the external dispatch must reach the endpoint");
+
+    let seen = captured.authorizations();
+    assert_eq!(seen.len(), 2, "both dispatches must reach the endpoint");
+    let vault = seen[0].clone().expect("managed call carries a credential");
+    let minted = seen[1].clone().expect("external call carries a credential");
+    assert_eq!(
+        vault,
+        format!("Bearer {ALICE_WORK_TOKEN}"),
+        "the managed capability must be served its own account's token"
+    );
+    assert!(
+        minted.starts_with("Bearer ") && minted != vault,
+        "the external descriptor must mint its own assertion, never the vault token: {minted}"
+    );
+    assert_eq!(
+        custody.releases(),
+        2,
+        "only the managed descriptor releases during preparation and rechecks before egress"
+    );
+}
+
+/// THE ONE MetaMcp THREADING CONTROL.
+///
+/// Everything above hands the verified identity to the executor directly, which
+/// proves the credential boundary but not that the GATEWAY fills it. This case
+/// drives the real Code Mode dispatch entry twice against a capability whose
+/// host cannot resolve, so the wire is irrelevant and the observable is custody:
+///
+/// - with no verified caller, the account boundary refuses and custody is never
+///   consulted (`releases == 0`);
+/// - with a verified caller, the SAME dispatch reaches custody and passes the
+///   real release recheck (`releases == 1`) before failing at the unroutable
+///   host.
+///
+/// The difference between the two runs is the `MetaMcpCallerContext`'s
+/// `verified_identity` and nothing else, so a gateway that invented an issuer
+/// from a `GrantSubject`, an API key name or a display name could not produce
+/// it: both runs carry no grant subject and no API key name.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn meta_mcp_capability_dispatch_carries_the_verified_identity_to_the_account_boundary() {
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let backend = backend_with(
+        &registry,
+        capability(UNROUTABLE, "oauth:google", Some(WORK)),
+    )
+    .expect("the capability must register");
+    meta.set_capabilities(Arc::clone(&backend));
+
+    let anonymous = meta_execute(&meta, None)
+        .await
+        .expect_err("an unverified caller must not reach a managed account");
+    assert!(
+        !anonymous.to_string().contains(ALICE_WORK_TOKEN),
+        "the refusal must not carry the account token"
+    );
+    assert_eq!(
+        custody.releases(),
+        0,
+        "an unverified Code Mode dispatch must never reach custody"
+    );
+
+    let _ = meta_execute(&meta, Some("alice")).await;
+    assert_eq!(
+        custody.releases(),
+        3,
+        "Code Mode releases during preparation and rechecks before inner cache and egress"
+    );
+    assert_eq!(
+        custody.refreshes(),
+        0,
+        "the seeded grant is fresh, so nothing may hit the refresh provider"
+    );
+}
+
+// ── Warm cache ───────────────────────────────────────────────────────────────
+//
+// EVERYTHING ABOVE RUNS WITH THE CACHE OFF. `allow_loopback_egress` — the flag
+// that lets an IP-literal endpoint be reached — also suppresses the response
+// cache by design, so none of those cases can say anything about a cached
+// entry. The cases below therefore run the OTHER way round: an explicit
+// positive TTL, a `localhost` base URL that clears the SSRF guard on its own,
+// no loopback relaxation, and a swapped (finite-timeout, unpinned) client. The
+// endpoint's request COUNT is the oracle for a real cache hit, and its echoed
+// body is the oracle for whose entry was served.
+
+/// THE POSITIVE CACHE CONTROL: an identical second request is served WITHOUT a
+/// second upstream call.
+///
+/// Without this, every "the revocation was refused" case below could pass
+/// against a cache that never stores anything — two refusals prove nothing about
+/// a cache that was never warm. Here the count stays at one and the second
+/// response is byte-identical, including the per-request sequence number the
+/// endpoint stamps, which a re-dispatch could not reproduce.
+///
+/// The account boundary still runs on the cached call: custody records TWO
+/// releases for one HTTP request, because the credential is resolved and
+/// rechecked BEFORE the cache is consulted, not skipped by a hit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_identical_second_request_from_alice_is_served_from_the_warm_cache() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[(account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let executor = caching_executor(&registry, None);
+    let capability = cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK));
+
+    let first = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice's first dispatch must reach the endpoint");
+    assert_eq!(
+        captured.count(),
+        1,
+        "the first dispatch must actually go on the wire and prime the cache"
+    );
+    assert_eq!(
+        first["authorization"],
+        json!(format!("Bearer {ALICE_WORK_TOKEN}")),
+        "Alice must be served her own account's credential"
+    );
+
+    let second = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice's identical second dispatch must succeed");
+
+    assert_eq!(
+        captured.count(),
+        1,
+        "the identical second request must be served from cache: the endpoint's request count \
+         must not move"
+    );
+    assert_eq!(
+        first, second,
+        "a warm cache hit must return the stored body verbatim, sequence number included"
+    );
+    assert_eq!(
+        custody.releases(),
+        3,
+        "the cold dispatch releases twice; the warm hit rechecks custody once before cache"
+    );
+}
+
+/// BOB IS NEVER SERVED ALICE'S CACHED RESPONSE.
+///
+/// Same capability, same arguments, same executor and a cache that is provably
+/// warm (the case above shares this exact setup). The only thing that differs is
+/// the verified caller — and therefore the account credential's opaque binding,
+/// which the cache key is partitioned by. Bob must MISS, dispatch, and receive a
+/// body carrying HIS credential; Alice's entry must survive his call intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bob_is_never_served_alices_warm_cache_entry() {
+    let (port, captured) = capture_endpoint().await;
+    let custody = custody_with(&[
+        (account_key("alice", WORK), grant(ALICE_WORK_TOKEN, FRESH)),
+        (account_key("bob", WORK), grant(BOB_WORK_TOKEN, FRESH)),
+    ]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let executor = caching_executor(&registry, None);
+    let capability = cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK));
+
+    let alice_first = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice primes the cache");
+    assert_eq!(captured.count(), 1);
+
+    let bob = executor
+        .execute_with_context(&capability, json!({}), caching_context("bob"))
+        .await
+        .expect("Bob's dispatch must succeed on his own credential");
+
+    assert_eq!(
+        captured.count(),
+        2,
+        "Bob must miss Alice's entry and dispatch on his own"
+    );
+    assert_eq!(
+        bob["authorization"],
+        json!(format!("Bearer {BOB_WORK_TOKEN}")),
+        "Bob must be served his own account's credential, never Alice's"
+    );
+    assert_ne!(
+        bob, alice_first,
+        "Bob must not receive Alice's cached response body"
+    );
+
+    let alice_again = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect("Alice's entry must still be there");
+    assert_eq!(
+        captured.count(),
+        2,
+        "Alice's warm entry must survive Bob's miss — isolation, not a dead cache"
+    );
+    assert_eq!(
+        alice_again, alice_first,
+        "Alice must still be served her own stored body"
+    );
+}
+
+/// A REVOCATION COMMITTED AFTER THE CREDENTIAL WAS PREPARED REFUSES THE WARM
+/// ENTRY AND THE WIRE.
+///
+/// The credential is resolved FIRST, as the invoke path resolves it, and the
+/// very same carried credential warms the cache. The revocation then lands
+/// through the real `CustodyHandle`, strictly between that warm-up and the
+/// second call. The second call is byte-identical to the first — the entry is
+/// sitting there and would be returned by any check that ran after the lookup —
+/// so it can only be refused by the recheck that runs BEFORE the lookup.
+///
+/// The trap: a valid gateway-held `oauth:google` token is loaded, so the legacy
+/// fallback is available and working. It must stay unused, unrecorded and
+/// unmentioned.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_revocation_after_prepare_refuses_the_warm_cache_entry_and_the_wire() {
+    let (port, captured) = capture_endpoint().await;
+    let alice = account_key("alice", WORK);
+    let custody = custody_with(&[(alice.clone(), grant(ALICE_WORK_TOKEN, FRESH))]);
+    let installed: Arc<dyn AccountCustody> = custody.installed();
+    let (_meta, registry) = installed_gateway(&[(WORK, managed(WORK))], &installed);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let executor = caching_executor(&registry, Some((LEGACY_TRAP_TOKEN, &dir)));
+    let capability = cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(WORK));
+
+    // Resolved BEFORE the revocation and carried, exactly as the invoke path
+    // carries it into the executor.
+    let prepared = prepared_caching_context(&registry, "alice", WORK, "oauth:google").await;
+    let warm = executor
+        .execute_with_context(&capability, json!({}), prepared.clone())
+        .await
+        .expect("the prepared credential must dispatch while the grant is current");
+    assert_eq!(captured.count(), 1, "the cache must actually be warm");
+    assert_eq!(
+        warm["authorization"],
+        json!(format!("Bearer {ALICE_WORK_TOKEN}")),
+        "the warm entry must be Alice's own account credential, not the legacy trap"
+    );
+
+    custody
+        .handle
+        .invalidate(&alice)
+        .await
+        .expect("revocation must be applied");
+
+    let error = executor
+        .execute_with_context(&capability, json!({}), prepared)
+        .await
+        .expect_err("a revoked grant must not be served its own warm cache entry");
+
+    let text = error.to_string();
+    assert!(
+        !text.contains(ALICE_WORK_TOKEN) && !text.contains(LEGACY_TRAP_TOKEN),
+        "the refusal must carry neither the account token nor the legacy trap: {text}"
+    );
+    assert_eq!(
+        captured.count(),
+        1,
+        "the refusal must reach neither the cache nor the wire: no new request, and an error \
+         instead of the stored body"
+    );
+}
+
+/// AN ALREADY-EXPIRED EXTERNAL CREDENTIAL IS REFUSED AT THE INITIAL RESOLVE.
+///
+/// THE REGRESSION. `published_lifetime_open` used to read `expires_at <=
+/// minted_at` as "this strategy published no lifetime" for EVERY strategy. That
+/// reading is the vault's per-dispatch signal and is only safe because a managed
+/// credential is separately re-released through durable custody. An external
+/// descriptor has no lease, so the custody half is skipped entirely — and an
+/// issuer that hands back a token whose expiry has already passed produces
+/// exactly `expires_at <= minted_at`, which sailed through the check and went on
+/// the wire.
+///
+/// The strategy here mints successfully with usable headers; the ONLY thing
+/// wrong with the credential is that its published expiry is an hour in the
+/// past. The refusal must therefore be attributable to the expiry alone, must
+/// happen before the cache key is built and before egress, and must not fall
+/// back to the seeded legacy token.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_already_expired_external_credential_refuses_before_cache_and_wire() {
+    let (port, captured) = capture_endpoint().await;
+    let registry = installed_expired_external(PERSONAL);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let executor = caching_executor(&registry, Some((LEGACY_TRAP_TOKEN, &dir)));
+    let capability =
+        cacheable_capability(&cacheable_base_url(port), "oauth:google", Some(PERSONAL));
+
+    let error = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect_err("an external credential whose expiry has passed must never be used");
+
+    let text = error.to_string();
+    assert!(
+        text.contains("expired"),
+        "the refusal must be attributable to the published expiry: {text}"
+    );
+    assert!(
+        !text.contains(EXPIRED_EXTERNAL_TOKEN) && !text.contains(LEGACY_TRAP_TOKEN),
+        "the refusal must carry neither the expired credential nor the legacy trap: {text}"
+    );
+    assert_eq!(
+        captured.count(),
+        0,
+        "an expired external credential must not reach the wire"
+    );
+
+    // And it is refused every time: nothing was stored under it, so a second
+    // identical request cannot be answered from a cache entry either.
+    let repeat = executor
+        .execute_with_context(&capability, json!({}), caching_context("alice"))
+        .await
+        .expect_err("the refusal must be stable, not a one-off miss");
+    assert!(
+        !repeat.to_string().contains(EXPIRED_EXTERNAL_TOKEN),
+        "the repeated refusal must not carry the expired credential"
+    );
+    assert_eq!(
+        captured.count(),
+        0,
+        "no cached body and no egress on the repeat either"
+    );
+}
+
+/// A registry that declares nothing still fails CLOSED at execution.
+///
+/// This is the standalone `CapabilityExecutor` a non-gateway embedder builds:
+/// there is no account catalogue at all, so a capability naming one cannot be
+/// resolved and must not reach the legacy `oauth:<provider>` storage.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_executor_with_no_account_catalogue_refuses_a_managed_capability() {
+    let (port, captured) = capture_endpoint().await;
+    let executor = CapabilityExecutor::new()
+        .with_account_strategies(Arc::new(AccountStrategyRegistry::default()));
+
+    let error = executor
+        .execute_with_context(
+            &capability(&base_url(port), "oauth:google", Some(WORK)),
+            json!({}),
+            context(Some("alice")),
+        )
+        .await
+        .expect_err("an undeclared account reference has nothing to resolve against");
+
+    assert_no_credential_leaked(&error, &captured);
+}

--- a/src/gateway/meta_mcp/invoke.rs
+++ b/src/gateway/meta_mcp/invoke.rs
@@ -7,6 +7,7 @@
 //! `gateway_list_disabled_capabilities`, `gateway_reload_config`,
 //! `gateway_webhook_status`, and `gateway_run_playbook`.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -1403,8 +1404,33 @@ impl MetaMcp {
                 ),
             ));
         }
-        let identity_suffix = caller_credential
-            .cache_binding
+        // THE CAPABILITY ROUTE'S ACCOUNT BOUNDARY, RESOLVED HERE — BEFORE THE
+        // OUTER RESPONSE CACHE IS CONSULTED.
+        //
+        // The MCP route resolves its per-user credential above, for the same
+        // reason: a cache key built before the caller's credential is known
+        // cannot name the caller. A REST capability's credential does not come
+        // from `backend_identity_propagation` (that map is keyed by BACKEND
+        // name) but from the capability's own `auth.account`, so it has to be
+        // resolved from the capability definition — the tool's PRIMARY auth —
+        // and it has to be resolved here rather than inside the executor, which
+        // only runs after this cache lookup has already happened. The credential
+        // is carried into dispatch and rechecked there; it is never minted
+        // twice, and a refusal returns now, before any lookup.
+        let account_credential = self
+            .resolve_capability_account_credential(server, tool, verified_identity)
+            .await?;
+        // ONE binding for both cache layers and for the transport's session
+        // partitioning. The MCP route's propagation binding when there is one,
+        // otherwise the account credential's — they are never both present,
+        // because one describes a backend's propagation config and the other a
+        // capability's account reference.
+        let dispatch_binding = caller_credential.cache_binding.clone().or_else(|| {
+            account_credential
+                .as_ref()
+                .map(|prepared| prepared.cache_binding().to_owned())
+        });
+        let identity_suffix = dispatch_binding
             .as_deref()
             .map(|b| format!("|idp:{b}"))
             .unwrap_or_default();
@@ -1419,7 +1445,7 @@ impl MetaMcp {
         // separate from `identity_suffix` above: that one keys retry
         // de-duplication, a different contract with a different lifetime.
         let caller_principal = super::support::caller_cache_principal(
-            caller_credential.cache_binding.as_deref(),
+            dispatch_binding.as_deref(),
             verified_identity,
             caller.grant_subject.as_ref(),
         );
@@ -1644,8 +1670,10 @@ impl MetaMcp {
                 want_full,
                 session_id,
                 caller_identity,
+                verified_identity,
                 &caller_credential.headers,
-                caller_credential.cache_binding.as_deref(),
+                dispatch_binding.as_deref(),
+                account_credential,
                 api_key_name,
                 trace_id,
                 policy_epoch,
@@ -2560,6 +2588,55 @@ impl MetaMcp {
         }
     }
 
+    /// Resolve the account credential a CAPABILITY tool needs, before any
+    /// cache is consulted.
+    ///
+    /// `Ok(None)` means there is nothing to resolve on this route: the target
+    /// is not the capability backend, the tool is not one of its capabilities,
+    /// the capability names no account, or the account is an explicit `shared`
+    /// descriptor whose static credential path is preserved unchanged. Every
+    /// other outcome is either a credential minted for the verified caller by
+    /// the ONE shared registry — the same instance the executor rechecks
+    /// against — or a refusal that returns before the response cache is read.
+    ///
+    /// The reference read here is the capability's PRIMARY `auth`, which is the
+    /// same `auth` the executor injects at egress; nothing here re-derives it
+    /// from a provider name or a backend name.
+    ///
+    /// # Errors
+    ///
+    /// Every refusal from
+    /// [`crate::identity_propagation::AccountStrategyRegistry::resolve`].
+    async fn resolve_capability_account_credential(
+        &self,
+        server: &str,
+        tool: &str,
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
+    ) -> Result<Option<Arc<crate::identity_propagation::PreparedAccountCredential>>> {
+        use crate::identity_propagation::AccountCredential;
+
+        let Some(capabilities) = self.get_capabilities() else {
+            return Ok(None);
+        };
+        if server != capabilities.name {
+            return Ok(None);
+        }
+        let Some(definition) = capabilities.get(tool) else {
+            return Ok(None);
+        };
+        let Some(account) = definition.auth.account.as_deref() else {
+            return Ok(None);
+        };
+        match self
+            .account_strategies
+            .resolve(account, &definition.auth.key, verified_identity)
+            .await?
+        {
+            AccountCredential::Legacy => Ok(None),
+            AccountCredential::Prepared(prepared) => Ok(Some(prepared)),
+        }
+    }
+
     /// Dispatch one round to the backend and meter it.
     ///
     /// Holds every emission that must fire once per backend call: the
@@ -2585,8 +2662,15 @@ impl MetaMcp {
         want_full: bool,
         session_id: Option<&str>,
         caller_identity: Option<&GrantSubject>,
+        // The VERIFIED end-user identity, carried for the capability route
+        // whose account boundary is inside the executor. Pass-through only.
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
         propagated_headers: &[(String, String)],
         cache_binding: Option<&str>,
+        // The capability route's account credential, resolved once above the
+        // response cache and carried down unchanged. `None` for every MCP
+        // backend and for a capability with no account reference.
+        account_credential: Option<Arc<crate::identity_propagation::PreparedAccountCredential>>,
         api_key_name: Option<&str>,
         trace_id: &str,
         policy_epoch: u64,
@@ -2605,8 +2689,10 @@ impl MetaMcp {
                 want_full,
                 session_id,
                 caller_identity,
+                verified_identity,
                 propagated_headers,
                 cache_binding,
+                account_credential,
                 policy_epoch,
                 protocol_revision,
                 routing_profile,
@@ -2696,6 +2782,11 @@ impl MetaMcp {
         // re-decides it — this is the value the call is made *with*, not the
         // one it is checked against.
         caller_identity: Option<&GrantSubject>,
+        // The VERIFIED end-user identity, carried for the capability route,
+        // whose account boundary is inside the executor rather than at the
+        // resolver above. Pass-through only: nothing here decides it, and the
+        // MCP route continues to use the credential already resolved.
+        verified_identity: Option<&crate::key_server::oidc::VerifiedIdentity>,
         // Pre-resolved per-user propagation headers (empty = none). Resolved
         // once in `invoke_tool_traced` so the cache key and this dispatch share
         // one credential (MIK-6734); dispatch never mints.
@@ -2705,6 +2796,10 @@ impl MetaMcp {
         // copies the same already-resolved string into the inner cache key.
         // `None` → shared default bucket / public namespace.
         identity_key: Option<&str>,
+        // Resolved before the outer response cache, rechecked against the same
+        // registry inside the executor before the inner cache and before
+        // egress. Never minted here.
+        account_credential: Option<Arc<crate::identity_propagation::PreparedAccountCredential>>,
         policy_epoch: u64,
         protocol_revision: Option<&str>,
         routing_profile: &str,
@@ -2733,6 +2828,18 @@ impl MetaMcp {
                     protocol_revision: protocol_revision.map(str::to_owned),
                     routing_profile: Some(routing_profile.to_owned()),
                     cache_binding: identity_key.map(str::to_owned),
+                    // The ONLY source of a verified identity on this route is
+                    // `MetaMcpCallerContext::verified_identity`, which carries a
+                    // verified issuer AND subject. `caller_identity` above is a
+                    // `GrantSubject`: an authorization handle whose authority is
+                    // not an OAuth issuer, so an account key built from it would
+                    // bind a person the gateway never authenticated. It is
+                    // threaded here untouched and never synthesised.
+                    verified_identity: verified_identity.cloned().map(Arc::new),
+                    // Carried, not re-resolved: the executor rechecks it
+                    // against the same registry before its own cache lookup
+                    // and again before egress.
+                    account_credential,
                 },
             )
             .await?;

--- a/src/gateway/meta_mcp/mod.rs
+++ b/src/gateway/meta_mcp/mod.rs
@@ -295,6 +295,14 @@ pub struct MetaMcp {
             Arc<dyn crate::identity_propagation::IdentityPropagation>,
         >,
     >,
+    /// Per-DESCRIPTOR account strategies, shared with the capability executor.
+    ///
+    /// The map above is keyed by backend name, which a REST capability does not
+    /// have: it names an `accounts.descriptors` map key directly and may be
+    /// that account's only consumer. The shared installer writes ONE strategy
+    /// per descriptor here and hands the same `Arc` to the per-backend map, so
+    /// both consumers of one account hold one instance.
+    pub(super) account_strategies: Arc<crate::identity_propagation::AccountStrategyRegistry>,
     pub(super) code_mode_enabled: bool,
     /// Whether this gateway serves more than one principal (ADR-008 INV-2).
     ///
@@ -512,6 +520,9 @@ impl MetaMcp {
             reload_context: RwLock::new(None),
             identity_propagation: RwLock::new(None),
             backend_identity_propagation: RwLock::new(std::collections::HashMap::new()),
+            account_strategies: Arc::new(
+                crate::identity_propagation::AccountStrategyRegistry::default(),
+            ),
             code_mode_enabled: false,
             multi_user: std::sync::atomic::AtomicBool::new(false),
             projection_mode: crate::projection::ProjectionMode::default(),
@@ -800,6 +811,12 @@ impl MetaMcp {
     /// writes into the same tamper-evident chain from the direct backend
     /// route, which does not go through `MetaMcp`.
     pub fn enable_transparency_log(&mut self, logger: Arc<crate::security::TransparencyLogger>) {
+        // The account registry mints credentials for REST capabilities under
+        // the same "no mint without a durable audit record" rule as the
+        // Meta-MCP route, and it is reached through the capability executor
+        // rather than through `self`, so it needs its own handle on the sink.
+        self.account_strategies
+            .set_audit_logger(Arc::clone(&logger));
         self.transparency_logger = Some(logger);
     }
 
@@ -906,6 +923,17 @@ impl MetaMcp {
             .read()
             .get(backend)
             .map(Arc::clone)
+    }
+
+    /// The per-descriptor account strategies.
+    ///
+    /// Handed out rather than consulted here: the REST consumer reaches it
+    /// through `CapabilityExecutor`, which has no view of `MetaMcp`. The same
+    /// `Arc` on both sides is what makes it ONE registry rather than two.
+    pub(crate) fn account_strategies(
+        &self,
+    ) -> Arc<crate::identity_propagation::AccountStrategyRegistry> {
+        Arc::clone(&self.account_strategies)
     }
 
     /// Declare whether this gateway serves more than one principal (ADR-008
@@ -2104,6 +2132,10 @@ mod account_resolver_fixture;
 mod account_resolver_gate;
 #[cfg(test)]
 mod account_resolver_tests;
+#[cfg(test)]
+mod account_rest_fixture;
+#[cfg(test)]
+mod account_rest_tests;
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/src/gateway/server/account_bindings.rs
+++ b/src/gateway/server/account_bindings.rs
@@ -17,14 +17,41 @@
 use std::sync::Arc;
 
 use crate::config::Config;
-use crate::config::account_bindings::{BoundAccountBackend, compile};
+use crate::config::account_bindings::{CompiledDescriptor, compile, compile_descriptors};
 use crate::gateway::meta_mcp::MetaMcp;
 use crate::gateway::oauth::GatewayKeyPair;
-use crate::identity_propagation::PropagationStrategyKind;
+use crate::identity_propagation::{
+    AccountStrategyRegistry, IdentityPropagation, InstalledAccount, PropagationStrategyKind,
+};
 use crate::personal_accounts::{AccountCustody, VaultStrategy};
 use crate::{Error, Result};
 
-/// Install one strategy per bound backend, or refuse to start.
+/// Declare every configured descriptor into the shared registry.
+///
+/// Separate from installation because DECLARATION is what the capability
+/// registration boundary checks against, and it must run before capabilities
+/// are loaded — earlier than installation, which needs custody and the gateway
+/// key pair. Idempotent, so startup and a later install may both call it.
+pub(crate) fn declare_account_descriptors(config: &Config, registry: &AccountStrategyRegistry) {
+    let Some(descriptors) = config
+        .accounts
+        .as_ref()
+        .and_then(|accounts| accounts.descriptors.as_ref())
+    else {
+        return;
+    };
+    for (id, descriptor) in descriptors {
+        registry.declare(id, &descriptor.provider, descriptor.mode);
+    }
+}
+
+/// Install one strategy per configured descriptor, then bind it to every
+/// backend that names it — or refuse to start.
+///
+/// TWO CONSUMERS, ONE STRATEGY. A descriptor's strategy is built ONCE, into the
+/// shared registry a REST capability resolves against, and the SAME `Arc` is
+/// handed to the per-backend map. Neither consumer can drift onto its own
+/// instance, and there is no second store or second lookup pipeline.
 ///
 /// # Errors
 ///
@@ -36,99 +63,135 @@ pub(crate) fn install_account_strategies(
     gateway_key_pair: &Arc<GatewayKeyPair>,
     meta_mcp: &MetaMcp,
 ) -> Result<()> {
+    let registry = meta_mcp.account_strategies();
+    declare_account_descriptors(config, &registry);
+
+    for compiled in compile_descriptors(config)? {
+        install_descriptor(&compiled, custody, gateway_key_pair, &registry);
+    }
+
     for (name, bound) in compile(config)? {
         // A disabled backend was never registered, so installing a strategy
         // for it would bind custody to something that cannot be dispatched to.
         if !config.backends.get(&name).is_some_and(|b| b.enabled) {
             continue;
         }
-        install_one(&bound, custody, gateway_key_pair, meta_mcp)?;
-    }
-    Ok(())
-}
-
-fn install_one(
-    bound: &BoundAccountBackend,
-    custody: Option<&Arc<dyn AccountCustody>>,
-    gateway_key_pair: &Arc<GatewayKeyPair>,
-    meta_mcp: &MetaMcp,
-) -> Result<()> {
-    let backend = bound.backend.as_str();
-    let Some(propagation) = bound.propagation.as_ref() else {
-        // A `shared` descriptor names an account this deployment already serves
-        // statically. Nothing is installed, and nothing changes.
-        return Ok(());
-    };
-
-    match propagation.strategy {
-        PropagationStrategyKind::Vault => {
-            let custody = custody.ok_or_else(|| {
-                Error::Config(format!(
+        let backend = name.as_str();
+        let Some(propagation) = bound.propagation.as_ref() else {
+            // A `shared` descriptor names an account this deployment already
+            // serves statically. Nothing is installed, and nothing changes.
+            continue;
+        };
+        let Some(installed) = registry.installed(&bound.descriptor_id) else {
+            return Err(match propagation.strategy {
+                PropagationStrategyKind::Vault => Error::Config(format!(
                     "backend '{backend}' is bound to personal_managed account '{}' but no \
                      account custody was started; the gateway refuses to serve a managed \
                      account as though it were a shared one. Configure the accounts block \
                      (enabled, store and authority directories, keys) for this deployment.",
                     bound.descriptor_id
-                ))
-            })?;
-            let descriptor = bound.account.clone().ok_or_else(|| {
-                Error::Config(format!(
-                    "backend '{backend}' compiled to vault custody without an account \
-                     descriptor; refusing to dispatch without one"
-                ))
-            })?;
+                )),
+                // Refused at config load (`external_strategy` accepts only the
+                // two minting strategies), so this is unreachable from a
+                // validated config. It refuses rather than installing nothing,
+                // because installing nothing for a `required` binding would be
+                // discovered at dispatch.
+                _ => Error::Config(format!(
+                    "backend '{backend}' is bound to account '{}', whose strategy mints no \
+                     credential; an account binding must produce the account holder's own \
+                     credential",
+                    bound.descriptor_id
+                )),
+            });
+        };
+        meta_mcp.set_backend_identity_propagation(backend, Arc::clone(&installed.strategy));
+        tracing::info!(
+            backend,
+            account = %bound.descriptor_id,
+            strategy = ?propagation.strategy,
+            "Account descriptor bound to backend"
+        );
+    }
+    Ok(())
+}
+
+/// Build and register the strategy for ONE descriptor.
+///
+/// Skips rather than refuses when it cannot build one: a `shared` descriptor
+/// installs nothing by design, and a managed descriptor may be declared by a
+/// deployment that never started custody. Skipping is safe ONLY because every
+/// consumer fails closed on a missing installation — the backend loop above
+/// refuses at startup for a bound MCP backend, and
+/// `AccountStrategyRegistry::resolve` refuses at dispatch for a capability.
+fn install_descriptor(
+    compiled: &CompiledDescriptor,
+    custody: Option<&Arc<dyn AccountCustody>>,
+    gateway_key_pair: &Arc<GatewayKeyPair>,
+    registry: &AccountStrategyRegistry,
+) {
+    let id = compiled.descriptor_id.as_str();
+    let Some(propagation) = compiled.propagation.as_ref() else {
+        return;
+    };
+    // The managed strategy, retained TYPED beside the trait object below when
+    // this descriptor is `personal_managed`. It is the same `Arc`: the registry
+    // needs the concrete type to re-release a lease through durable custody
+    // (which `IdentityPropagation` cannot express), and the MCP backend map
+    // needs the trait object. One instance, so one key, one resolver and one
+    // store serve both consumers.
+    let mut managed: Option<Arc<VaultStrategy>> = None;
+    let strategy: Arc<dyn IdentityPropagation> = match propagation.strategy {
+        PropagationStrategyKind::Vault => {
+            let (Some(custody), Some(descriptor)) = (custody, compiled.account.clone()) else {
+                tracing::warn!(
+                    account = id,
+                    "personal_managed account declared with no started custody; no strategy is \
+                     installed and every consumer of this account refuses"
+                );
+                return;
+            };
             // The production custody, erased only so the strategy can hold it:
             // the same handle, the same service, the same store the gateway
             // claimed its locks with at startup.
             let erased: Arc<dyn AccountCustody> = Arc::clone(custody);
-            meta_mcp.set_backend_identity_propagation(
-                backend,
-                Arc::new(VaultStrategy::new(erased, descriptor)),
-            );
-            tracing::info!(
-                backend,
-                account = %bound.descriptor_id,
-                "Managed personal account bound to backend (vault custody)"
-            );
+            let vault = Arc::new(VaultStrategy::new(erased, descriptor));
+            managed = Some(Arc::clone(&vault));
+            vault
         }
         PropagationStrategyKind::SignedAssertion => {
-            let strategy = Arc::new(crate::identity_propagation::SignedAssertionStrategy::new(
+            Arc::new(crate::identity_propagation::SignedAssertionStrategy::new(
                 Arc::clone(gateway_key_pair),
                 ASSERTION_TTL_SECS,
-            ));
-            meta_mcp.set_backend_identity_propagation(backend, strategy);
-            tracing::info!(
-                backend,
-                account = %bound.descriptor_id,
-                "External account descriptor bound to backend (signed-assertion strategy)"
-            );
+            ))
         }
         PropagationStrategyKind::TokenExchange => {
-            let strategy = Arc::new(crate::identity_propagation::TokenExchangeStrategy::new(
+            Arc::new(crate::identity_propagation::TokenExchangeStrategy::new(
                 Arc::clone(gateway_key_pair),
                 ASSERTION_TTL_SECS,
-            ));
-            meta_mcp.set_backend_identity_propagation(backend, strategy);
-            tracing::info!(
-                backend,
-                account = %bound.descriptor_id,
-                "External account descriptor bound to backend (RFC 8693 token-exchange strategy)"
-            );
+            ))
         }
-        // Refused at config load (`external_strategy` accepts only the two
-        // minting strategies), so this is unreachable from a validated config.
-        // It refuses rather than installing nothing, because installing
-        // nothing for a `required` binding would be discovered at dispatch.
-        PropagationStrategyKind::Passthrough => {
-            return Err(Error::Config(format!(
-                "backend '{backend}' is bound to account '{}', whose strategy mints no \
-                 credential; an account binding must produce the account holder's own \
-                 credential",
-                bound.descriptor_id
-            )));
-        }
-    }
-    Ok(())
+        // Mints no credential. Left uninstalled so the bound-backend loop
+        // above turns it into the startup refusal it has always been.
+        PropagationStrategyKind::Passthrough => return,
+    };
+    registry.install(
+        InstalledAccount {
+            descriptor_id: id.to_string(),
+            provider: compiled.provider.clone(),
+            audience: propagation.audience.clone(),
+            required: propagation.required,
+            token_exchange_endpoint: propagation.token_exchange_endpoint.clone(),
+            token_exchange_scope: propagation.token_exchange_scope.clone(),
+            strategy,
+            managed,
+        },
+        compiled.mode,
+    );
+    tracing::info!(
+        account = id,
+        strategy = ?propagation.strategy,
+        "Account descriptor strategy installed"
+    );
 }
 
 /// Subject-assertion lifetime for an external descriptor's strategy, matching

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -2188,11 +2188,26 @@ impl Gateway {
                 }
             };
 
+        // Account strategies must exist before stdio can admit a request, just
+        // as they do before the HTTP listener starts serving.
+        if self.config.accounts.is_some() {
+            let gateway_key_pair = Arc::new(GatewayKeyPair::generate().map_err(|error| {
+                crate::Error::Config(format!(
+                    "stdio account signing key generation failed: {error}"
+                ))
+            })?);
+            let account_custody = self.custody.as_ref().map(|custody| {
+                Arc::clone(custody) as Arc<dyn crate::personal_accounts::AccountCustody>
+            });
+            account_bindings::install_account_strategies(
+                &self.config,
+                account_custody.as_ref(),
+                &gateway_key_pair,
+                &meta_mcp,
+            )?;
+        }
+
         if self.config.capabilities.enabled {
-            // The stdio path installs no account strategies (it never called
-            // the installer, and this slice does not change that), so a managed
-            // reference is DECLARED here and refuses at dispatch rather than
-            // silently resolving the gateway-held token.
             let account_strategies = meta_mcp.account_strategies();
             account_bindings::declare_account_descriptors(&self.config, &account_strategies);
             let executor = Arc::new(
@@ -2205,10 +2220,23 @@ impl Gateway {
                 &self.config.capabilities.name,
                 executor,
             ));
+            let mut refused = Vec::new();
             for dir in &self.config.capabilities.directories {
-                if let Ok(count) = cap_backend.load_from_directory(dir).await {
-                    debug!(directory = %dir, count, "Loaded capabilities (stdio)");
+                match cap_backend.load_from_directory_reporting(dir).await {
+                    Ok(report) => {
+                        debug!(directory = %dir, count = report.admitted, "Loaded capabilities (stdio)");
+                        refused.extend(report.rejected);
+                    }
+                    Err(error) => {
+                        debug!(directory = %dir, %error, "Failed to load optional capabilities (stdio)");
+                    }
                 }
+            }
+            if !refused.is_empty() {
+                return Err(crate::Error::Config(format!(
+                    "capabilities rejected by the account admission gate: {}",
+                    refused.join("; ")
+                )));
             }
             meta_mcp.set_capabilities(cap_backend);
         }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -1253,10 +1253,17 @@ impl Gateway {
         // when webhook route construction does not depend on them, populate the
         // backend in the background so health/MCP endpoints bind promptly.
         let _capability_watcher: Option<CapabilityWatcher> = if self.config.capabilities.enabled {
+            // Declared synchronously, BEFORE the loader task is spawned: the
+            // declared catalogue is what the capability registration boundary
+            // checks against. Installation of the strategies themselves happens
+            // below, still before this gateway serves.
+            let account_strategies = meta_mcp.account_strategies();
+            account_bindings::declare_account_descriptors(&self.config, &account_strategies);
             let executor = Arc::new(
                 CapabilityExecutor::new()
                     .with_env(Arc::clone(&self.env))
-                    .with_policy_epoch(Arc::clone(&meta_mcp.policy_epoch)),
+                    .with_policy_epoch(Arc::clone(&meta_mcp.policy_epoch))
+                    .with_account_strategies(account_strategies),
             );
             let cap_backend = Arc::new(CapabilityBackend::new(
                 &self.config.capabilities.name,
@@ -1279,16 +1286,50 @@ impl Gateway {
             let cap_backend_for_load = Arc::clone(&cap_backend);
             let webhook_registry_for_load = Arc::clone(&webhook_registry);
             let webhooks_enabled = self.config.webhooks.enabled;
-            tokio::spawn(async move {
-                // Let the HTTP listener bind before large capability scans start.
-                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+            // AN ACCOUNT-BOUND DEPLOYMENT SCANS BEFORE IT SERVES.
+            //
+            // The background scan below exists so a large capability directory
+            // does not delay the listener binding, and it stays the default.
+            // But when the configuration declares `accounts.descriptors`, the
+            // scan is also the ADMISSION GATE that rejects a capability whose
+            // `auth.account` names no declared descriptor or whose `auth.key`
+            // is not that descriptor's `oauth:<provider>`
+            // (`CapabilityBackend::register_capability`). Running that gate
+            // concurrently with serving would mean the first requests are
+            // answered while the catalogue is still partial — a tool that the
+            // gate is about to refuse could be absent, and a tool it will admit
+            // could be missing. So an account-bound gateway completes the whole
+            // scan HERE, before `start` returns to bind and serve, and the
+            // strategies are installed further below, still before serving.
+            let accounts_configured = self.config.accounts.as_ref().is_some_and(|accounts| {
+                accounts.enabled
+                    && accounts
+                        .descriptors
+                        .as_ref()
+                        .is_some_and(|descriptors| !descriptors.is_empty())
+            });
+
+            let scan = async move {
+                if !accounts_configured {
+                    // Let the HTTP listener bind before large capability scans start.
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                }
 
                 let mut total_caps = 0;
+                // Every capability the account admission gate refused during the
+                // INITIAL scan. A missing or unreadable optional directory is
+                // NOT collected here — that stays benign, exactly as before.
+                let mut refused: Vec<String> = Vec::new();
                 for dir in &capability_dirs {
-                    match cap_backend_for_load.load_from_directory(dir).await {
-                        Ok(count) => {
-                            total_caps += count;
-                            debug!(directory = %dir, count = count, "Loaded capabilities");
+                    match cap_backend_for_load
+                        .load_from_directory_reporting(dir)
+                        .await
+                    {
+                        Ok(report) => {
+                            total_caps += report.admitted;
+                            debug!(directory = %dir, count = report.admitted, "Loaded capabilities");
+                            refused.extend(report.rejected);
                         }
                         Err(e) => {
                             // Don't fail startup if capability dir doesn't exist
@@ -1312,7 +1353,33 @@ impl Gateway {
                         "Capability backend ready"
                     );
                 }
-            });
+
+                if refused.is_empty() {
+                    Ok(())
+                } else {
+                    Err(crate::Error::Config(format!(
+                        "{} capabilit{} rejected by the account admission gate: {}",
+                        refused.len(),
+                        if refused.len() == 1 { "y" } else { "ies" },
+                        refused.join("; ")
+                    )))
+                }
+            };
+
+            if accounts_configured {
+                // Completed before serving, and its refusals are FATAL: an
+                // invalid `auth.account` binding present at boot fails startup
+                // rather than being logged behind a listener that is already
+                // answering. A missing optional directory is still benign.
+                scan.await?;
+                info!("Capability scan completed before serving (accounts.descriptors configured)");
+            } else {
+                tokio::spawn(async move {
+                    if let Err(error) = scan.await {
+                        warn!(error = %error, "Capability scan reported refusals");
+                    }
+                });
+            }
 
             // Start file watcher for hot-reload
             match CapabilityWatcher::start(Arc::clone(&cap_backend), shutdown_tx.subscribe()) {
@@ -2122,10 +2189,17 @@ impl Gateway {
             };
 
         if self.config.capabilities.enabled {
+            // The stdio path installs no account strategies (it never called
+            // the installer, and this slice does not change that), so a managed
+            // reference is DECLARED here and refuses at dispatch rather than
+            // silently resolving the gateway-held token.
+            let account_strategies = meta_mcp.account_strategies();
+            account_bindings::declare_account_descriptors(&self.config, &account_strategies);
             let executor = Arc::new(
                 CapabilityExecutor::new()
                     .with_env(Arc::clone(&self.env))
-                    .with_policy_epoch(Arc::clone(&meta_mcp.policy_epoch)),
+                    .with_policy_epoch(Arc::clone(&meta_mcp.policy_epoch))
+                    .with_account_strategies(account_strategies),
             );
             let cap_backend = Arc::new(CapabilityBackend::new(
                 &self.config.capabilities.name,

--- a/src/identity_propagation/account_strategies.rs
+++ b/src/identity_propagation/account_strategies.rs
@@ -1,0 +1,683 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! The per-descriptor strategy registry: ONE credential boundary, two consumers.
+//!
+//! WHY A REGISTRY KEYED BY DESCRIPTOR. `MetaMcp::backend_identity_propagation`
+//! is keyed by BACKEND NAME, which is the right key for an MCP backend and the
+//! wrong one for a REST capability: a capability names an
+//! `accounts.descriptors` MAP KEY directly and may be the only consumer of that
+//! account. Keying this registry by descriptor id is what lets both consumers
+//! hold the SAME `Arc<dyn IdentityPropagation>` — the shared installer inserts
+//! once here and hands that very instance to `set_backend_identity_propagation`.
+//! There is no second store, no second auth enum and no second lookup pipeline.
+//!
+//! DECLARATION IS NOT INSTALLATION. `declare` records what the validated
+//! configuration says an account IS (its provider and mode) and runs BEFORE
+//! capabilities are registered, so an unresolved reference or a provider
+//! mismatch is refused at the registration boundary. `install` records what can
+//! actually MINT for it. A declared-but-uninstalled descriptor is exactly the
+//! state a reload leaves behind when a binding is dropped, and [`Self::resolve`]
+//! refuses it rather than borrowing an unrelated strategy.
+//!
+//! NOTHING FALLS BACK. Every refusal below is an `Err`. The one non-error,
+//! non-credential answer is [`AccountCredential::Legacy`], returned ONLY for an
+//! explicit `shared` descriptor — an account the deployment already serves
+//! statically, whose existing behaviour this increment must not tighten.
+//!
+//! AUDIT IS FAIL-CLOSED ON THE MINT PATH, identically to the Meta-MCP route: a
+//! `required` account with no transparency log refuses rather than minting
+//! blind, and an audit-write failure aborts the mint. Only subject, account,
+//! audience and reason are ever written — never the credential.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use super::{BackendDescriptor, IdentityPropagation, audit_identity_propagation, audit_subject};
+use crate::key_server::oidc::VerifiedIdentity;
+use crate::personal_accounts::config::DescriptorMode;
+use crate::security::TransparencyLogger;
+use crate::{Error, Result};
+
+/// What the validated configuration says an account IS. Keyed by the
+/// `accounts.descriptors` map key — the logical `backend_id` of the account key,
+/// and the only thing `auth.account` may name.
+#[derive(Clone, Debug)]
+pub(crate) struct DeclaredAccount {
+    /// The descriptor's logical OAuth provider id. A capability's
+    /// `auth.key` must be exactly `oauth:<provider>`; the provider NEVER
+    /// selects an account on its own.
+    pub(crate) provider: String,
+    /// The declared mode, as written. No mode is ever inferred.
+    pub(crate) mode: DescriptorMode,
+}
+
+/// What can actually mint for an account, installed before serving.
+pub(crate) struct InstalledAccount {
+    pub(crate) descriptor_id: String,
+    pub(crate) provider: String,
+    /// The audience the credential is scoped to: a managed descriptor's own
+    /// RFC 8707 resource, or an external strategy's configured audience.
+    pub(crate) audience: String,
+    pub(crate) required: bool,
+    pub(crate) token_exchange_endpoint: Option<String>,
+    pub(crate) token_exchange_scope: Option<String>,
+    /// The strategy instance. Shared with the per-backend install for the same
+    /// descriptor, so two consumers can never drift onto two strategies.
+    pub(crate) strategy: Arc<dyn IdentityPropagation>,
+    /// The SAME instance as [`Self::strategy`], typed, when this descriptor is
+    /// `personal_managed`.
+    ///
+    /// Not a second install and not a second strategy: the installer builds one
+    /// `Arc<VaultStrategy>`, hands it here and coerces that very `Arc` into the
+    /// trait object above and into the per-backend MCP map, so one descriptor
+    /// has one key, one resolver and one store no matter which consumer reaches
+    /// it. It is retained typed because durable custody is not expressible
+    /// through [`IdentityPropagation`]: `propagate` mints, and a recheck must
+    /// NOT mint. `None` for an external descriptor, whose published expiry and
+    /// strategy behaviour stay exactly what they were.
+    pub(crate) managed: Option<Arc<crate::personal_accounts::VaultStrategy>>,
+}
+
+/// What resolving an account reference produced.
+pub(crate) enum AccountCredential {
+    /// An explicit `shared` descriptor: use the EXISTING static credential
+    /// path, unchanged. Never returned for `personal_managed` or `external`.
+    Legacy,
+    /// A credential minted for the verified identity, carrying the headers to
+    /// put on the wire VERBATIM plus the opaque binding and expiry the strategy
+    /// published. Resolved ONCE per dispatch, before any cache is consulted.
+    Prepared(Arc<PreparedAccountCredential>),
+}
+
+/// One dispatch's account credential, resolved before the first cache lookup.
+///
+/// WHY THIS EXISTS. A cache key that is built before the account is resolved is
+/// a key that cannot name the account holder, so the first caller's result
+/// would be served to the next one. Resolving first and CARRYING the answer is
+/// what lets the outer response cache, the inner capability cache and the
+/// egress headers all speak about the same credential — the same shape the MCP
+/// route already uses (`CallerCredential`, resolved once in
+/// `invoke_tool_traced` and reused verbatim at dispatch).
+///
+/// The binding and the expiry are the STRATEGY's own values
+/// ([`crate::identity_propagation::PropagatedCredential::cache_binding`] /
+/// `expires_at`), copied and never re-derived here: the vault publishes the
+/// five-field account digest widened with the grant generation, authorization
+/// epoch, token revision and descriptor revision, and a re-authorized, rotated
+/// or revoked account therefore produces a DIFFERENT binding rather than a
+/// silently reused one.
+///
+/// `Debug` redacts header values: they carry the live credential (CWE-532).
+pub(crate) struct PreparedAccountCredential {
+    /// The `accounts.descriptors` map key this was minted for.
+    pub(crate) descriptor_id: String,
+    /// The capability's `auth.key`, revalidated against the descriptor's
+    /// provider on every recheck.
+    pub(crate) auth_key: String,
+    /// The verified caller this credential belongs to, as the same
+    /// length-prefixed issuer+subject derivation the account key uses. A
+    /// recheck for any other principal refuses.
+    pub(crate) actor_id: String,
+    /// The audience the credential is scoped to, as installed.
+    pub(crate) audience: String,
+    /// The strategy's opaque cache binding. Copied into every cache key,
+    /// never re-hashed and never parsed.
+    pub(crate) cache_binding: String,
+    /// The strategy's published expiry, in Unix seconds, exactly as minted.
+    pub(crate) expires_at: i64,
+    /// Unix seconds at which this credential was minted. Kept so a published
+    /// LIFETIME can be told apart from a strategy that publishes none (the
+    /// vault deliberately publishes `expires_at == minted_at`, because its
+    /// credential is not reusable past the dispatch it was released for).
+    pub(crate) minted_at: i64,
+    /// The strategy instance that minted it, so a recheck can prove the
+    /// installed strategy has not been swapped underneath this dispatch.
+    strategy: Arc<dyn IdentityPropagation>,
+    /// For a MANAGED descriptor: the concrete strategy and the LEASE this
+    /// credential was released under.
+    ///
+    /// This is what makes the recheck a custody boundary rather than a registry
+    /// comparison. The lease names the grant generation, authorization epoch,
+    /// token revision and descriptor revision the credential came from, so
+    /// re-releasing it asks the durable store the only question that matters
+    /// before a cache entry is selected or a request goes out: is THIS still
+    /// the current grant? A revocation committed after the credential was
+    /// prepared answers no.
+    ///
+    /// It lives here — inside the REST registry — rather than on
+    /// [`PropagatedCredential`], which every unrelated strategy produces and
+    /// none of the others has a lease for. A lease is a non-secret binding; no
+    /// token material is retained.
+    managed: Option<ManagedLease>,
+    /// The outbound headers, presented verbatim.
+    headers: Vec<(String, String)>,
+}
+
+/// One managed credential's custody handle: the concrete strategy that released
+/// it and the lease it was released under.
+struct ManagedLease {
+    strategy: Arc<crate::personal_accounts::VaultStrategy>,
+    lease: crate::personal_accounts::CredentialLease,
+}
+
+impl PreparedAccountCredential {
+    /// The headers to put on the wire, verbatim.
+    pub(crate) fn headers(&self) -> &[(String, String)] {
+        &self.headers
+    }
+
+    /// The opaque binding cache keys are partitioned by.
+    pub(crate) fn cache_binding(&self) -> &str {
+        &self.cache_binding
+    }
+
+    /// Whether a PUBLISHED lifetime is still open at `now`.
+    ///
+    /// THE PER-DISPATCH READING IS NOT UNIVERSAL. `expires_at <= minted_at` is
+    /// the vault's deliberate "no reusable lifetime" signal, and treating it as
+    /// neither fresh nor expired is only sound because a managed credential's
+    /// real freshness is decided by the durable custody recheck below, under the
+    /// store's authority lock. Applying that reading to EVERY strategy is what
+    /// made an external credential whose issuer published an ALREADY-PAST expiry
+    /// (`expires_at <= minted_at` is exactly what an expired token looks like at
+    /// mint time) pass this check with nothing else able to catch it: an
+    /// external descriptor has no lease, so the custody half below is skipped
+    /// entirely and an expired credential would have gone on the wire.
+    ///
+    /// So the per-dispatch reading is available ONLY to a credential backed by
+    /// concrete managed custody — the same `ManagedLease` the recheck uses, not
+    /// a mode string that a reload could change underneath this dispatch. An
+    /// external credential is held to the expiry ITS strategy published, and
+    /// nothing here extends, rounds, defaults or invents a lifetime for it.
+    fn published_lifetime_open(&self, now: i64) -> bool {
+        if self.managed.is_some() {
+            return self.expires_at <= self.minted_at || now <= self.expires_at;
+        }
+        now < self.expires_at
+    }
+}
+
+impl std::fmt::Debug for PreparedAccountCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let header_names: Vec<&str> = self.headers.iter().map(|(k, _)| k.as_str()).collect();
+        f.debug_struct("PreparedAccountCredential")
+            .field("descriptor_id", &self.descriptor_id)
+            .field("auth_key", &self.auth_key)
+            .field("audience", &self.audience)
+            .field("cache_binding", &self.cache_binding)
+            .field("expires_at", &self.expires_at)
+            .field("headers", &format_args!("{header_names:?} = <redacted>"))
+            .finish()
+    }
+}
+
+/// The one place a descriptor reference is resolved for a credential.
+#[derive(Default)]
+pub(crate) struct AccountStrategyRegistry {
+    declared: RwLock<BTreeMap<String, DeclaredAccount>>,
+    installed: RwLock<BTreeMap<String, Arc<InstalledAccount>>>,
+    audit: RwLock<Option<Arc<TransparencyLogger>>>,
+}
+
+impl AccountStrategyRegistry {
+    /// Record a configured descriptor. Idempotent: a reload declaring the same
+    /// descriptor replaces the entry with an identical one.
+    pub(crate) fn declare(&self, descriptor_id: &str, provider: &str, mode: DescriptorMode) {
+        self.declared.write().insert(
+            descriptor_id.to_string(),
+            DeclaredAccount {
+                provider: provider.to_string(),
+                mode,
+            },
+        );
+    }
+
+    /// Install the strategy for one descriptor, carrying its DECLARED mode.
+    ///
+    /// The mode is a parameter rather than inferred from the strategy kind: an
+    /// `external` descriptor must keep its declared mode, and collapsing it
+    /// would make the registration check answer the wrong question.
+    pub(crate) fn install(&self, account: InstalledAccount, mode: DescriptorMode) {
+        self.declare(&account.descriptor_id, &account.provider, mode);
+        self.installed
+            .write()
+            .insert(account.descriptor_id.clone(), Arc::new(account));
+    }
+
+    /// The configured descriptor under `descriptor_id`, if the configuration
+    /// declared one.
+    pub(crate) fn declared(&self, descriptor_id: &str) -> Option<DeclaredAccount> {
+        self.declared.read().get(descriptor_id).cloned()
+    }
+
+    /// The installed strategy for `descriptor_id`, if one was installed.
+    pub(crate) fn installed(&self, descriptor_id: &str) -> Option<Arc<InstalledAccount>> {
+        self.installed.read().get(descriptor_id).map(Arc::clone)
+    }
+
+    /// Attach the durable audit sink. Called by `MetaMcp::enable_transparency_log`
+    /// because this registry is reached through the capability executor rather
+    /// than through `MetaMcp`.
+    pub(crate) fn set_audit_logger(&self, logger: Arc<TransparencyLogger>) {
+        *self.audit.write() = Some(logger);
+    }
+
+    /// The credential key a capability referencing `descriptor_id` must declare.
+    pub(crate) fn expected_auth_key(provider: &str) -> String {
+        format!("oauth:{provider}")
+    }
+
+    /// Resolve one `auth.account` reference into a credential, or refuse.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Config`] for an unresolved reference, a provider mismatch, a
+    /// missing installation, a missing verified identity, a strategy refusal or
+    /// an unusable minted header; [`Error::Internal`] when a required account
+    /// would mint without a durable audit record. Every one of these is a
+    /// refusal, never a fallback.
+    pub(crate) async fn resolve(
+        &self,
+        descriptor_id: &str,
+        auth_key: &str,
+        identity: Option<&VerifiedIdentity>,
+    ) -> Result<AccountCredential> {
+        let Some(declared) = self.declared(descriptor_id) else {
+            return Err(Error::Config(format!(
+                "capability auth references account '{descriptor_id}', which is not a key in \
+                 accounts.descriptors. The reference is the descriptor map key (the account's \
+                 logical id) — never the provider id, an email or a display name. Refusing \
+                 rather than falling back to the gateway-held credential for '{auth_key}'."
+            )));
+        };
+
+        // The provider half of the key must MATCH the referenced descriptor. A
+        // capability keyed `oauth:slack` pointing at a `google` descriptor is a
+        // refusal, and no capability is ever joined to an account by provider
+        // name alone.
+        let expected = Self::expected_auth_key(&declared.provider);
+        if auth_key != expected {
+            return Err(Error::Config(format!(
+                "capability auth key '{auth_key}' does not match account descriptor \
+                 '{descriptor_id}', whose provider requires '{expected}'. A capability is never \
+                 joined to an account by provider name alone."
+            )));
+        }
+
+        // Existing shared behaviour, preserved verbatim.
+        if declared.mode == DescriptorMode::Shared {
+            return Ok(AccountCredential::Legacy);
+        }
+
+        let Some(installed) = self.installed(descriptor_id) else {
+            return Err(Error::Config(format!(
+                "capability auth references account '{descriptor_id}' but no account strategy is \
+                 installed for it; refusing to dispatch without the account holder's credential."
+            )));
+        };
+
+        let logger = self.audit.read().clone();
+        let subject_id = audit_subject(identity);
+        let audience = installed.audience.as_str();
+
+        let Some(identity) = identity else {
+            self.audit_refusal(
+                logger.as_deref(),
+                &subject_id,
+                descriptor_id,
+                audience,
+                "the request carries no verified end-user identity",
+            );
+            return Err(Error::Config(format!(
+                "capability auth references account '{descriptor_id}' but the request carries no \
+                 verified end-user identity. Refusing rather than falling back to the \
+                 gateway-held credential for '{auth_key}'."
+            )));
+        };
+
+        let backend = BackendDescriptor {
+            // The descriptor id is the logical backend id of the account key,
+            // which is what the strategy's own audience check compares against.
+            id: descriptor_id.to_string(),
+            audience: installed.audience.clone(),
+            token_exchange_endpoint: installed.token_exchange_endpoint.clone(),
+            token_exchange_scope: installed.token_exchange_scope.clone(),
+        };
+
+        // ONE mint, two shapes. A managed descriptor mints through
+        // `VaultStrategy::prepare` — the SAME body `propagate` runs — and keeps
+        // the lease, so the recheck below can be the real custody release. An
+        // external descriptor keeps the trait call, its published expiry and
+        // its behaviour unchanged; there is no lease to keep and none is
+        // invented.
+        let minted = match installed.managed.as_ref() {
+            Some(vault) => vault
+                .prepare(identity, &backend)
+                .await
+                .map(|(credential, lease)| {
+                    (
+                        credential,
+                        Some(ManagedLease {
+                            strategy: Arc::clone(vault),
+                            lease,
+                        }),
+                    )
+                }),
+            None => installed
+                .strategy
+                .propagate(identity, &backend)
+                .await
+                .map(|credential| (credential, None)),
+        };
+        let (credential, managed) = match minted {
+            Ok(minted) => minted,
+            Err(error) => {
+                let reason = error.to_string();
+                self.audit_refusal(
+                    logger.as_deref(),
+                    &subject_id,
+                    descriptor_id,
+                    audience,
+                    &reason,
+                );
+                return Err(Error::Config(format!(
+                    "account '{descriptor_id}' produced no credential for this caller: {reason}"
+                )));
+            }
+        };
+
+        // AN EXTERNAL CREDENTIAL IS CHECKED AGAINST ITS OWN PUBLISHED EXPIRY
+        // HERE, at the INITIAL resolve — before the outer response cache is
+        // keyed, before the inner capability cache is consulted and before any
+        // egress. The revalidate below re-asks the same question, but only a
+        // credential that got past THIS point can reach it, and the outer cache
+        // key is built from the binding this function returns.
+        //
+        // A managed credential is exempt: `expires_at <= minted_at` is the
+        // vault's per-dispatch signal, not staleness, and its real freshness is
+        // decided by the lease recheck. Nothing here invents a lifetime for
+        // either kind — an external strategy that publishes no usable expiry
+        // publishes no usable credential.
+        let minted_at = chrono::Utc::now().timestamp();
+        if managed.is_none() && credential.expires_at <= minted_at {
+            let reason = "the external strategy published an expiry that has already passed";
+            self.audit_refusal(
+                logger.as_deref(),
+                &subject_id,
+                descriptor_id,
+                audience,
+                reason,
+            );
+            return Err(Error::Config(format!(
+                "account '{descriptor_id}' minted a credential that is already expired: {reason}. \
+                 Refusing rather than caching or dispatching with it."
+            )));
+        }
+
+        if credential.headers.is_empty() {
+            return Err(Error::Config(format!(
+                "account '{descriptor_id}' produced no credential header; an account binding \
+                 must produce the account holder's own credential."
+            )));
+        }
+        // Validate every header BEFORE dispatch, so an unusable minted
+        // credential fails closed instead of silently leaving the request
+        // unauthenticated.
+        for (name, value) in &credential.headers {
+            if name.parse::<reqwest::header::HeaderName>().is_err()
+                || value.parse::<reqwest::header::HeaderValue>().is_err()
+            {
+                return Err(Error::Config(format!(
+                    "account '{descriptor_id}' minted an unusable credential header '{name}'"
+                )));
+            }
+        }
+
+        // Operator-misconfig fail-OPEN guard, closed: the audit helper treats a
+        // disabled transparency log as a no-op, which on a required account
+        // would let a minted per-user credential go on the wire with NO durable
+        // record. Same rule the Meta-MCP mint path applies.
+        if installed.required && logger.is_none() {
+            return Err(Error::Internal(format!(
+                "account '{descriptor_id}' is required for this capability but no transparency \
+                 log is configured; refusing to mint a per-user credential without a durable \
+                 audit record"
+            )));
+        }
+        if let Err(error) = audit_identity_propagation(
+            logger.as_deref(),
+            "idp_mint",
+            &subject_id,
+            descriptor_id,
+            Some(audience),
+            None,
+        ) {
+            // CWE-209: the audit error can carry a filesystem path. Keep it in
+            // the server log; return a generic message to the caller.
+            tracing::warn!(
+                account = descriptor_id,
+                error = %error,
+                "account credential mint audit write failed"
+            );
+            return Err(Error::Internal(format!(
+                "identity-propagation audit unavailable for account '{descriptor_id}'"
+            )));
+        }
+
+        Ok(AccountCredential::Prepared(Arc::new(
+            PreparedAccountCredential {
+                descriptor_id: descriptor_id.to_string(),
+                auth_key: auth_key.to_string(),
+                actor_id: identity.stable_actor_id(),
+                audience: installed.audience.clone(),
+                // The strategy's own values, copied. Never re-derived, never
+                // widened and never rounded.
+                cache_binding: credential.cache_binding,
+                expires_at: credential.expires_at,
+                minted_at,
+                strategy: Arc::clone(&installed.strategy),
+                managed,
+                headers: credential.headers,
+            },
+        )))
+    }
+
+    /// Recheck a credential resolved earlier in THIS dispatch, before it is
+    /// allowed to select a cache entry or go on the wire.
+    ///
+    /// This is a validation, not a second mint: it re-answers, against the
+    /// registry as it stands NOW, every question [`Self::resolve`] answered —
+    /// the descriptor is still declared, still non-`shared`, still owned by the
+    /// same provider, still installed, still installed with the SAME strategy
+    /// instance and the same audience — and adds the two the carrying step
+    /// makes possible: the credential belongs to the identity this call is
+    /// being made as, and a published lifetime has not run out.
+    ///
+    /// AND, FOR A MANAGED ACCOUNT, IT ASKS DURABLE CUSTODY. The registry checks
+    /// above are configuration checks: none of them can see a grant that was
+    /// revoked, re-authorized or rotated after the credential was prepared,
+    /// because the registry is not where that state lives. So a managed
+    /// credential's lease is re-released through the SAME custody that released
+    /// it (`VaultStrategy::recheck`), under the store's authority lock, and a
+    /// retired lease — revoked, reconnect-required, superseded generation,
+    /// authorization or token revision — refuses HERE, before an inner cache
+    /// entry may be selected and before any egress. Nothing is refreshed and
+    /// nothing is re-minted: acquiring a new lease to answer "still valid"
+    /// would be pretending a retired credential is the current one. External
+    /// descriptors keep exactly the published-expiry behaviour they had; there
+    /// is no global fallback path here for either kind.
+    ///
+    /// A reload that dropped, re-pointed or re-installed the descriptor between
+    /// the resolve and this point therefore refuses here rather than letting a
+    /// credential minted under the previous configuration reach a cache lookup
+    /// or an upstream.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Config`] for every mismatch and for a custody refusal. None of
+    /// them falls back to the gateway-held credential, and none of them degrades
+    /// into a cache miss.
+    pub(crate) async fn revalidate(
+        &self,
+        prepared: &PreparedAccountCredential,
+        identity: Option<&VerifiedIdentity>,
+    ) -> Result<()> {
+        let descriptor_id = prepared.descriptor_id.as_str();
+        let refuse = |reason: &str| {
+            Err(Error::Config(format!(
+                "account '{descriptor_id}' no longer validates for this dispatch: {reason}. \
+                 Refusing rather than serving a cached result or dispatching with a credential \
+                 nothing rechecked."
+            )))
+        };
+
+        let Some(declared) = self.declared(descriptor_id) else {
+            return refuse("the descriptor is no longer declared");
+        };
+        if declared.mode == DescriptorMode::Shared {
+            return refuse(
+                "the descriptor is now declared shared, so a per-caller credential \
+                           minted for it is no longer the configured behaviour",
+            );
+        }
+        if prepared.auth_key != Self::expected_auth_key(&declared.provider) {
+            return refuse("the descriptor's provider no longer matches the capability auth key");
+        }
+        let Some(installed) = self.installed(descriptor_id) else {
+            return refuse("no account strategy is installed for it any more");
+        };
+        if installed.audience != prepared.audience {
+            return refuse("the installed audience changed after the credential was minted");
+        }
+        if !Arc::ptr_eq(&installed.strategy, &prepared.strategy) {
+            return refuse("the installed strategy was replaced after the credential was minted");
+        }
+        let Some(identity) = identity else {
+            return refuse("the request carries no verified end-user identity");
+        };
+        if identity.stable_actor_id() != prepared.actor_id {
+            return refuse("it was minted for a different verified caller");
+        }
+        if !prepared.published_lifetime_open(chrono::Utc::now().timestamp()) {
+            return refuse("its published lifetime has run out");
+        }
+
+        // THE DURABLE HALF. Last, because the checks above are cheap and this
+        // one takes the store's authority lock; first in importance, because it
+        // is the only one that can see a revocation committed since the mint.
+        if let Some(managed) = prepared.managed.as_ref() {
+            // The installed managed strategy must still be the one that
+            // released this lease. The pointer check above compares the trait
+            // object; this compares the concrete instance the lease belongs to,
+            // so a descriptor re-installed against different custody cannot be
+            // rechecked with the previous one.
+            match installed.managed.as_ref() {
+                Some(current) if Arc::ptr_eq(current, &managed.strategy) => {}
+                _ => {
+                    return refuse(
+                        "the managed custody backing it was replaced after the credential was \
+                         minted",
+                    );
+                }
+            }
+            if let Err(error) = managed.strategy.recheck(&managed.lease).await {
+                // The custody refusal text names the account state (revoked,
+                // reconnect required, retired lease), never a token.
+                return refuse(&format!("durable custody refused its lease: {error}"));
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a refusal. The request is already being refused, so an audit-write
+    /// failure does not change the outcome — but it must not be dropped
+    /// silently.
+    fn audit_refusal(
+        &self,
+        logger: Option<&TransparencyLogger>,
+        subject_id: &str,
+        descriptor_id: &str,
+        audience: &str,
+        reason: &str,
+    ) {
+        if let Err(error) = audit_identity_propagation(
+            logger,
+            "idp_refuse",
+            subject_id,
+            descriptor_id,
+            Some(audience),
+            Some(reason),
+        ) {
+            tracing::warn!(
+                account = descriptor_id,
+                error = %error,
+                "account credential refuse audit write failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod lifetime_tests {
+    use super::*;
+
+    struct NeverMints;
+
+    #[async_trait::async_trait]
+    impl IdentityPropagation for NeverMints {
+        async fn propagate(
+            &self,
+            _identity: &VerifiedIdentity,
+            _backend: &BackendDescriptor,
+        ) -> std::result::Result<super::super::PropagatedCredential, super::super::PropagationError>
+        {
+            unreachable!("the lifetime predicate never mints")
+        }
+    }
+
+    /// `managed: None` is the EXTERNAL shape: no lease, so the durable custody
+    /// half of `revalidate` is skipped and this predicate is the only thing
+    /// standing between a stale published expiry and the wire.
+    fn external(expires_at: i64, minted_at: i64) -> PreparedAccountCredential {
+        PreparedAccountCredential {
+            descriptor_id: "acct".to_string(),
+            auth_key: "oauth:google".to_string(),
+            actor_id: "actor".to_string(),
+            audience: "https://partner.invalid/".to_string(),
+            cache_binding: "binding".to_string(),
+            expires_at,
+            minted_at,
+            strategy: Arc::new(NeverMints),
+            managed: None,
+            headers: vec![("Authorization".to_string(), "Bearer x".to_string())],
+        }
+    }
+
+    /// THE REGRESSION, at the predicate itself. An external credential whose
+    /// published expiry is in the past looks exactly like `expires_at <=
+    /// minted_at`, which the old universal reading treated as "no lifetime
+    /// published" and therefore as usable.
+    #[test]
+    fn an_external_credential_with_a_past_expiry_is_closed() {
+        let now = 1_800_000_000;
+        assert!(
+            !external(now - 3600, now).published_lifetime_open(now),
+            "an external credential whose expiry has already passed must never be open"
+        );
+        assert!(
+            !external(now, now).published_lifetime_open(now),
+            "expiry exactly at now is not a lifetime an external credential may use"
+        );
+        assert!(
+            !external(0, now).published_lifetime_open(now),
+            "an external strategy publishing no usable expiry publishes no usable credential"
+        );
+        assert!(
+            external(now + 60, now).published_lifetime_open(now),
+            "an external credential inside its own published lifetime stays usable; nothing \
+             here shortens it"
+        );
+    }
+}

--- a/src/identity_propagation/mod.rs
+++ b/src/identity_propagation/mod.rs
@@ -45,7 +45,13 @@ use serde::{Deserialize, Serialize};
 use crate::gateway::oauth::GatewayKeyPair;
 use crate::key_server::oidc::VerifiedIdentity;
 
+mod account_strategies;
 mod token_exchange;
+
+pub(crate) use account_strategies::{
+    AccountCredential, AccountStrategyRegistry, DeclaredAccount, InstalledAccount,
+    PreparedAccountCredential,
+};
 pub use token_exchange::TokenExchangeStrategy;
 
 #[cfg(test)]

--- a/src/personal_accounts/mod.rs
+++ b/src/personal_accounts/mod.rs
@@ -538,10 +538,17 @@ impl PersonalAccountStore {
 // Names are fully qualified through `service::` on purpose: `worker.rs` already
 // imports the same six, and an import here would be one more chance to collide.
 
+/// The non-secret lease a managed credential was released under.
+///
+/// Exported unconditionally because the REST account registry RETAINS it beside
+/// the prepared credential: its recheck before the inner cache and before egress
+/// is `VaultStrategy::recheck`, the real custody release, which needs the lease
+/// this dispatch's credential came from. A lease is a binding, never authority.
+pub(crate) use service::CredentialLease;
 #[cfg(test)]
 pub(crate) use service::{
-    CredentialLease, CredentialReleaseObserver, ProviderRefreshError, RefreshProvider,
-    ReleasedCredentials, TokenRefresh,
+    CredentialReleaseObserver, ProviderRefreshError, RefreshProvider, ReleasedCredentials,
+    TokenRefresh,
 };
 #[cfg(test)]
 pub(crate) use worker::CustodyHandle;

--- a/src/personal_accounts/vault.rs
+++ b/src/personal_accounts/vault.rs
@@ -91,41 +91,30 @@ impl VaultStrategy {
             descriptor,
         }
     }
-}
 
-/// What a cache or an upstream session may be keyed on.
-///
-/// The five account-key fields, separated by the existing versioned
-/// length-prefixed digest, plus the grant authority the credential was released
-/// under: a re-authorized or rotated account produces a different binding, so a
-/// result cached for the previous grant is never served for the new one. No
-/// token material, and no raw subject: the digest already distinguishes
-/// principals without publishing them into cache keys and log lines.
-fn cache_binding(
-    account: &AccountKey,
-    lease: &CredentialLease,
-) -> Result<String, PropagationError> {
-    let digest = account
-        .digest()
-        .map_err(|error| PropagationError::Refuse(format!("account key is unusable: {error}")))?;
-    Ok(format!(
-        "acct:v1:{digest}:{}:{}:{}:{}:{}:{}",
-        lease.generation.len(),
-        lease.generation,
-        lease.authorization_epoch,
-        lease.token_revision,
-        lease.descriptor_revision.len(),
-        lease.descriptor_revision,
-    ))
-}
-
-#[async_trait::async_trait]
-impl IdentityPropagation for VaultStrategy {
-    async fn propagate(
+    /// The WHOLE of `propagate`, plus the lease the credential was released
+    /// under.
+    ///
+    /// Factored out rather than duplicated: [`IdentityPropagation::propagate`]
+    /// below is this function with the lease dropped, so the MCP route's trait
+    /// behaviour is byte for byte what it was. A consumer that must RECHECK the
+    /// credential later — the REST account registry, which resolves before its
+    /// cache lookup and rechecks before egress — keeps the lease instead, so the
+    /// recheck can be the real custody boundary rather than an expiry
+    /// comparison. The lease is a non-secret binding: it authorizes nothing on
+    /// its own, and holding it is not holding a token.
+    ///
+    /// # Errors
+    ///
+    /// [`PropagationError::Misconfigured`] when the backend audience and the
+    /// descriptor resource have drifted; [`PropagationError::Refuse`] for an
+    /// unusable account key, an unusable account (revoked, reconnect-required,
+    /// superseded) or a refused release. Nothing here falls back.
+    pub(crate) async fn prepare(
         &self,
         identity: &VerifiedIdentity,
         backend: &BackendDescriptor,
-    ) -> Result<PropagatedCredential, PropagationError> {
+    ) -> Result<(PropagatedCredential, CredentialLease), PropagationError> {
         // The installed descriptor and the backend's compiled propagation
         // config are produced together by `config::account_bindings`. A
         // mismatch means an install and a configuration have drifted, and
@@ -161,7 +150,7 @@ impl IdentityPropagation for VaultStrategy {
             ))
         })?;
 
-        Ok(PropagatedCredential {
+        let credential = PropagatedCredential {
             headers: vec![(
                 "Authorization".to_string(),
                 authorization_value(&credentials),
@@ -178,7 +167,79 @@ impl IdentityPropagation for VaultStrategy {
             // durable record — never from a claim the caller made.
             scopes: lease.scopes.clone(),
             cache_binding: binding,
-        })
+        };
+        Ok((credential, lease))
+    }
+
+    /// Re-run the REAL release recheck for a lease released earlier in this
+    /// dispatch, and discard what it releases.
+    ///
+    /// This is the durable-custody half of a credential recheck: it asks the
+    /// store, under its authority lock, whether THIS lease — this generation,
+    /// this authorization epoch, this token revision, this descriptor revision
+    /// — is still the current grant. A revocation, a reconnect requirement, a
+    /// re-authorization or a rotation committed after the credential was
+    /// prepared therefore refuses HERE, before a cache entry may be selected
+    /// and before anything reaches the wire.
+    ///
+    /// It never refreshes and never re-mints: a recheck that could mint would
+    /// answer "still valid" for a lease that is not, by quietly acquiring a
+    /// different one. The released credential is dropped immediately; the
+    /// credential this dispatch presents is the one prepared with it.
+    ///
+    /// # Errors
+    ///
+    /// [`PropagationError::Refuse`] naming the custody refusal.
+    pub(crate) async fn recheck(&self, lease: &CredentialLease) -> Result<(), PropagationError> {
+        // Bound to this statement: the released token is never bound to a name
+        // that outlives the check it exists for (CWE-226).
+        self.custody.release(lease).await.map_err(|error| {
+            PropagationError::Refuse(format!(
+                "managed account credential is no longer releasable: {error}"
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+/// What a cache or an upstream session may be keyed on.
+///
+/// The five account-key fields, separated by the existing versioned
+/// length-prefixed digest, plus the grant authority the credential was released
+/// under: a re-authorized or rotated account produces a different binding, so a
+/// result cached for the previous grant is never served for the new one. No
+/// token material, and no raw subject: the digest already distinguishes
+/// principals without publishing them into cache keys and log lines.
+fn cache_binding(
+    account: &AccountKey,
+    lease: &CredentialLease,
+) -> Result<String, PropagationError> {
+    let digest = account
+        .digest()
+        .map_err(|error| PropagationError::Refuse(format!("account key is unusable: {error}")))?;
+    Ok(format!(
+        "acct:v1:{digest}:{}:{}:{}:{}:{}:{}",
+        lease.generation.len(),
+        lease.generation,
+        lease.authorization_epoch,
+        lease.token_revision,
+        lease.descriptor_revision.len(),
+        lease.descriptor_revision,
+    ))
+}
+
+#[async_trait::async_trait]
+impl IdentityPropagation for VaultStrategy {
+    /// Unchanged behaviour for every existing consumer: [`Self::prepare`] with
+    /// the lease dropped. The MCP route's credential, headers, binding, expiry
+    /// and refusals are exactly what they were.
+    async fn propagate(
+        &self,
+        identity: &VerifiedIdentity,
+        backend: &BackendDescriptor,
+    ) -> Result<PropagatedCredential, PropagationError> {
+        let (credential, _lease) = self.prepare(identity, backend).await?;
+        Ok(credential)
     }
 }
 

--- a/tests/stdio_account_startup.rs
+++ b/tests/stdio_account_startup.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Real stdio startup admission, including the optional-directory control.
+use serde_json::json;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+
+async fn startup(invalid_account: bool) -> (std::process::Output, bool) {
+    let temp = tempfile::tempdir().expect("isolated home");
+    let caps = temp.path().join("caps");
+    if invalid_account {
+        std::fs::create_dir(&caps).unwrap();
+        std::fs::write(caps.join("bad.yaml"), "name: isolated_read\ndescription: Synthetic account admission probe\nauth:\n  required: true\n  type: bearer\n  key: oauth:google\n  account: no-such-account\nproviders:\n  primary:\n    service: rest\n    config:\n      base_url: http://127.0.0.1:9\n      path: /read\n      method: GET\n").unwrap();
+    }
+    let config = temp.path().join("gateway.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            "capabilities:\n  enabled: true\n  directories:\n    - {}\n",
+            caps.display()
+        ),
+    )
+    .unwrap();
+    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_mcp-gateway"));
+    command
+        .args(["--config", config.to_str().unwrap(), "serve", "--stdio"])
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("config"))
+        .env("XDG_DATA_HOME", temp.path().join("data"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    for (name, _) in std::env::vars_os() {
+        if name.to_string_lossy().starts_with("MCP_GATEWAY_") {
+            command.env_remove(name);
+        }
+    }
+    let mut child = command.spawn().expect("spawn shipped binary");
+    let request = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"stdio-account-test","version":"1"}}});
+    let mut stdin = child.stdin.take().unwrap();
+    stdin
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(stdin);
+    let output = tokio::time::timeout(Duration::from_secs(60), child.wait_with_output())
+        .await
+        .expect("startup must terminate after EOF")
+        .expect("reap child");
+    let initialized = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .any(|reply| reply["id"] == 1 && reply.get("result").is_some());
+    (output, initialized)
+}
+
+#[tokio::test]
+async fn missing_optional_directory_preserves_stdio_initialization() {
+    let (output, initialized) = startup(false).await;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        initialized,
+        "missing optional directory must still allow initialize"
+    );
+}
+
+#[tokio::test]
+async fn invalid_capability_account_refuses_before_stdio_initialization() {
+    let (output, initialized) = startup(true).await;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "invalid account binding must fail startup"
+    );
+    assert!(!initialized, "must refuse before serving initialize");
+    assert!(
+        stderr.contains("account admission gate") && stderr.contains("no-such-account"),
+        "wrong startup failure: {stderr}"
+    );
+}


### PR DESCRIPTION
Stdio now installs configured account strategies before serving and refuses capabilities with invalid account references during startup. Missing optional capability directories still allow initialization.

Validation: baseline regression 1 passed / 1 failed; patched transport tests 2 passed, plus two real-binary smoke checks, all-target/all-feature compilation and format. Registered Kimi review: SHIP at f951ea11.

This remains a draft increment. Successful personal-account stdio dispatch, missing-custody coverage, directory-error visibility and a stale panic doc remain follow-ups; full release CI/DoD is not cleared.
