### PR TITLE
fix(lifecycle): report reclaimed session count

### DIFF
--- a/src/gateway/session_lifecycle.rs
+++ b/src/gateway/session_lifecycle.rs
@@ -121,7 +121,7 @@ impl SessionLifecycle {
     /// Each key fires the handlers exactly once and is then forgotten: these
     /// callbacks free things, and a handler that runs twice for one key is its
     /// own defect.
-    pub fn reap(&self, now: u64) {
+    pub fn reap(&self, now: u64) -> usize {
         let expired: Vec<String> = {
             let mut tracked = self.tracked.write();
             let expired: Vec<String> = tracked
@@ -134,11 +134,13 @@ impl SessionLifecycle {
             }
             expired
         };
+        let reclaimed = expired.len();
         for key in expired {
             // Already removed above. `on_disconnect` would remove it again, and
             // a second removal can only take an entry someone re-registered.
             self.fire_cleanup(&key);
         }
+        reclaimed
     }
 
     /// How many keys are awaiting reclamation.


### PR DESCRIPTION
The CONTROL.4 count acceptance tests cannot compile because SessionLifecycle::reap returns (). Return the number of expired keys removed while preserving existing callback and lock behavior.

Validation: both count acceptance tests and all six lifecycle tests pass on a forced-rebuild Spark snapshot; formatting and diff checks pass. Independent review pending. This addresses CONTROL.4 T3 and the type mismatch only; cleanup wiring and the full release criterion remain open.
