### PR TITLE
ci: test pull requests targeting v4 integration branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main, codex/v4-release-delivery, fix/mrtr2-continuation-handle]
+    branches: [main, "codex/v4-*", fix/mrtr2-continuation-handle]
 
 permissions:
   contents: read


### PR DESCRIPTION
PRs targeting the v4 integration branches currently receive no CI because the pull_request branch filter names only the old delivery branch. Match codex/v4-* so stacked release PRs receive the same checks, preserving main and the Claude integration branch.

Validation: actionlint .github/workflows/ci.yml and git diff --check pass. No job, permission or test gate changes. Existing PRs #506–#508 have only a skipped auto-merge check; their CI is not passing or verified.
