### PR TITLE
feat: add explicit offline account store initialization

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,6 +153,29 @@ pub struct Cli {
     pub command: Option<Command>,
 }
 
+/// Offline administration of the personal-account custody store.
+///
+/// Every subcommand here is offline and explicit: nothing starts the gateway,
+/// the custody worker or an HTTP client, and no account record is read, written
+/// or migrated. The configuration is selected with the global `--config PATH`
+/// rather than a second `--config` of this subcommand's own, so the path the
+/// store is initialized from is the same path `serve` would later open; a
+/// duplicate flag could name one file here and another there.
+#[derive(Subcommand, Debug)]
+pub enum AccountsCommand {
+    /// Create a fresh empty account authority for the configured roots.
+    ///
+    /// Requires `accounts` in the selected config, requires both configured
+    /// roots to be empty, and refuses rather than replacing, merging or
+    /// migrating existing custody state. The store it creates has zero records
+    /// by construction.
+    #[command(
+        name = "init-store",
+        about = "Create an empty personal-account store from --config (offline)"
+    )]
+    InitStore,
+}
+
 /// Top-level subcommands
 #[derive(Subcommand, Debug)]
 pub enum Command {
@@ -206,6 +229,10 @@ pub enum Command {
     /// Manage caller identity and local personal-capability grants.
     #[command(subcommand, about = "Identity and local grant administration")]
     Identity(IdentityCommand),
+
+    /// Offline administration of the personal-account custody store.
+    #[command(subcommand, about = "Personal account store administration (offline)")]
+    Accounts(AccountsCommand),
 
     /// Generate a starter gateway.yaml with sensible defaults
     #[command(about = "Create a new gateway configuration file")]

--- a/src/commands/accounts.rs
+++ b/src/commands/accounts.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! Offline handlers for `mcp-gateway accounts`.
+//!
+//! This is the only CLI path that may create a personal-account store. It is
+//! deliberately thin: it selects a configuration, loads it through the existing
+//! loader so `env_files` are honoured exactly as they are at startup, and hands
+//! the result to `initialize_store_offline`. No crypto, no path rule and no
+//! emptiness rule is decided here, and nothing in this module opens a socket,
+//! starts the custody worker or touches an account record.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use mcp_gateway::{
+    InitializedStore, OfflineInitError, cli::AccountsCommand, config::Config,
+    initialize_store_offline,
+};
+
+/// Run `mcp-gateway accounts` subcommands.
+///
+/// `config_path` is the globally selected `--config`, passed in from `main`
+/// because `Cli` parses it before the subcommand is dispatched.
+pub fn run_accounts_command(cmd: AccountsCommand, config_path: Option<&Path>) -> ExitCode {
+    match cmd {
+        AccountsCommand::InitStore => run_init_store(config_path),
+    }
+}
+
+/// Initialize an empty store for the selected configuration.
+fn run_init_store(config_path: Option<&Path>) -> ExitCode {
+    // No implicit discovery. Creating custody state is irreversible for the
+    // roots it claims, so the operator names the file instead of learning
+    // afterwards which config happened to be found first.
+    let Some(path) = config_path else {
+        eprintln!(
+            "Error: accounts init-store needs an explicit configuration. \
+             Pass --config PATH naming the gateway config whose `accounts` block \
+             declares the store to create."
+        );
+        return ExitCode::FAILURE;
+    };
+
+    // `load_evaluated`, not `load`: it returns the overlay the config's own
+    // `env_files` produced, which is the environment the key references must be
+    // resolved against, and it refuses a malformed env file rather than
+    // initializing a store against half of one. The env file is never exported
+    // into this process's environment.
+    let evaluated = match Config::load_evaluated(Some(path)) {
+        Ok(evaluated) => evaluated,
+        Err(error) => {
+            eprintln!(
+                "Error: cannot load configuration {}: {error}",
+                path.display()
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match initialize_store_offline(&evaluated.config, &evaluated.overlay) {
+        Ok(report) => {
+            print_report(&report);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("Error: {error}");
+            eprintln!("{}", hint(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Operator guidance per refusal, so a failure says what to do next.
+fn hint(error: &OfflineInitError) -> &'static str {
+    match error {
+        OfflineInitError::NotConfigured => {
+            "Add an `accounts` block naming store_dir, authority_dir and the key \
+             references before initializing a store."
+        }
+        OfflineInitError::Configuration(_) => {
+            "Fix the `accounts` block, or make the declared key reference resolve \
+             in one of the config's own `env_files`. Keys are 32 raw bytes in \
+             standard base64."
+        }
+        OfflineInitError::Refused(_) => {
+            "Existing state is never replaced and nothing is migrated. Both \
+             configured roots must be empty, owner-only directories, and no other \
+             process may hold the store locks."
+        }
+    }
+}
+
+/// Report paths and non-secret names only: no key material, no key bytes and no
+/// account identity ever reaches this output.
+fn print_report(report: &InitializedStore) {
+    println!("Initialized an empty personal-account store.");
+    println!("  instance_id:   {}", report.instance_id);
+    println!("  store_dir:     {}", report.store_dir.display());
+    println!("  authority_dir: {}", report.authority_dir.display());
+    if report.secret_refs_read.is_empty() {
+        println!("  keys read:     none");
+    } else {
+        // Variable NAMES, which is what makes "which key did it read"
+        // answerable without printing what it read.
+        println!("  keys read:     {}", report.secret_refs_read.join(", "));
+    }
+    println!();
+    println!("The store holds zero records. No gateway was started and nothing was imported.");
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! Each public function corresponds to a top-level `Command` variant and
 //! returns an `ExitCode` so `main` can remain a thin dispatcher.
 
+mod accounts;
 #[cfg(feature = "webui")]
 mod add_remove;
 mod cap;
@@ -25,6 +26,7 @@ mod stats;
 mod trust;
 mod upgrade;
 
+pub use accounts::run_accounts_command;
 #[cfg(feature = "webui")]
 pub use add_remove::{run_add_command, run_get_command, run_list_command, run_remove_command};
 pub use cap::run_cap_command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,12 @@ pub mod validator;
 
 pub use error::{Error, Result};
 
+// Offline account-store initialization only — the same narrowing `config`
+// already applies to the `AccountsConfig` DTO. The store, the service and the
+// worker stay crate-private; this exposes one explicit, offline entry point so
+// the `accounts init-store` command can reach it without opening the module.
+pub use personal_accounts::{InitializedStore, OfflineInitError, initialize_store_offline};
+
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// MCP Protocol version supported by this gateway (latest)

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,11 @@ async fn main() -> ExitCode {
         Some(Command::Tls(tls_cmd)) => commands::run_tls_command(tls_cmd),
         Some(Command::Trust(trust_cmd)) => commands::run_trust_command(trust_cmd).await,
         Some(Command::Identity(identity_cmd)) => commands::run_identity_command(identity_cmd).await,
+        // Offline and synchronous on purpose: initializing custody state must
+        // not share a dispatch path with anything that starts the gateway.
+        Some(Command::Accounts(accounts_cmd)) => {
+            commands::run_accounts_command(accounts_cmd, config_path.as_deref())
+        }
         Some(Command::Stats { url }) => {
             let effective_url = resolve_stats_url(
                 url,

--- a/src/personal_accounts/mod.rs
+++ b/src/personal_accounts/mod.rs
@@ -681,5 +681,104 @@ pub(crate) async fn start_custody_with_http(
     Ok(handle)
 }
 
+// ── Offline store initialization ─────────────────────────────────────────────
+//
+// The ONLY public surface of this module besides the `AccountsConfig` DTO.
+// Everything else — the store, the service, the worker, `StoreConfig` and the
+// raw key bytes it carries — stays crate-private, so `accounts init-store`
+// cannot reach past custody to the records themselves.
+
+/// What an offline initialization created, for an operator to read back.
+///
+/// Paths and non-secret names only: no key material, no key bytes, and no
+/// account identity. `secret_refs_read` names the environment variables the
+/// resolution looked up, which is what makes "which key did it read" answerable
+/// without printing what it read.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InitializedStore {
+    /// `accounts.instance_id` the fresh authority was sealed for.
+    pub instance_id: String,
+    /// The configured record root.
+    pub store_dir: PathBuf,
+    /// The configured authority root.
+    pub authority_dir: PathBuf,
+    /// Environment variable NAMES read while resolving keys, sorted.
+    pub secret_refs_read: Vec<String>,
+}
+
+/// Why offline initialization was refused. Carries no key material.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum OfflineInitError {
+    /// The configuration declares no `accounts` block at all. Initializing a
+    /// store the deployment never asked for would create custody state nothing
+    /// opens, so absence is refused rather than defaulted.
+    #[error("configuration declares no accounts block; there is no store to initialize")]
+    NotConfigured,
+    /// The `accounts` block is invalid, or a declared key reference did not
+    /// resolve against the config's own env-file overlay.
+    #[error("accounts configuration refused: {0}")]
+    Configuration(String),
+    /// The existing storage initializer refused: a configured root already
+    /// holds records or a manifest, a root is not a private directory, or
+    /// another owner holds the store locks. Existing state is never replaced,
+    /// and nothing is migrated into a store this command creates.
+    #[error("accounts store initialization refused: {0}")]
+    Refused(String),
+}
+
+/// Create a fresh empty account authority for an already-loaded configuration.
+///
+/// OFFLINE AND EXPLICIT. This is the only path that may create a store, and it
+/// is never reached by daemon startup: `serve` opens an existing authority or
+/// fails. Nothing here launches a gateway, starts the custody worker, builds an
+/// HTTP client or reaches the network, and no token is read, written or
+/// migrated — a store this creates has zero records by construction.
+///
+/// The existing initializer stays authoritative for everything it already
+/// owns: it validates and locks both roots, requires them empty, generates the
+/// random store epoch and seals the encrypted authority. No crypto, no path
+/// rule and no emptiness rule is reimplemented here; this resolves the
+/// configuration through the existing `config::resolve` and hands the resolved
+/// `StoreConfig` straight to it.
+///
+/// `overlay` is the environment the config was evaluated against — an env file
+/// loads into an overlay and is never exported, so the caller must pass the
+/// overlay its `env_files` produced rather than the process environment.
+///
+/// The store handle is dropped before returning, releasing both exclusive
+/// locks: this command initializes and exits, it does not hold custody open.
+///
+/// # Errors
+///
+/// [`OfflineInitError::NotConfigured`] when `accounts` is absent,
+/// [`OfflineInitError::Configuration`] when the block or a key reference is
+/// invalid, and [`OfflineInitError::Refused`] when the configured roots already
+/// hold state or are otherwise unusable as a private store.
+pub fn initialize_store_offline(
+    gateway_config: &crate::config::Config,
+    overlay: &crate::config::EnvOverlay,
+) -> Result<InitializedStore, OfflineInitError> {
+    let resolved = config::resolve(gateway_config.accounts.as_ref(), overlay)
+        .map_err(|error| OfflineInitError::Configuration(error.to_string()))?
+        .ok_or(OfflineInitError::NotConfigured)?;
+
+    // Read back before the resolved config is moved into the initializer. Names
+    // and paths only; `StoreConfig::keys` never leaves this function.
+    let report = InitializedStore {
+        instance_id: resolved.store.instance_id.clone(),
+        store_dir: resolved.store.store_dir.clone(),
+        authority_dir: resolved.store.authority_dir.clone(),
+        secret_refs_read: resolved.secret_refs_read.clone(),
+    };
+
+    let store = PersonalAccountStore::initialize(resolved.store)
+        .map_err(|error| OfflineInitError::Refused(error.to_string()))?;
+    // Explicit, not incidental: the locks are released here, and no worker,
+    // provider or gateway ever sees this handle.
+    drop(store);
+
+    Ok(report)
+}
+
 #[cfg(test)]
 mod tests;

--- a/tests/accounts_init_store.rs
+++ b/tests/accounts_init_store.rs
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2026 Mikko Parkkola
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//! `mcp-gateway accounts init-store` through the real binary.
+//!
+//! Everything here runs the shipped executable against a synthetic temp-dir
+//! config and its own env file. Nothing in this file mutates the test
+//! process's environment: the keys exist only inside the env file the config
+//! names, which is exactly how an operator supplies them, and
+//! `MCP_GATEWAY_CONFIG` is cleared from the *child* so an ambient value cannot
+//! silently select a different config.
+//!
+//! The refusal cases assert the bytes on disk afterwards, not just the exit
+//! code. "Refused existing state" is only true if the state is still there.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Variable name the fixture config references as `env:...`.
+const KEY_VAR: &str = "ACCOUNTS_INIT_STORE_KEY";
+/// 32 raw bytes (all 0x51) in standard base64: a well-formed store key.
+const KEY_B64: &str = "UVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVE=";
+/// Written by the existing initializer into `authority_dir`.
+const AUTHORITY_FILE: &str = "authority.json";
+/// Lock file both roots carry while a store is held.
+const LOCK_FILE: &str = ".personal-accounts.lock";
+
+struct Fixture {
+    /// Kept alive: dropping it removes every path below.
+    _root: tempfile::TempDir,
+    config: PathBuf,
+    store: PathBuf,
+    authority: PathBuf,
+}
+
+/// A config whose `accounts` block points at two fresh roots, with `key_value`
+/// supplied through the config's own `env_files` entry. `None` writes an env
+/// file that does not define `KEY_VAR` at all.
+fn fixture(key_value: Option<&str>) -> Fixture {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let store = root.path().join("store");
+    let authority = root.path().join("authority");
+
+    let env_path = root.path().join("keys.env");
+    let env_body = match key_value {
+        Some(value) => format!("{KEY_VAR}={value}\n"),
+        None => "ACCOUNTS_INIT_STORE_UNRELATED=1\n".to_string(),
+    };
+    fs::write(&env_path, env_body).expect("env file");
+
+    let config = root.path().join("gateway.yaml");
+    fs::write(
+        &config,
+        format!(
+            "env_files:\n  - {env}\nserver:\n  port: 18731\naccounts:\n  \
+             schema_version: accounts.v1\n  enabled: true\n  deployment: single_process\n  \
+             instance_id: gateway-init-store\n  store_dir: {store}\n  authority_dir: {authority}\n  \
+             current_key_id: current\n  keys:\n    current: env:{KEY_VAR}\n  limits:\n    \
+             store_entries: 1000\n    authority_bytes: 1048576\n",
+            env = env_path.display(),
+            store = store.display(),
+            authority = authority.display(),
+        ),
+    )
+    .expect("config file");
+
+    Fixture {
+        _root: root,
+        config,
+        store,
+        authority,
+    }
+}
+
+fn init_store(config: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
+        .args(["accounts", "init-store", "--config"])
+        .arg(config)
+        // Child-only: the test process's own environment is never touched.
+        .env_remove("MCP_GATEWAY_CONFIG")
+        .output()
+        .expect("the gateway binary must run")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Only the lock file may sit beside a freshly created store's records.
+fn entries(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(dir)
+        .expect("root must exist")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn init_store_creates_an_empty_store_and_a_second_run_refuses_without_touching_it() {
+    let fixture = fixture(Some(KEY_B64));
+
+    let first = init_store(&fixture.config);
+    let out = stdout_of(&first);
+    assert!(
+        first.status.success(),
+        "first run must succeed; stdout={out} stderr={}",
+        stderr_of(&first)
+    );
+
+    let manifest = fixture.authority.join(AUTHORITY_FILE);
+    assert!(manifest.is_file(), "a sealed authority must exist: {out}");
+    let sealed = fs::read(&manifest).expect("authority bytes");
+
+    // Zero records by construction: nothing but the lock is in the record root.
+    let record_entries = entries(&fixture.store);
+    assert!(
+        record_entries.iter().all(|name| name == LOCK_FILE),
+        "a fresh store must hold no records, found {record_entries:?}"
+    );
+
+    // Names, not values: the report must answer "which key did it read" without
+    // printing what it read.
+    assert!(
+        out.contains(KEY_VAR),
+        "the key NAME must be reported: {out}"
+    );
+    assert!(
+        !out.contains(KEY_B64) && !stderr_of(&first).contains(KEY_B64),
+        "key material must never be printed: {out}"
+    );
+    assert!(
+        out.contains("gateway-init-store"),
+        "the instance the authority was sealed for must be reported: {out}"
+    );
+
+    // The locks are released by the first run, so a second run fails on existing
+    // state rather than on a lock the command forgot to drop.
+    let second = init_store(&fixture.config);
+    assert!(
+        !second.status.success(),
+        "an initialized store must not be re-initialized; stdout={}",
+        stdout_of(&second)
+    );
+    let refusal = stderr_of(&second);
+    assert!(
+        refusal.to_lowercase().contains("refus"),
+        "the second run must say it refused: {refusal}"
+    );
+    assert!(
+        !refusal.contains(KEY_B64),
+        "a refusal must not leak key material: {refusal}"
+    );
+    assert_eq!(
+        fs::read(&manifest).expect("authority bytes after refusal"),
+        sealed,
+        "the existing authority must be byte-identical after a refused re-init"
+    );
+}
+
+#[test]
+fn a_nonempty_record_root_is_refused_and_its_file_keeps_its_original_bytes() {
+    let fixture = fixture(Some(KEY_B64));
+
+    // An owner-only root that already holds something: the refusal must be for
+    // the existing content, not for the directory mode.
+    fs::create_dir(&fixture.store).expect("store root");
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(&fixture.store, fs::Permissions::from_mode(0o700))
+            .expect("owner-only root");
+    }
+    let stray = fixture.store.join("pre-existing.bin");
+    let original: &[u8] = b"records this command must never touch\n";
+    fs::write(&stray, original).expect("pre-existing file");
+
+    let output = init_store(&fixture.config);
+    assert!(
+        !output.status.success(),
+        "a non-empty record root must be refused; stdout={}",
+        stdout_of(&output)
+    );
+    assert_eq!(
+        fs::read(&stray).expect("pre-existing bytes"),
+        original,
+        "the pre-existing file must be byte-identical after the refusal"
+    );
+    assert!(
+        !fixture.authority.join(AUTHORITY_FILE).is_file(),
+        "a refused run must not seal an authority"
+    );
+}
+
+#[test]
+fn an_unresolved_key_reference_is_refused_before_any_root_is_created() {
+    // The env file exists and parses, but never defines the referenced name.
+    let fixture = fixture(None);
+
+    let output = init_store(&fixture.config);
+    assert!(
+        !output.status.success(),
+        "an unresolvable key reference must be refused; stdout={}",
+        stdout_of(&output)
+    );
+    let refusal = stderr_of(&output);
+    assert!(
+        refusal.contains(KEY_VAR),
+        "the refusal must name the variable that did not resolve: {refusal}"
+    );
+    assert!(
+        !fixture.store.exists() && !fixture.authority.exists(),
+        "a configuration refusal must not create custody directories"
+    );
+}
+
+#[test]
+fn an_unparsable_key_is_refused_without_echoing_it() {
+    let fixture = fixture(Some("%%%not-base64%%%"));
+
+    let output = init_store(&fixture.config);
+    assert!(
+        !output.status.success(),
+        "a malformed key must be refused; stdout={}",
+        stdout_of(&output)
+    );
+    let refusal = stderr_of(&output);
+    assert!(
+        !refusal.contains("%%%not-base64%%%"),
+        "the refusal must not echo the supplied material: {refusal}"
+    );
+    assert!(
+        !fixture.store.exists() && !fixture.authority.exists(),
+        "a configuration refusal must not create custody directories"
+    );
+}
+
+#[test]
+fn a_wrong_length_key_is_refused() {
+    // Valid base64, but three bytes rather than the required thirty-two. A store
+    // sealed under a short key would be a store no correct build can open.
+    let fixture = fixture(Some("QUJD"));
+
+    let output = init_store(&fixture.config);
+    assert!(
+        !output.status.success(),
+        "a short key must be refused; stdout={}",
+        stdout_of(&output)
+    );
+    assert!(
+        !fixture.store.exists() && !fixture.authority.exists(),
+        "a configuration refusal must not create custody directories"
+    );
+}
+
+#[test]
+fn init_store_without_a_config_refuses_instead_of_guessing_one() {
+    let output = Command::new(env!("CARGO_BIN_EXE_mcp-gateway"))
+        .args(["accounts", "init-store"])
+        .env_remove("MCP_GATEWAY_CONFIG")
+        .output()
+        .expect("the gateway binary must run");
+
+    assert!(
+        !output.status.success(),
+        "creating custody state from a discovered config must not happen; stdout={}",
+        stdout_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("--config"),
+        "the refusal must point at --config: {}",
+        stderr_of(&output)
+    );
+}


### PR DESCRIPTION
Add `mcp-gateway accounts init-store --config PATH` to explicitly create an empty personal-account authority using the existing encrypted store initializer. Refuse existing state and invalid configuration; do not start the gateway or import tokens.

Validation: six real binary tests pass, covering fresh initialization, reinitialization refusal with authority-byte preservation, a nonempty record root, missing/invalid keys, and missing config. Formatting and diff checks pass. Registered independent Grok review returned SHIP. Follow-ups: lock-contention binary coverage, clearer filesystem refusal guidance, and documented lock/sibling-directory side effects on refused initialization. Runtime adapter/hosted consent and release-wide qualification remain open.
