### PR TITLE
ci(runners): run the v4 stack on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   public-repo-hygiene:
     name: Public repo hygiene
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate public repo hygiene scripts
@@ -33,7 +33,7 @@ jobs:
 
   service-template-smoke:
     name: Service template smoke
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -45,7 +45,7 @@ jobs:
 
   usability-smoke:
     name: First-use usability smoke
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -57,7 +57,7 @@ jobs:
 
   helm-chart-smoke:
     name: Helm chart lint + render
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -68,7 +68,7 @@ jobs:
 
   helm-oci-roundtrip:
     name: Helm OCI package/push/pull
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     services:
       registry:
         image: registry:2
@@ -96,7 +96,7 @@ jobs:
 
   helm-supply-chain:
     name: Helm supply chain (cosign + SBOM)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     services:
       registry:
         image: registry:2
@@ -118,7 +118,7 @@ jobs:
 
   helm-airgap:
     name: Helm air-gap export/import
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     services:
       registry:
         image: registry:2
@@ -144,7 +144,7 @@ jobs:
 
   k8s-kind-rollback:
     name: K8s kind apply+upgrade+rollback
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate kind rollback smoke script
@@ -170,7 +170,7 @@ jobs:
 
   check:
     name: Clippy (pedantic)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -181,7 +181,7 @@ jobs:
 
   windows-check:
     name: Windows check
-    runs-on: avrea-windows-2025-4-vcpu
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -190,7 +190,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -203,7 +203,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -213,7 +213,7 @@ jobs:
 
   audit:
     name: Dependency audit
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -228,7 +228,7 @@ jobs:
     name: Kani
     # Kani's current toolchain is validated against Ubuntu 22.04. Keep the
     # Avrea runner pinned to that image rather than following latest.
-    runs-on: avrea-ubuntu-22.04-4-vcpu
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -248,7 +248,7 @@ jobs:
 
   public-claims:
     name: Public claims
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -259,7 +259,7 @@ jobs:
 
   release-criteria:
     name: Release criteria ledger (report-only off a tag, blocking on one)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     # The ledger is a live working document: a row edited mid-flight must not
     # block unrelated PRs, but a stale header count must not reach a tag. On a
     # tag this job blocks, and the container publish below depends on it —
@@ -281,7 +281,7 @@ jobs:
 
   secrets-scan:
     name: Secrets scan
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -298,7 +298,7 @@ jobs:
     # trufflehog only flags verified live secret VALUES it can see in the
     # diff. This is the class of bug fixed in #323 (redact credentials from
     # Debug output). Pure stdlib Python, no extra deps, so it stays fast.
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Test the leak-lint parser (fail on parser regression)
@@ -308,7 +308,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     # secrets-scan + secret-leak-lint added so the container image release
     # path can't ship on a tag whose push already failed a security check —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,8 @@ jobs:
 
   kani:
     name: Kani
-    # Kani's current toolchain is validated against Ubuntu 22.04. Keep the
-    # Avrea runner pinned to that image rather than following latest.
+    # Kani's current toolchain is validated against Ubuntu 22.04. Keep this
+    # job pinned to that image rather than following latest.
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   auto-merge:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    runs-on: avrea-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch dependabot metadata
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
   # Exceptions are time-boxed in .github/osv-scanner.toml.
   security-gate:
     name: Security gate (block image on known vulns)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -39,7 +39,7 @@ jobs:
   # anyway. Duplicated deliberately — a workflow cannot depend on another workflow's job.
   release-criteria:
     name: Release criteria ledger (header matches rows)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   build:
     needs: [security-gate, release-criteria]
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -130,7 +130,7 @@ jobs:
   publish-mcp-registry:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   # Exceptions are time-boxed in .github/osv-scanner.toml.
   security-gate:
     name: Security gate (block release on known vulns)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,7 +60,7 @@ jobs:
   # If CodeQL is added later, wire it into this same needs: chain.
   secret-leak-lint:
     name: Secret-leak lint (CWE-532)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Test the leak-lint parser (fail on parser regression)
@@ -79,7 +79,7 @@ jobs:
   # and every publishing job is transitively needs:-ed to `verify`.
   release-criteria:
     name: Release criteria ledger (header matches rows)
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Test the counter (fail on parser regression)
@@ -102,7 +102,7 @@ jobs:
 
   verify:
     needs: [security-gate, secret-leak-lint, release-criteria, task-sdk-recovery]
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -137,27 +137,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: avrea-ubuntu-latest-4-vcpu
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             artifact: mcp-gateway-linux-x86_64
             suffix: ""
             packages: musl-tools
