### PR TITLE
fix(transport): re-assert modern headers on an SSE reconnect

### DIFF
--- a/src/transport/http/mod.rs
+++ b/src/transport/http/mod.rs
@@ -1040,10 +1040,34 @@ impl HttpTransport {
     }
 
     /// Establish SSE connection and get the message endpoint
+    ///
+    /// `initialize()` re-enters this on session expiry, by which time
+    /// `outbound_era()` may already read `Modern` (MIK-7214.HEADER.9a/.9b,
+    /// `docs/design/2026-09-03-header-9-era-conditional-outbound.md`). The
+    /// builder always writes the legacy handshake version, so a reconnect to
+    /// an already-classified peer is re-asserted here, after the builder's
+    /// static-header merge — the same ordering the `Request`/`Notify`
+    /// finalisation needs, and for the same reason: sited earlier, an
+    /// operator's pinned header would win. Two headers only, not the full
+    /// `finalise_modern_headers` set: `Mcp-Method`/`Mcp-Name` mirror a
+    /// JSON-RPC body field and this `GET` has no body to mirror.
+    /// `MCP-Session-Id` is removed rather than merely left unminted —
+    /// `build_mcp_headers`'s `Sse` arm never mints one, but an
+    /// operator-configured static header would otherwise reach a modern peer,
+    /// which `MIK-7215.STATELESS.3a` prohibits outright. The first connection
+    /// is unaffected: the era is unresolved before the first `initialize()`,
+    /// `outbound_era()` reads `None`, and the GET stays legacy-shaped.
     async fn establish_sse_connection(&self) -> Result<String> {
         use futures::StreamExt;
 
-        let headers = self.build_mcp_headers(HeaderMode::Sse, None).await?;
+        let mut headers = self.build_mcp_headers(HeaderMode::Sse, None).await?;
+        if self.outbound_era() == Some(Era::Modern) {
+            headers.insert(
+                "MCP-Protocol-Version",
+                header::HeaderValue::from_static(MODERN_VERSIONS[0]),
+            );
+            headers.remove("MCP-Session-Id");
+        }
 
         debug!(url = %sanitize_url_for_diagnostics(&self.base_url), "Establishing SSE connection");
 

--- a/tests/mik_7214_header_9_acs.rs
+++ b/tests/mik_7214_header_9_acs.rs
@@ -983,3 +983,156 @@ fn every_name_shape_round_trips_and_only_the_safe_one_stays_plain() {
         );
     }
 }
