### PR TITLE
fix(docker): re-run the base-image upgrade the CVE gate depends on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,12 @@ jobs:
           tags: |
             ghcr.io/mikkoparkkola/mcp-gateway:${{ steps.meta.outputs.version }}
             ${{ steps.meta.outputs.is_prerelease != 'true' && 'ghcr.io/mikkoparkkola/mcp-gateway:latest' || '' }}
+          # Same reason as docker.yml: without a per-build value the runtime
+          # stage's `apt-get upgrade` is restored from the shared gha cache, and
+          # a release image ships whatever packages were current when that layer
+          # was first built.
+          build-args: |
+            APT_CACHE_BUST=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,11 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Busts the runtime stage's apt layer once per run. Both builds below read
+  # this same value, so the push build still restores the layers the scan build
+  # wrote and trivy clears the image that actually ships. Defined here rather
+  # than inline so the two cannot drift apart.
+  APT_CACHE_BUST: ${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   # Dependency-vulnerability gate for the image build. ci.yml runs `cargo audit`
@@ -134,6 +139,8 @@ jobs:
           # literal for the ephemeral local scan tag (the pushed image uses the
           # metadata-action's already-lowercased tags).
           tags: ${{ env.REGISTRY }}/mikkoparkkola/mcp-gateway:scan
+          build-args: |
+            APT_CACHE_BUST=${{ env.APT_CACHE_BUST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -155,6 +162,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APT_CACHE_BUST=${{ env.APT_CACHE_BUST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,18 @@ FROM debian:trixie-slim
 
 LABEL io.modelcontextprotocol.server.name="io.github.MikkoParkkola/mcp-gateway"
 
-RUN apt-get update && apt-get upgrade -y \
+# Debian ships security updates into the apt archives continuously, but the
+# `debian:trixie-slim` image they are published against is rebuilt far less
+# often. While that base image's digest sits still, this layer's cache key sits
+# still with it, so a rebuild restores the upgrade from cache instead of running
+# it: the image keeps whatever package versions were current the day the layer
+# was first built, and the trivy gate in docker.yml reports CVEs that
+# `apt-get upgrade` would already have fixed. Pass a per-build value here to
+# move the cache key and force the upgrade to re-run against today's archives.
+ARG APT_CACHE_BUST=local
+
+RUN echo "apt cache bust: ${APT_CACHE_BUST}" \
+    && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \


### PR DESCRIPTION
## Problem

The `build` job's trivy step fails with 12 fixable HIGH/CRITICAL CVEs in `debian:trixie-slim` packages — `perl-base` CVE-2026-13221 is the CRITICAL one. The runtime stage already runs `apt-get upgrade -y`, which fixes every one of them.

It never runs. From the failing job's log:

```
#17 [stage-1 2/6] RUN apt-get update && apt-get upgrade -y     && apt-get install ...
#17 CACHED
```

Debian pushes security updates into the apt archives continuously; the `debian:trixie-slim` image is rebuilt far less often. While that base digest sits still, the layer's cache key sits still with it, and every build restores an upgrade performed on some earlier day. The image ships the package versions of that day and trivy reports exactly the CVEs the upgrade was there to fix.

This is not specific to any one branch. The last five Docker runs on `main` are green, the most recent at `2026-09-12T13:29:47Z` — two and a half hours before the first failure. `main` fails identically on its next Docker run.

## Fix

`ARG APT_CACHE_BUST`, referenced inside the RUN so it joins the cache key, with `github.run_id`-`github.run_attempt` supplied from the workflows.

Both builds in a `docker.yml` run read one workflow-level `env` value, so the push build still restores what the scan build wrote — the image trivy cleared is the image that ships. `ci.yml`'s release publisher gets its own per-run value, which is correct: a release build should re-check the archives itself.

## Verification

- 🟢 `trivy image --severity HIGH,CRITICAL --ignore-unfixed debian:trixie-slim` reproduces the same 12 findings against the upstream base right now, with no repo checkout involved — the CVEs are in the base image, not in any change.
- 🟢 `scripts/release/test_workflow_wiring_mutations.py`: 79 mutation cases agree with the suite.
- 🟢 Both workflow files parse.
- The gate itself is the remaining check: if the upgrade now runs, trivy goes green.

## Not in this change

`.trivyignore` stays empty. The file says so itself: the right fix for a fixable base-image CVE is to bump the package, not to ignore it. Suppressing a CRITICAL remote-code-execution finding to unblock a merge is how a gate becomes decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)