-          - os: avrea-ubuntu-latest-arm-4-vcpu
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             artifact: mcp-gateway-linux-aarch64
             suffix: ""
             packages: musl-tools
-          - os: avrea-macos-26-8-vcpu
+          - os: macos-latest
             target: aarch64-apple-darwin
             artifact: mcp-gateway-darwin-arm64
             suffix: ""
             packages: ""
-          - os: avrea-macos-26-8-vcpu
+          - os: macos-latest
             target: x86_64-apple-darwin
             artifact: mcp-gateway-darwin-x86_64
             suffix: ""
             packages: ""
-          - os: avrea-windows-2025-4-vcpu
+          - os: windows-2025
             target: x86_64-pc-windows-msvc
             artifact: mcp-gateway-windows-x86_64
             suffix: .exe
@@ -196,7 +196,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 
@@ -274,7 +274,7 @@ jobs:
 
   publish:
     needs: release
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -294,9 +294,9 @@ jobs:
 
   npm-publish:
     needs: release
-    # GitHub-hosted on purpose. npm rejects a provenance bundle signed on a
+    # Must stay GitHub-hosted. npm rejects a provenance bundle signed on a
     # self-hosted runner ("Unsupported GitHub Actions runner environment:
-    # self-hosted"), so publishing from avrea-* costs the build attestation.
+    # self-hosted"), so a third-party runner costs the build attestation.
     # This package is a thin wrapper that needs nothing from that fleet.
     # https://docs.npmjs.com/generating-provenance-statements
     runs-on: ubuntu-latest
@@ -343,7 +343,7 @@ jobs:
 
   homebrew-update:
     needs: release
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
 
     steps:
       - name: Compute version and download checksums

--- a/.github/workflows/task-sdk-recovery.yml
+++ b/.github/workflows/task-sdk-recovery.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   recovery:
     name: Task SDK recovery
-    runs-on: avrea-ubuntu-latest-4-vcpu
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Why this exists

The Avrea runner fleet bills against a flat $12/month credit. In August it took $210.62. `main` was fixed in #534, but that did not stop the billing, because Avrea is selected purely by the label in `runs-on:` — the routing is literal YAML on each branch, and no repository variable can override it.

This branch is the root of a stack of eight open pull requests (#499, #502, #503, #506, #508, #511, #512, #531 — all but #512 are based on it). Every one of them still carries `avrea-*` labels, so every push to any of them bills. Measured live after #534 merged: run `34706187111` on `fix/v4-integration-ci-green` put 8 jobs on `avrea-ubuntu-latest-4-vcpu`.

The obvious route — merge `main` down — does not work: this branch conflicts with `main`, and `gh pr update-branch` refuses. Resolving that conflict is the stack owner's call and a much larger change. So this applies the same swap directly instead, touching nothing but runner labels.

## What changed

37 runner labels, using the mapping `main` settled on in `ad08f035`:

| Avrea label | GitHub-hosted |
|---|---|
| `avrea-ubuntu-latest-4-vcpu`, `avrea-ubuntu-latest` | `ubuntu-latest` |
| `avrea-ubuntu-22.04-4-vcpu` | `ubuntu-22.04` |
| `avrea-windows-2025-4-vcpu` | `windows-2025` |
| `avrea-ubuntu-latest-arm-4-vcpu` | `ubuntu-24.04-arm` |
| `avrea-macos-26-8-vcpu` | `macos-latest` |

Plus two comments that named the fleet, realigned with `main`'s wording. `task-sdk-recovery.yml` only exists on this branch, so `main`'s fix never covered it.

## Verification

- 🟢 Every `runs-on:` and matrix `os:` value across the five workflows now reads a GitHub-hosted label; no `avrea` reference survives outside `.github/actionlint.yaml`, which is a lint allowlist and starts no jobs.
- 🟢 All five workflows parse; actionlint passes.
- 🟢 Independent review confirmed all 37 mappings correct and complete.
- The open question is hosted capacity, not correctness: these jobs previously had 4 dedicated vCPUs and now take the standard hosted runner. `main`'s equivalent change has been running clean — #534's own CI and #535's Docker build both passed on hosted runners.

## After this lands

The seven child pull requests inherit it by updating from this branch, which is a clean merge for each. That is what actually stops the meter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)