### PR TITLE
fix(windows): pass APPDATA and LOCALAPPDATA to stdio children

### DIFF
--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -56,6 +56,8 @@ fn configure_child_environment(cmd: &mut Command, backend_env: &HashMap<String, 
     #[cfg(windows)]
     for key in [
         "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
         "TEMP",
         "TMP",
         "SYSTEMROOT",


### PR DESCRIPTION
## Summary
- On Windows, `configure_child_environment` clears the child env and only re-injects a small allowlist (`USERPROFILE`, `TEMP`, `TMP`, `SYSTEMROOT`, …).
- Python’s **user** site-packages live under `%APPDATA%\Python\…`. Without `APPDATA` / `LOCALAPPDATA`, stdio backends that rely on user-site installs (e.g. `fastmcp` via `pip install --user`) fail at import with `ModuleNotFoundError`, and the stdio transport then surfaces a **request timeout** instead of a clear spawn/import error.
- This PR adds `APPDATA` and `LOCALAPPDATA` to the Windows allowlist next to `USERPROFILE`.

## Repro (before)
1. Install an MCP server dependency into the user site (`pip install --user fastmcp` / typical Windows Python layout).
2. Configure it as a stdio backend and start the gateway.
3. First `tools/list` / initialize against that backend times out; child stderr shows missing modules from user site.

## Test plan
- [ ] `cargo test -p mcp-gateway transport::stdio` (or full suite if preferred)
- [ ] On Windows: stdio backend whose deps live only in `%APPDATA%\Python\…\site-packages` initializes and returns `tools/list`
- [ ] Confirm secrets still do not leak: child env remains cleared aside from the allowlist + per-backend `env:`

## Notes
- Minimal two-line change; no behavior change on non-Windows.
- Separately we hit Windows `shlex` backslash path issues and FastMCP `Errno 22` on Tokio pipes — happy to file those as follow-up issues if useful.