+
+/// An SSE-mode peer: `GET /` answers the SSE handshake with an `endpoint`
+/// event naming `/message`, and `POST /message` speaks the same JSON-RPC the
+/// streamable-HTTP fixtures above speak. `tools/list`'s second call expires
+/// the session, the same way `spawn_expiring_peer` does, so a reconnect is
+/// forced — the only way the `Modern`/`Sse` cell in
+/// `docs/design/2026-09-03-header-9-era-conditional-outbound-test-plan.md` can
+/// be proved: a primed first connect never reaches the code under test.
+async fn spawn_sse_expiring_peer() -> (String, Recorder) {
+    let recorder: Recorder = Arc::new(Mutex::new(Vec::new()));
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let sse_recorder = Arc::clone(&recorder);
+    let msg_recorder = Arc::clone(&recorder);
+    let msg_calls = Arc::clone(&calls);
+
+    let app = axum::Router::new()
+        .route(
+            "/",
+            axum::routing::get(move |headers: HeaderMap| {
+                let sink = Arc::clone(&sse_recorder);
+                async move {
+                    sink.lock().expect("recorder poisoned").push(Wire {
+                        method: "GET /".to_string(),
+                        headers,
+                        body: Value::Null,
+                    });
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                        "event: endpoint\ndata: /message\n\n".to_string(),
+                    )
+                }
+            }),
+        )
+        .route(
+            "/message",
+            axum::routing::post(
+                move |headers: HeaderMap, axum::Json(request): axum::Json<Value>| {
+                    let sink = Arc::clone(&msg_recorder);
+                    let calls = Arc::clone(&msg_calls);
+                    async move {
+                        let method = request
+                            .get("method")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string();
+                        sink.lock().expect("recorder poisoned").push(Wire {
+                            method: method.clone(),
+                            headers,
+                            body: request.clone(),
+                        });
+                        let mut out = HeaderMap::new();
+                        if method != "server/discover" {
+                            out.insert("Mcp-Session-Id", "s1".parse().expect("ascii"));
+                        }
+                        // The first ordinary response mints a session. The
+                        // second expires it, forcing the reconnect this case
+                        // exists to observe.
+                        if method == "tools/list"
+                            && calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 1
+                        {
+                            let id = request.get("id").cloned().unwrap_or(Value::Null);
+                            return (
+                                out,
+                                axum::Json(json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": { "code": -32015, "message": "session not found" }
+                                })),
+                            );
+                        }
+                        (out, axum::Json(answer(Peer::Modern, &request)))
+                    }
+                },
+            ),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("the fixture peer must get a port");
+    let url = format!("http://{}/", listener.local_addr().expect("bound address"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (url, recorder)
+}
+
+/// MIK-7214.HEADER.9a/.9b — the `Modern`/`Sse` cell: a reconnect to a peer
+/// already classified `Modern` carries the modern protocol version and no
+/// session header, even though the *first* `GET` (before the era resolved)
+/// stayed legacy-shaped and even though the backend is statically configured
+/// with an operator-pinned `MCP-Session-Id`.
+///
+/// Proved by a reconnect, not a primed first connect: a primed era would make
+/// the first `GET` green against a production path that only ever reaches
+/// `Modern` on the session-expiry re-entry inside `request()`
+/// (test-plan.md `Cases`, "The `Modern`/`Sse` cell is proved by a reconnect").
+#[tokio::test]
+async fn a_reconnect_to_a_modern_peer_sends_the_modern_sse_get() {
+    let (url, recorder) = spawn_sse_expiring_peer().await;
+    let backend = Backend::new(
+        "header9-sse-fixture",
+        BackendConfig {
+            enabled: true,
+            transport: TransportConfig::Http {
+                http_url: url,
+                streamable_http: false,
+                protocol_version: None,
+            },
+            headers: [("MCP-Session-Id".to_string(), "operator-pinned".to_string())]
+                .into_iter()
+                .collect(),
+            ..BackendConfig::default()
+        },
+        &FailsafeConfig::default(),
+        Duration::from_secs(60),
+    );
+
+    backend
+        .request("tools/list", None)
+        .await
+        .expect("the first call starts the backend and mints a session");
+    backend
+        .request("tools/list", None)
+        .await
+        .expect("the retry after the forced reconnect succeeds");
+
+    let seen = recorder.lock().expect("recorder poisoned").clone();
+    let gets: Vec<&Wire> = seen.iter().filter(|w| w.method == "GET /").collect();
+    assert_eq!(
+        gets.len(),
+        2,
+        "the session expiry must force exactly one reconnect; saw {:?}",
+        seen.iter().map(|w| &w.method).collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        header(gets[0], "MCP-Protocol-Version"),
+        PROTOCOL_VERSION,
+        "the era is unresolved before the first GET, which must stay legacy-shaped"
+    );
+    assert_eq!(
+        header(gets[1], "MCP-Protocol-Version"),
+        MODERN_VERSIONS[0],
+        "a reconnect to a peer already classified Modern must carry the modern \
+         protocol version, not the legacy handshake's"
+    );
+    assert!(
+        gets[1].headers.get("MCP-Session-Id").is_none(),
+        "MIK-7215.STATELESS.3a: a modern-classified reconnect must not emit \
+         MCP-Session-Id, including one the operator statically configured; saw {:?}",
+        gets[1].headers
+    );
+}


### PR DESCRIPTION
Closes MIK-7214.HEADER.9a/.9b on the release line.

`initialize()` re-enters `establish_sse_connection` on session expiry, by which point the peer's era is already classified as modern. The header builder always writes the legacy handshake version, so a reconnect to an already-classified peer sent legacy-shaped headers. It also left `MCP-Session-Id` in place when an operator had configured it as a static header — which `MIK-7215.STATELESS.3a` prohibits outright for a modern peer.

Both are corrected after the builder's static-header merge, the same ordering the `Request`/`Notify` finalisation uses and for the same reason: sited earlier, an operator's pinned header would win. Two headers only, not the full `finalise_modern_headers` set — `Mcp-Method`/`Mcp-Name` mirror a JSON-RPC body field and this `GET` has no body to mirror.

The first connection is unaffected: the era is unresolved before the first `initialize()`, so the GET stays legacy-shaped.

Gates run locally on the merge result (`origin/chore/v4-reconcile-main` + `c35ee4dd`), not on the branch in isolation:

| gate | result |
|---|---|
| `cargo test --test mik_7214_header_9_acs` | 19 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |

Design: `docs/design/2026-09-03-header-9-era-conditional-outbound.md`.